### PR TITLE
Hide log-flush-frequency

### DIFF
--- a/cmd/bootkube/main.go
+++ b/cmd/bootkube/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/coreos/bootkube/pkg/version"
 )
@@ -26,6 +27,11 @@ var (
 		},
 	}
 )
+
+func init() {
+	remove := pflag.Lookup("log-flush-frequency")
+	remove.Hidden = true
+}
 
 func main() {
 	cmdRoot.AddCommand(cmdVersion)


### PR DESCRIPTION
hides the flag log-flush-frequency from the command line.
this flag is set from k8s libraries and not used in bootkube.

Fixes #53