### PR TITLE
Bootkube checks for active checkpointer pod.

### DIFF
--- a/image/checkpoint/checkpoint-pod.yaml
+++ b/image/checkpoint/checkpoint-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: kube-api-checkpoint
   namespace: kube-system
+  labels:
+    k8s-app: kube-api-checkpoint
 spec:
   containers:
   - name: checkpoint

--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -31,6 +31,7 @@ const (
 )
 
 var requiredPods = []string{
+	"kube-api-checkpoint",
 	"kubelet",
 	"kube-apiserver",
 	"kube-scheduler",


### PR DESCRIPTION
During the provisioning of the cluster bootkube will be checking for running checkpointing pod to reduce the window on first boot where an api-server could fail and there is no checkpoint.

Fixes #117