### PR TITLE
pkg/bootkube: add simple stdout status info

### DIFF
--- a/cmd/bootkube/start.go
+++ b/cmd/bootkube/start.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"net/url"
 
@@ -48,6 +49,8 @@ func runCmdStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// set in util init() func, but lets not depend on that
+	flag.Set("logtostderr", "true")
 	util.InitLogs()
 	defer util.FlushLogs()
 

--- a/hack/multi-node/bootkube-up
+++ b/hack/multi-node/bootkube-up
@@ -28,7 +28,7 @@ scp -q -o stricthostkeychecking=no -i ${ssh_ident} -P ${ssh_port} -r cluster cor
 scp -q -o stricthostkeychecking=no -i ${ssh_ident} -P ${ssh_port} ../../_output/bin/linux/bootkube core@127.0.0.1:/home/core
 
 # Run bootkube
-ssh -q -o stricthostkeychecking=no -i ${ssh_ident} -p ${ssh_port} core@127.0.0.1 "sudo /home/core/bootkube start --asset-dir=/home/core/cluster --etcd-server=http://172.17.4.51:2379"
+ssh -q -o stricthostkeychecking=no -i ${ssh_ident} -p ${ssh_port} core@127.0.0.1 "sudo /home/core/bootkube start --asset-dir=/home/core/cluster --etcd-server=http://172.17.4.51:2379 2> /home/core/stderr.log"
 
 echo
 echo "Bootstrap complete. Access your kubernetes cluster using:"

--- a/hack/single-node/bootkube-up
+++ b/hack/single-node/bootkube-up
@@ -25,7 +25,7 @@ scp -q -o stricthostkeychecking=no -i ${ssh_ident} -P ${ssh_port} -r cluster cor
 scp -q -o stricthostkeychecking=no -i ${ssh_ident} -P ${ssh_port} ../../_output/bin/linux/bootkube core@127.0.0.1:/home/core
 
 # Run bootkube
-ssh -q -o stricthostkeychecking=no -i ${ssh_ident} -p ${ssh_port} core@127.0.0.1 "sudo /home/core/bootkube start --asset-dir=/home/core/cluster"
+ssh -q -o stricthostkeychecking=no -i ${ssh_ident} -p ${ssh_port} core@127.0.0.1 "sudo /home/core/bootkube start --asset-dir=/home/core/cluster 2> /home/core/stderr.log"
 
 echo
 echo "Bootstrap complete. Access your kubernetes cluster using:"

--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -1,6 +1,7 @@
 package bootkube
 
 import (
+	"fmt"
 	"net/url"
 	"path/filepath"
 	"time"
@@ -94,6 +95,8 @@ func NewBootkube(config Config) (*bootkube, error) {
 }
 
 func (b *bootkube) Run() error {
+	UserOutput("Running temporary bootstrap control plane...\n")
+
 	errch := make(chan error)
 	go func() { errch <- apiapp.Run(b.apiServer) }()
 	go func() { errch <- cmapp.Run(b.controller) }()
@@ -107,4 +110,12 @@ func (b *bootkube) Run() error {
 
 	// If any of the bootkube services exit, it means it is unrecoverable and we should exit.
 	return <-errch
+}
+
+// All bootkube printing to stdout should go through this fmt.Printf wrapper.
+// The stdout of bootkube should convey information useful to a human sitting
+// at a terminal watching their cluster bootstrap itself. Otherwise the message
+// should go to stderr.
+func UserOutput(format string, a ...interface{}) {
+	fmt.Printf(format, a...)
 }

--- a/pkg/bootkube/create.go
+++ b/pkg/bootkube/create.go
@@ -2,6 +2,7 @@ package bootkube
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -18,6 +19,8 @@ import (
 )
 
 func CreateAssets(manifestDir string, timeout time.Duration) error {
+	UserOutput("Sending self-hosted assets to temporary control plane...\n")
+
 	upFn := func() (bool, error) {
 		if err := apiTest(); err != nil {
 			glog.Warningf("Unable to determine api-server version: %v", err)
@@ -44,6 +47,9 @@ func CreateAssets(manifestDir string, timeout time.Duration) error {
 	if err := wait.Poll(5*time.Second, timeout, createFn); err != nil {
 		return fmt.Errorf("Failed to create assets: %v", err)
 	}
+
+	UserOutput("Spawning self-hosted control plane...\n")
+
 	return nil
 }
 
@@ -111,6 +117,7 @@ func createAssets(manifestDir string) error {
 			f.PrintObjectSpecificMessage(info.Object, util.GlogWriter{})
 		}
 		cmdutil.PrintSuccess(mapper, shortOutput, util.GlogWriter{}, info.Mapping.Resource, info.Name, "created")
+		UserOutput("\tcreated %23s %s\n", info.Name, strings.TrimSuffix(info.Mapping.Resource, "s"))
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
Basic status information goes to stdout and diagnostics/logs go to
stderr.

Running `bootkube start 2> /dev/null`gives the following output:
```
Running temporary bootstrap control plane...
Sending self-hosted assets to temporary control plane...
Spawning self-hosted control plane...
       	Pod Status: kube-controller-manager    	Pending
       	Pod Status:          kube-scheduler    	Pending
       	Pod Status:                 kubelet    	Pending
       	Pod Status:          kube-apiserver    	Pending
       	Pod Status:          kube-scheduler    	Running
       	Pod Status:          kube-apiserver    	Running
       	Pod Status:                 kubelet    	Running
       	Pod Status: kube-controller-manager    	Running
All self-hosted control plane components successfully started

Bootstrap complete. Access your kubernetes cluster using:
kubectl --kubeconfig=cluster/auth/kubeconfig get nodes
```

First 3 lines of output happen pretty fast. I think its probably worth deleting the line about sending assets but left it in for first review.