### PR TITLE
pkg/asset: Update kube-dns to v17.1

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -30,7 +30,7 @@ const (
 	AssetPathControllerManager       = "manifests/kube-controller-manager.yaml"
 	AssetPathControllerManagerSecret = "manifests/kube-controller-manager-secret.yaml"
 	AssetPathScheduler               = "manifests/kube-scheduler.yaml"
-	AssetPathKubeDNSRc               = "manifests/kube-dns-rc.yaml"
+	AssetPathKubeDNSDeployment       = "manifests/kube-dns-deployment.yaml"
 	AssetPathKubeDNSSvc              = "manifests/kube-dns-svc.yaml"
 	AssetPathSystemNamespace         = "manifests/kube-system-ns.yaml"
 )

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -279,14 +279,14 @@ spec:
         hostPath:
           path: /etc/kubernetes
 `)
-	DNSRcTemplate = []byte(`apiVersion: extensions/v1beta1
+	DNSDeploymentTemplate = []byte(`apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: kube-dns-v11
+  name: kube-dns-v17.1
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v11
+    version: v17.1
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -294,41 +294,19 @@ spec:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v11
+        version: v17.1
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-      - name: etcd
-        image: gcr.io/google_containers/etcd-amd64:2.2.1
+      - name: kubedns
+        image: gcr.io/google_containers/kubedns-amd64:1.5
         resources:
           limits:
             cpu: 100m
-            memory: 500Mi
+            memory: 170Mi
           requests:
             cpu: 100m
-            memory: 50Mi
-        command:
-        - /usr/local/bin/etcd
-        - -data-dir
-        - /var/etcd/data
-        - -listen-client-urls
-        - http://127.0.0.1:2379,http://127.0.0.1:4001
-        - -advertise-client-urls
-        - http://127.0.0.1:2379,http://127.0.0.1:4001
-        - -initial-cluster-token
-        - skydns-etcd
-        volumeMounts:
-        - name: etcd-storage
-          mountPath: /var/etcd/data
-      - name: kube2sky
-        image: gcr.io/google_containers/kube2sky:1.14
-        resources:
-          limits:
-            cpu: 100m
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 50Mi
+            memory: 70Mi
         livenessProbe:
           httpGet:
             path: /healthz
@@ -346,21 +324,21 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 5
         args:
-        - --domain=cluster.local
-      - name: skydns
-        image: gcr.io/google_containers/skydns:2015-10-13-8c72f8c
-        resources:
-          limits:
-            cpu: 100m
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 50Mi
-        args:
-        - -machines=http://127.0.0.1:4001
-        - -addr=0.0.0.0:53
-        - -ns-rotate=false
-        - -domain=cluster.local.
+          - --domain=cluster.local.
+          - --dns-port=10053
+          ports:
+          - containerPort: 10053
+            name: dns-local
+            protocol: UDP
+          - containerPort: 10053
+            name: dns-tcp-local
+            protocol: TCP
+        - name: dnsmasq
+          image: gcr.io/google_containers/kube-dnsmasq-amd64:1.3
+          args:
+          - --cache-size=1000
+          - --no-resolv
+          - --server=127.0.0.1#10053
         ports:
         - containerPort: 53
           name: dns
@@ -369,23 +347,21 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: healthz
-        image: gcr.io/google_containers/exechealthz:1.0
+        image: gcr.io/google_containers/exechealthz-amd64:1.1
         resources:
           limits:
             cpu: 10m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 10m
-            memory: 20Mi
+            memory: 50Mi
         args:
         - -cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null
         - -port=8080
+        - -quiet
         ports:
         - containerPort: 8080
           protocol: TCP
-      volumes:
-      - name: etcd-storage
-        emptyDir: {}
       dnsPolicy: Default
 `)
 	DNSSvcTemplate = []byte(`apiVersion: v1

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -22,7 +22,7 @@ func newStaticAssets() Assets {
 	return Assets{
 		mustCreateAssetFromTemplate(AssetPathControllerManager, internal.ControllerManagerTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathScheduler, internal.SchedulerTemplate, noData),
-		mustCreateAssetFromTemplate(AssetPathKubeDNSRc, internal.DNSRcTemplate, noData),
+		mustCreateAssetFromTemplate(AssetPathKubeDNSDeployment, internal.DNSDeploymentTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeDNSSvc, internal.DNSSvcTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathSystemNamespace, internal.SystemNSTemplate, noData),
 	}


### PR DESCRIPTION
Update kube-dns deployment from 11 to v17.1.

rel: https://github.com/coreos/coreos-kubernetes/commit/64e44562fd4da459d631d28f6269c22779372cca
replaces: #107
cc: @ericchiang 