### PR TITLE
pkg/bootkube: remove apiserver port staggering

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -128,7 +128,7 @@ spec:
       hostNetwork: true
       containers:
       - name: checkpoint-installer
-        image: quay.io/coreos/pod-checkpointer:969e207f005a78d1823e88bb10be34386eea473f
+        image: quay.io/coreos/pod-checkpointer:746b23aa9adb7ed383170dd03f418a1fa1175181
         command:
         - /checkpoint-installer.sh
         volumeMounts:

--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -18,16 +18,8 @@ import (
 )
 
 const (
-	assetTimeout = 10 * time.Minute
-	// NOTE: using 8081 as the port is a temporary hack when there is a single api-server.
-	// The self-hosted apiserver will immediately die if it cannot bind to the insecure interface.
-	// However, if it can successfully bind to insecure interface, it will continue to retry
-	// failures on the the secure interface.
-	// Staggering the insecure port allows us to launch a self-hosted api-server on the same machine
-	// as the bootkube, and the self-hosted api-server will continually retry binding to secure interface
-	// and doesn't end up in a race with bootkube for the insecure port. When bootkube dies, the self-hosted
-	// api-server is using the correct standard ports (443/8080).
-	insecureAPIAddr = "http://127.0.0.1:8081"
+	assetTimeout    = 10 * time.Minute
+	insecureAPIAddr = "http://127.0.0.1:8080"
 )
 
 var requiredPods = []string{
@@ -57,7 +49,7 @@ func NewBootkube(config Config) (*bootkube, error) {
 	fs.Parse([]string{
 		"--bind-address=0.0.0.0",
 		"--secure-port=443",
-		"--insecure-port=8081", // NOTE: temp hack for single-apiserver
+		"--insecure-port=8080",
 		"--allow-privileged=true",
 		"--tls-private-key-file=" + filepath.Join(config.AssetDir, asset.AssetPathAPIServerKey),
 		"--tls-cert-file=" + filepath.Join(config.AssetDir, asset.AssetPathAPIServerCert),


### PR DESCRIPTION
followup to: https://github.com/kubernetes-incubator/bootkube/pull/144

@aaronlevy 