### PR TITLE
Kublet is optionally run as a self-hosted component

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -33,6 +33,7 @@ var (
 		etcdServers       string
 		apiServers        string
 		altNames          string
+		selfHostKubelet   bool
 	}
 )
 
@@ -44,6 +45,7 @@ func init() {
 	cmdRender.Flags().StringVar(&renderOpts.etcdServers, "etcd-servers", "http://127.0.0.1:2379", "List of etcd servers URLs including host:port, comma separated")
 	cmdRender.Flags().StringVar(&renderOpts.apiServers, "api-servers", "https://127.0.0.1:443", "List of API server URLs including host:port, commma seprated")
 	cmdRender.Flags().StringVar(&renderOpts.altNames, "api-server-alt-names", "", "List of SANs to use in api-server certificate. Example: 'IP=127.0.0.1,IP=127.0.0.2,DNS=localhost'. If empty, SANs will be extracted from the --api-servers flag.")
+	cmdRender.Flags().BoolVar(&renderOpts.selfHostKubelet, "self-host-kubelet", true, "Set false to skip creation of and pivot to self-hosted kubelet.")
 }
 
 func runCmdRender(cmd *cobra.Command, args []string) error {
@@ -106,11 +108,12 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 		}
 	}
 	return &asset.Config{
-		EtcdServers: etcdServers,
-		CACert:      caCert,
-		CAPrivKey:   caPrivKey,
-		APIServers:  apiServers,
-		AltNames:    altNames,
+		EtcdServers:     etcdServers,
+		CACert:          caCert,
+		CAPrivKey:       caPrivKey,
+		APIServers:      apiServers,
+		AltNames:        altNames,
+		SelfHostKubelet: renderOpts.selfHostKubelet,
 	}, nil
 }
 

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -38,18 +38,19 @@ const (
 // AssetConfig holds all configuration needed when generating
 // the default set of assets.
 type Config struct {
-	EtcdServers []*url.URL
-	APIServers  []*url.URL
-	CACert      *x509.Certificate
-	CAPrivKey   *rsa.PrivateKey
-	AltNames    *tlsutil.AltNames
+	EtcdServers     []*url.URL
+	APIServers      []*url.URL
+	CACert          *x509.Certificate
+	CAPrivKey       *rsa.PrivateKey
+	AltNames        *tlsutil.AltNames
+	SelfHostKubelet bool
 }
 
 // NewDefaultAssets returns a list of default assets, optionally
 // configured via a user provided AssetConfig. Default assets include
 // TLS assets (certs, keys and secrets), and k8s component manifests.
 func NewDefaultAssets(conf Config) (Assets, error) {
-	as := newStaticAssets()
+	as := newStaticAssets(conf.SelfHostKubelet)
 	as = append(as, newDynamicAssets(conf)...)
 
 	// TLS assets

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -17,16 +17,20 @@ const (
 	secretCMName        = "kube-controller-manager"
 )
 
-func newStaticAssets() Assets {
+func newStaticAssets(selfHostKubelet bool) Assets {
 	var noData interface{}
-	return Assets{
+	assets := Assets{
 		mustCreateAssetFromTemplate(AssetPathControllerManager, internal.ControllerManagerTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathScheduler, internal.SchedulerTemplate, noData),
-		mustCreateAssetFromTemplate(AssetPathKubelet, internal.KubeletTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathProxy, internal.ProxyTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeDNSDeployment, internal.DNSDeploymentTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeDNSSvc, internal.DNSSvcTemplate, noData),
 	}
+	if selfHostKubelet {
+		assets = append(assets, mustCreateAssetFromTemplate(AssetPathKubelet, internal.KubeletTemplate, noData))
+	}
+
+	return assets
 }
 
 func newDynamicAssets(conf Config) Assets {

--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -24,7 +24,6 @@ const (
 
 var requiredPods = []string{
 	"kube-api-checkpoint",
-	"kubelet",
 	"kube-apiserver",
 	"kube-scheduler",
 	"kube-controller-manager",


### PR DESCRIPTION
` --self-host-kubelet=false` can be passed to the `bootkube render` command to disable to creation of the kubelet asset. The self-hosted kubelet will never be created and the system kubelet will remain functional this way.

`bootkube start` no longer requires the kubelet pod to be running before it exits since the cluster should be functional either way. This simplifies this PR but it is possible, in the future, that `requiredPods` might need to be specified or inferred from the rendered assets.