### PR TITLE
Deploy checkpointer independently from api-server

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -27,6 +27,7 @@ const (
 	AssetPathProxy                   = "manifests/kube-proxy.yaml"
 	AssetPathAPIServerSecret         = "manifests/kube-apiserver-secret.yaml"
 	AssetPathAPIServer               = "manifests/kube-apiserver.yaml"
+	AssetPathCheckpointer            = "manifests/kube-api-checkpointer.yaml"
 	AssetPathControllerManager       = "manifests/kube-controller-manager.yaml"
 	AssetPathControllerManagerSecret = "manifests/kube-controller-manager-secret.yaml"
 	AssetPathScheduler               = "manifests/kube-scheduler.yaml"

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -127,13 +127,6 @@ spec:
         master: "true"
       hostNetwork: true
       containers:
-      - name: checkpoint-installer
-        image: quay.io/coreos/pod-checkpointer:f226b70d3a863a5dbcc5846ccd818296c30e703f
-        command:
-        - /checkpoint-installer.sh
-        volumeMounts:
-        - mountPath: /etc/kubernetes/manifests
-          name: etc-k8s-manifests
       - name: kube-apiserver
         image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
         command:
@@ -168,12 +161,38 @@ spec:
       - name: ssl-certs-host
         hostPath:
           path: /usr/share/ca-certificates
-      - name: etc-k8s-manifests
-        hostPath:
-          path: /etc/kubernetes/manifests
       - name: secrets
         secret:
           secretName: kube-apiserver
+`)
+	CheckpointerTemplate = []byte(`apiVersion: "extensions/v1beta1"
+kind: DaemonSet
+metadata:
+  name: checkpoint-installer
+  namespace: kube-system
+  labels:
+    k8s-app: kube-api-checkpointer
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-api-checkpointer
+    spec:
+      nodeSelector:
+        master: "true"
+      hostNetwork: true
+      containers:
+      - name: checkpoint-installer
+        image: quay.io/coreos/pod-checkpointer:f226b70d3a863a5dbcc5846ccd818296c30e703f
+        command:
+        - /checkpoint-installer.sh
+        volumeMounts:
+        - mountPath: /etc/kubernetes/manifests
+          name: etc-k8s-manifests
+      volumes:
+      - name: etc-k8s-manifests
+        hostPath:
+          path: /etc/kubernetes/manifests
 `)
 	ControllerManagerTemplate = []byte(`apiVersion: extensions/v1beta1
 kind: Deployment

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -25,6 +25,7 @@ func newStaticAssets(selfHostKubelet bool) Assets {
 		mustCreateAssetFromTemplate(AssetPathProxy, internal.ProxyTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeDNSDeployment, internal.DNSDeploymentTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeDNSSvc, internal.DNSSvcTemplate, noData),
+		mustCreateAssetFromTemplate(AssetPathCheckpointer, internal.CheckpointerTemplate, noData),
 	}
 	if selfHostKubelet {
 		assets = append(assets, mustCreateAssetFromTemplate(AssetPathKubelet, internal.KubeletTemplate, noData))


### PR DESCRIPTION
Checkpointer deployed independently from api-server. Deploying it as a separate component so it can be upgraded independently.

fixes #161 
