### PR TITLE
asset: add cloud provider as config option

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -45,6 +45,7 @@ type Config struct {
 	CAPrivKey       *rsa.PrivateKey
 	AltNames        *tlsutil.AltNames
 	SelfHostKubelet bool
+	CloudProvider   string
 }
 
 // NewDefaultAssets returns a list of default assets, optionally

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -141,6 +141,7 @@ spec:
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --client-ca-file=/etc/kubernetes/secrets/ca.crt
+        - --cloud-provider={{ .CloudProvider }}
         env:
           - name: MY_POD_IP
             valueFrom:
@@ -213,6 +214,8 @@ spec:
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
         - --leader-elect=true
+        - --cloud-provider={{ .CloudProvider }}
+        - --configure-cloud-routes=false
         volumeMounts:
         - name: secrets
           mountPath: /etc/kubernetes/secrets

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -20,7 +20,6 @@ const (
 func newStaticAssets(selfHostKubelet bool) Assets {
 	var noData interface{}
 	assets := Assets{
-		mustCreateAssetFromTemplate(AssetPathControllerManager, internal.ControllerManagerTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathScheduler, internal.SchedulerTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathProxy, internal.ProxyTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeDNSDeployment, internal.DNSDeploymentTemplate, noData),
@@ -37,6 +36,7 @@ func newStaticAssets(selfHostKubelet bool) Assets {
 func newDynamicAssets(conf Config) Assets {
 	return Assets{
 		mustCreateAssetFromTemplate(AssetPathAPIServer, internal.APIServerTemplate, conf),
+		mustCreateAssetFromTemplate(AssetPathControllerManager, internal.ControllerManagerTemplate, conf),
 	}
 }
 


### PR DESCRIPTION
This exposes a config option for setting the cloud-provider in the asset templates. The option is not plumbed through the cli options.

It is not part of the cli options yet because this could require a flag to be consistently used between `render` and `start`. I'd like to avoid this because a user could easily `render` with the flag, but then run `start` with out it -- which could end up in broken / difficult to debug situations. (this is also highly dependent on the cloud-provider implementation -- and whether we need this option to be part of the "internal/bootstrap" control-plane -- which I'm also leaving to a follow up PR if needed).

Instead I'd like both render and start to use a configuration file so rendered assets can also contain any options that might need to be passed to `start` -- but I will leave this to a follow-up issue.

/cc @dghubble @ericchiang @philips @sym3tri 