### PR TITLE
self hosted etcd migration

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -34,6 +34,7 @@ var (
 		apiServers        string
 		altNames          string
 		selfHostKubelet   bool
+		storageBackend    string
 	}
 )
 
@@ -43,6 +44,7 @@ func init() {
 	cmdRender.Flags().StringVar(&renderOpts.caCertificatePath, "ca-certificate-path", "", "Path to an existing PEM encoded CA. If provided, TLS assets will be generated using this certificate authority.")
 	cmdRender.Flags().StringVar(&renderOpts.caPrivateKeyPath, "ca-private-key-path", "", "Path to an existing Certificate Authority RSA private key. Required if --ca-certificate is set.")
 	cmdRender.Flags().StringVar(&renderOpts.etcdServers, "etcd-servers", "http://127.0.0.1:2379", "List of etcd servers URLs including host:port, comma separated")
+	cmdRender.Flags().StringVar(&renderOpts.storageBackend, "storage-backend", "etcd2", "storage backend for APIServer. Supports: etcd2, etcd3.")
 	cmdRender.Flags().StringVar(&renderOpts.apiServers, "api-servers", "https://127.0.0.1:443", "List of API server URLs including host:port, commma seprated")
 	cmdRender.Flags().StringVar(&renderOpts.altNames, "api-server-alt-names", "", "List of SANs to use in api-server certificate. Example: 'IP=127.0.0.1,IP=127.0.0.2,DNS=localhost'. If empty, SANs will be extracted from the --api-servers flag.")
 	cmdRender.Flags().BoolVar(&renderOpts.selfHostKubelet, "self-host-kubelet", false, "Create a self-hosted kubelet daemonset.")
@@ -114,6 +116,7 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 		APIServers:      apiServers,
 		AltNames:        altNames,
 		SelfHostKubelet: renderOpts.selfHostKubelet,
+		StorageBackend:  renderOpts.storageBackend,
 	}, nil
 }
 

--- a/cmd/bootkube/start.go
+++ b/cmd/bootkube/start.go
@@ -51,8 +51,9 @@ func runCmdStart(cmd *cobra.Command, args []string) error {
 	}
 
 	bk, err := bootkube.NewBootkube(bootkube.Config{
-		AssetDir:   startOpts.assetDir,
-		EtcdServer: etcdServer,
+		AssetDir:       startOpts.assetDir,
+		EtcdServer:     etcdServer,
+		SelfHostedEtcd: startOpts.selfHostedEtcd,
 	})
 
 	if err != nil {

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -34,6 +34,8 @@ const (
 	AssetPathKubeDNSDeployment       = "manifests/kube-dns-deployment.yaml"
 	AssetPathKubeDNSSvc              = "manifests/kube-dns-svc.yaml"
 	AssetPathSystemNamespace         = "manifests/kube-system-ns.yaml"
+	AssetPathEtcdOperator            = "manifests/etcd-operator.yaml"
+	AssetPathEtcdSvc                 = "manifests/etcd-service.yaml"
 )
 
 // AssetConfig holds all configuration needed when generating
@@ -45,6 +47,7 @@ type Config struct {
 	CAPrivKey       *rsa.PrivateKey
 	AltNames        *tlsutil.AltNames
 	SelfHostKubelet bool
+	StorageBackend  string
 }
 
 // NewDefaultAssets returns a list of default assets, optionally

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -133,6 +133,7 @@ spec:
         - --insecure-port=8080
         - --advertise-address=$(MY_POD_IP)
         - --etcd-servers={{ range $i, $e := .EtcdServers }}{{ if $i }},{{end}}{{ $e }}{{end}}
+        - --storage-backend={{.StorageBackend}}
         - --allow-privileged=true
         - --service-cluster-ip-range=10.3.0.0/24
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota
@@ -417,6 +418,44 @@ spec:
     protocol: UDP
   - name: dns-tcp
     port: 53
+    protocol: TCP
+`)
+	EtcdOperatorTemplate = []byte(`apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: etcd-operator
+  namespace: kube-system
+  labels:
+    k8s-app: etcd-operator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: etcd-operator
+    spec:
+      containers:
+      - name: etcd-operator
+        image: quay.io/coreos/etcd-operator
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+`)
+	EtcdSvcTemplate = []byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-service
+  namespace: kube-system
+spec:
+  selector:
+    app: etcd
+    etcd_cluster: etcd-cluster
+  clusterIP: 10.3.0.15
+  ports:
+  - name: client
+    port: 2379
     protocol: TCP
 `)
 )

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -26,6 +26,8 @@ func newStaticAssets(selfHostKubelet bool) Assets {
 		mustCreateAssetFromTemplate(AssetPathKubeDNSDeployment, internal.DNSDeploymentTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeDNSSvc, internal.DNSSvcTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathCheckpointer, internal.CheckpointerTemplate, noData),
+		mustCreateAssetFromTemplate(AssetPathEtcdOperator, internal.EtcdOperatorTemplate, noData),
+		mustCreateAssetFromTemplate(AssetPathEtcdSvc, internal.EtcdSvcTemplate, noData),
 	}
 	if selfHostKubelet {
 		assets = append(assets, mustCreateAssetFromTemplate(AssetPathKubelet, internal.KubeletTemplate, noData))

--- a/pkg/util/etcdutil/migrate.go
+++ b/pkg/util/etcdutil/migrate.go
@@ -1,0 +1,176 @@
+package etcdutil
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+	"k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_4"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/wait"
+)
+
+const (
+	apiserverAddr = "http://127.0.0.1:8080"
+	etcdServiceIP = "10.3.0.15"
+)
+
+func Migrate() error {
+	restcli, err := restclient.RESTClientFor(&restclient.Config{
+		Host: apiserverAddr,
+	})
+	if err != nil {
+		return fmt.Errorf("fail to create kube client: %v", err)
+	}
+	kubecli := clientset.New(restcli)
+
+	err = waitEtcdTPRReady(restcli.Client, 5*time.Second, 60*time.Second, apiserverAddr, api.NamespaceSystem)
+	if err != nil {
+		return err
+	}
+
+	ip, err := getBootEtcdPodIP(kubecli)
+	if err != nil {
+		return err
+	}
+	glog.Infof("boot-etcd pod IP is: %s", ip)
+
+	if err := createMigratedEtcdCluster(restcli.Client, apiserverAddr, ip); err != nil {
+		glog.Errorf("fail to create migrated etcd cluster: %v", err)
+		return err
+	}
+
+	return checkEtcdClusterUp()
+}
+
+func listETCDCluster(host, ns string, httpClient *http.Client) (*http.Response, error) {
+	return httpClient.Get(fmt.Sprintf("%s/apis/coreos.com/v1/namespaces/%s/etcdclusters",
+		host, ns))
+}
+
+func waitEtcdTPRReady(httpClient *http.Client, interval, timeout time.Duration, host, ns string) error {
+	err := wait.Poll(interval, timeout, func() (bool, error) {
+		resp, err := listETCDCluster(host, ns, httpClient)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			return true, nil
+		case http.StatusNotFound: // not set up yet. wait.
+			return false, nil
+		default:
+			return false, fmt.Errorf("invalid status code: %v", resp.Status)
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("fail to wait etcd TPR to be ready: %v", err)
+	}
+	return nil
+}
+
+func getBootEtcdPodIP(kubecli clientset.Interface) (string, error) {
+	var ip string
+	err := wait.Poll(5*time.Second, 60*time.Second, func() (bool, error) {
+		podList, err := kubecli.Core().Pods(api.NamespaceSystem).List(api.ListOptions{
+			LabelSelector: labels.SelectorFromSet(labels.Set{"k8s-app": "boot-etcd"}),
+		})
+		if err != nil {
+			glog.Errorf("fail to list 'boot-etcd' pod: %v", err)
+			return false, err
+		}
+		if len(podList.Items) < 1 {
+			glog.Warningf("no 'boot-etcd' pod found, retrying after 5s...")
+			return false, nil
+		}
+
+		pod := podList.Items[0]
+		ip = pod.Status.PodIP
+		if len(ip) == 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+	return ip, err
+}
+
+func createMigratedEtcdCluster(httpcli *http.Client, host, podIP string) error {
+	b := []byte(fmt.Sprintf(`{
+  "apiVersion": "coreos.com/v1",
+  "kind": "EtcdCluster",
+  "metadata": {
+    "name": "etcd-cluster",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "size": 1,
+    "version": "v3.1.0-alpha.1",
+    "seed": {
+      "MemberClientEndpoints": [
+        "http://%s:2379"
+      ],
+      "RemoveDelay": 30
+    }
+  }
+}`, podIP))
+
+	resp, err := httpcli.Post(
+		fmt.Sprintf("%s/apis/coreos.com/v1/namespaces/kube-system/etcdclusters", host),
+		"application/json", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("fail to create etcd cluster object, status (%v), object (%s)", resp.Status, string(b))
+	}
+	return nil
+}
+
+func checkEtcdClusterUp() error {
+	glog.Infof("initial delaying (30s)...")
+	time.Sleep(30 * time.Second)
+
+	// The checking does:
+	// - Trying to talk to etcd cluster via etcd service. The assumption here is that
+	//   the etcd service only selects the etcd pods newly created, excluding the boot one.
+	//   Once we can talk to it, we are sure that etcd cluster is created.
+	// - Then we list members and see if it's been reduced to 1 member. Because when we
+	//   can talk to the etcd cluster, we are certain there are 2 members at the beginning,
+	//   and will reduce to 1 eventually. That's the timeline of expected events.
+	//   As long as 1 member cluster is reached, we are certain cluster has been migrated successfully.
+	err := wait.PollImmediate(10*time.Second, 60*time.Second, func() (bool, error) {
+		cfg := clientv3.Config{
+			Endpoints:   []string{fmt.Sprintf("http://%s:2379", etcdServiceIP)},
+			DialTimeout: 5 * time.Second,
+		}
+		etcdcli, err := clientv3.New(cfg)
+		if err != nil {
+			glog.Errorf("fail to create etcd client, retrying...: %v", err)
+			return false, nil
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		m, err := etcdcli.MemberList(ctx)
+		if err != nil {
+			glog.Errorf("fail to list etcd members, retrying...: %v", err)
+			return false, nil
+		}
+		if len(m.Members) != 1 {
+			glog.Infof("Still migrating boot etcd member, retrying...")
+			return false, nil
+		}
+		glog.Infof("etcd cluster is up. Member: %v", m.Members[0].Name)
+		return true, nil
+	})
+	return err
+}

--- a/pkg/util/etcdutil/start_etcd.go
+++ b/pkg/util/etcdutil/start_etcd.go
@@ -38,6 +38,8 @@ kind: Pod
 metadata:
   name: boot-etcd
   namespace: kube-system
+  labels:
+    k8s-app: boot-etcd
 spec:
   containers:
   - command:
@@ -61,4 +63,5 @@ spec:
     image: quay.io/coreos/etcd:v3.1.0-alpha.1
     name: etcd
   hostNetwork: true
+  restartPolicy: Never
 `


### PR DESCRIPTION
This PR implements the migration process in self hosted etcd mode:
- starts etcd operator
- reserve etcd service with IP 10.3.0.15
- migrate static etcd pod to managed etcd clusterd

## How to use the feature?

In Render:
```
$ _output/bin/linux/bootkube render --asset-dir=asset --etcd-servers=http://10.3.0.20:2379 --storage-backend=etcd3
```

In Start:
```
$ _output/bin/linux/bootkube start --asset-dir=asset --experimental-self-hosted-etcd=true
```
You might need to use "sudo" or get access to "/etc/kubernetes/manifest" dir.