### PR TITLE
pkg/asset: Add CloudProvider field to Config

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -45,13 +45,14 @@ type Config struct {
 	CAPrivKey       *rsa.PrivateKey
 	AltNames        *tlsutil.AltNames
 	SelfHostKubelet bool
+	CloudProvider   string
 }
 
 // NewDefaultAssets returns a list of default assets, optionally
 // configured via a user provided AssetConfig. Default assets include
 // TLS assets (certs, keys and secrets), and k8s component manifests.
 func NewDefaultAssets(conf Config) (Assets, error) {
-	as := newStaticAssets(conf.SelfHostKubelet)
+	as := newStaticAssets()
 	as = append(as, newDynamicAssets(conf)...)
 
 	// TLS assets

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -51,6 +51,9 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --require-kubeconfig
         - --lock-file=/var/run/lock/kubelet.lock
+        {{ if .CloudProvider -}}
+        - --cloud-provider={{.CloudProvider}}
+        {{ end -}}
         env:
           - name: MY_POD_IP
             valueFrom:
@@ -141,6 +144,9 @@ spec:
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --client-ca-file=/etc/kubernetes/secrets/ca.crt
+        {{ if .CloudProvider -}}
+        - --cloud-provider={{.CloudProvider}}
+        {{ end -}}
         env:
           - name: MY_POD_IP
             valueFrom:
@@ -213,6 +219,10 @@ spec:
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
         - --leader-elect=true
+        {{ if .CloudProvider -}}
+        - --cloud-provider={{.CloudProvider}}
+        - --configure-cloud-routes=false
+        {{ end -}}
         volumeMounts:
         - name: secrets
           mountPath: /etc/kubernetes/secrets
@@ -227,6 +237,7 @@ spec:
       - name: ssl-host
         hostPath:
           path: /usr/share/ca-certificates
+      dnsPolicy: Default  # Don't use cluster DNS.
 `)
 	SchedulerTemplate = []byte(`apiVersion: extensions/v1beta1
 kind: Deployment

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -17,27 +17,26 @@ const (
 	secretCMName        = "kube-controller-manager"
 )
 
-func newStaticAssets(selfHostKubelet bool) Assets {
+func newStaticAssets() Assets {
 	var noData interface{}
-	assets := Assets{
-		mustCreateAssetFromTemplate(AssetPathControllerManager, internal.ControllerManagerTemplate, noData),
+	return Assets{
 		mustCreateAssetFromTemplate(AssetPathScheduler, internal.SchedulerTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathProxy, internal.ProxyTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeDNSDeployment, internal.DNSDeploymentTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeDNSSvc, internal.DNSSvcTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathCheckpointer, internal.CheckpointerTemplate, noData),
 	}
-	if selfHostKubelet {
-		assets = append(assets, mustCreateAssetFromTemplate(AssetPathKubelet, internal.KubeletTemplate, noData))
-	}
-
-	return assets
 }
 
 func newDynamicAssets(conf Config) Assets {
-	return Assets{
+	assets := Assets{
 		mustCreateAssetFromTemplate(AssetPathAPIServer, internal.APIServerTemplate, conf),
+		mustCreateAssetFromTemplate(AssetPathControllerManager, internal.ControllerManagerTemplate, conf),
 	}
+	if conf.SelfHostKubelet {
+		assets = append(assets, mustCreateAssetFromTemplate(AssetPathKubelet, internal.KubeletTemplate, conf))
+	}
+	return assets
 }
 
 func newKubeConfigAsset(assets Assets, conf Config) (Asset, error) {


### PR DESCRIPTION
Similar to #182, it was determined that changes to `bootkube start` and coordination btw render and start weren't needed. This change does not expose CloudProvider as a flag, unless that's desired @aaronlevy?