### PR TITLE
image/checkpoint: allow setting alternate mirror repo

### DIFF
--- a/image/checkpoint/build-image.sh
+++ b/image/checkpoint/build-image.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-IMAGE_REPO=${IMAGE_REPO:-quay.io/coreos/pod-checkpointer}
+MIRROR=${MIRROR:-quay.io}
+IMAGE_REPO=${IMAGE_REPO:-${MIRROR}/coreos/pod-checkpointer}
 
 readonly BOOTKUBE_ROOT=$(git rev-parse --show-toplevel)
 readonly VERSION=${VERSION:-$(${BOOTKUBE_ROOT}/build/git-version.sh)}
@@ -15,6 +16,7 @@ function image::build() {
     cp ${BOOTKUBE_ROOT}/image/checkpoint/checkpoint-install.sh ${TEMP_DIR}
     cp ${BOOTKUBE_ROOT}/image/checkpoint/checkpoint-pod.yaml ${TEMP_DIR}
     sed -i "s#{{ REPO }}:{{ TAG }}#${IMAGE_REPO}:${VERSION}#" ${TEMP_DIR}/checkpoint-pod.yaml
+    sed -i "s#{{ MIRROR }}#${MIRROR}#" ${TEMP_DIR}/checkpoint-install.sh
 
     docker build -t ${IMAGE_REPO}:${VERSION} -f ${TEMP_DIR}/Dockerfile ${TEMP_DIR}
     rm -rf ${TEMP_DIR}

--- a/image/checkpoint/checkpoint-install.sh
+++ b/image/checkpoint/checkpoint-install.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+MIRROR=${MIRROR:-{{ MIRROR }}}
+sed -i "s#{{ MIRROR }}#${MIRROR}#" /checkpoint-pod.yaml
 cp /checkpoint-pod.yaml /etc/kubernetes/manifests
 while true
 do


### PR DESCRIPTION
this enables setting optional MIRROR env var on checkpoint-installer
container to allow downloading images from a mirror.

fixes #180 