### PR TITLE
use self hosted spec and change static etcd pod

### DIFF
--- a/pkg/util/etcdutil/migrate.go
+++ b/pkg/util/etcdutil/migrate.go
@@ -113,11 +113,8 @@ func createMigratedEtcdCluster(httpcli *http.Client, host, podIP string) error {
   "spec": {
     "size": 1,
     "version": "v3.1.0-alpha.1",
-    "seed": {
-      "MemberClientEndpoints": [
-        "http://%s:2379"
-      ],
-      "RemoveDelay": 30
+    "selfHosted": {
+		"bootMemberClientEndpoint": "http://%s:12379"
     }
   }
 }`, podIP))

--- a/pkg/util/etcdutil/start_etcd.go
+++ b/pkg/util/etcdutil/start_etcd.go
@@ -47,11 +47,11 @@ spec:
     - -c
     - /usr/local/bin/etcd
       --name boot-etcd
-      --listen-client-urls=http://0.0.0.0:2379
-      --listen-peer-urls=http://0.0.0.0:2380
-      --advertise-client-urls=http://$(MY_POD_IP):2379
-      --initial-advertise-peer-urls http://$(MY_POD_IP):2380
-      --initial-cluster boot-etcd=http://$(MY_POD_IP):2380
+      --listen-client-urls=http://0.0.0.0:12379
+      --listen-peer-urls=http://0.0.0.0:12380
+      --advertise-client-urls=http://$(MY_POD_IP):12379
+      --initial-advertise-peer-urls http://$(MY_POD_IP):12380
+      --initial-cluster boot-etcd=http://$(MY_POD_IP):12380
       --initial-cluster-token bootkube
       --initial-cluster-state new
       --data-dir=/var/etcd/data


### PR DESCRIPTION
Self hosted spec is changed from etcd operator side.
Because we are now using host network, we can't conflict with self hosted etcd pods which use "2379" hard-coded right now, and we change the static etcd pod to use different ports.

## Changes in workflow:
"bootkube start":
```
$ _output/bin/linux/bootkube start --asset-dir=asset --experimental-self-hosted-etcd=true --etcd-server http://127.0.0.1:12379
```
We need to pass in etcd-server.
