### PR TITLE
Enable bootkube setup behind proxy

### DIFF
--- a/hack/multi-node/bootkube-up
+++ b/hack/multi-node/bootkube-up
@@ -15,6 +15,13 @@ if [ ! -d "cluster" ]; then
   cp cluster/user-data{,-worker}
   cp cluster/user-data{,-controller}
   sed -i.bak -e '/--node-labels=master=true/d' cluster/user-data-worker
+  for i in http_proxy https_proxy HTTP_PROXY HTTPS_PROXY; do
+    if [ -n "${!i:-}" ]; then
+        sed -i 's;${'"${i}"'};'"${!i}"';' cluster/user-data{,-worker,-controller}
+    else
+        sed -i '/${'"${i}"'/d' cluster/user-data{,-worker,-controller}
+    fi
+  done
 fi
 
 # Start the VM

--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -12,6 +12,10 @@ coreos:
         content: |
           [Service]
           ExecStartPre=/usr/bin/etcdctl --endpoint=http://172.17.4.51:2379 set /coreos.com/network/config '{ "Network": "10.2.0.0/16" }'
+          Environment=HTTP_PROXY=${http_proxy}
+          Environment=HTTPS_PROXY=${https_proxy}
+          Environment=http_proxy=${http_proxy}
+          Environment=https_proxy=${https_proxy}
     - name: docker.service
       drop-ins:
       - name: 50-flannel.conf
@@ -19,6 +23,11 @@ coreos:
           [Unit]
           Requires=flanneld.service
           After=flanneld.service
+          [Service]
+          Environment=HTTP_PROXY=${http_proxy}
+          Environment=HTTPS_PROXY=${https_proxy}
+          Environment=http_proxy=${http_proxy}
+          Environment=https_proxy=${https_proxy}
     - name: kubelet.service
       enable: true
       command: start
@@ -27,6 +36,10 @@ coreos:
         EnvironmentFile=/etc/environment
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
         Environment=KUBELET_VERSION=v1.4.6_coreos.0
+        Environment=HTTP_PROXY=${http_proxy}
+        Environment=HTTPS_PROXY=${https_proxy}
+        Environment=http_proxy=${http_proxy}
+        Environment=https_proxy=${https_proxy}
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets

--- a/hack/single-node/bootkube-up
+++ b/hack/single-node/bootkube-up
@@ -12,6 +12,13 @@ if [ ! -d "cluster" ]; then
   ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.100:443
   # Add rendered kubeconfig to the node user-data
   cat user-data.sample > cluster/user-data && sed 's/^/      /' cluster/auth/kubeconfig >> cluster/user-data
+  for i in http_proxy https_proxy HTTP_PROXY HTTPS_PROXY; do
+    if [ -n "${!i:-}" ]; then
+        sed -i 's;${'"${i}"'};'"${!i}"';' cluster/user-data
+    else
+        sed -i '/${'"${i}"'/d' cluster/user-data
+    fi
+  done
 fi
 
 # Start the VM

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -13,6 +13,10 @@ coreos:
         content: |
           [Service]
           ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ "Network": "10.2.0.0/16" }'
+          Environment=HTTP_PROXY=${http_proxy}
+          Environment=HTTPS_PROXY=${https_proxy}
+          Environment=http_proxy=${http_proxy}
+          Environment=https_proxy=${https_proxy}
     - name: docker.service
       drop-ins:
       - name: 50-flannel.conf
@@ -20,6 +24,11 @@ coreos:
           [Unit]
           Requires=flanneld.service
           After=flanneld.service
+          [Service]
+          Environment=HTTP_PROXY=${http_proxy}
+          Environment=HTTPS_PROXY=${https_proxy}
+          Environment=http_proxy=${http_proxy}
+          Environment=https_proxy=${https_proxy}
     - name: kubelet.service
       enable: true
       command: start
@@ -28,6 +37,10 @@ coreos:
         EnvironmentFile=/etc/environment
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
         Environment=KUBELET_VERSION=v1.4.6_coreos.0
+        Environment=HTTP_PROXY=${http_proxy}
+        Environment=HTTPS_PROXY=${https_proxy}
+        Environment=http_proxy=${http_proxy}
+        Environment=https_proxy=${https_proxy}
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets


### PR DESCRIPTION
Add http proxy settings to user-data.sample which is then expanded or
deleted when running bootkube-up. This  allows setup behind corporate proxies.