### PR TITLE
pkg/asset: Add OIDC flags to kube-apiserver

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -50,6 +50,14 @@ type Config struct {
 	SelfHostedEtcd  bool
 	StorageBackend  string
 	CloudProvider   string
+	OIDCIssuer      *OIDCIssuer
+}
+
+type OIDCIssuer struct {
+	IssuerURL     string
+	ClientID      string
+	UsernameClaim string
+	CAPath        string
 }
 
 // NewDefaultAssets returns a list of default assets, optionally

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -143,7 +143,13 @@ spec:
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --client-ca-file=/etc/kubernetes/secrets/ca.crt
         - --cloud-provider={{ .CloudProvider  }}
-        env:
+        {{ if .OIDCIssuer -}}
+        - --oidc-issuer-url={{.OIDCIssuer.IssuerURL}}
+        - --oidc-client-id={{.OIDCIssuer.ClientID}}
+        - --oidc-username-claim={{.OIDCIssuer.UsernameClaim}}
+        - --oidc-ca-file={{.OIDCIssuer.CAPath}}
+        {{ end }}
+				env:
           - name: MY_POD_IP
             valueFrom:
               fieldRef:


### PR DESCRIPTION
This adds the ability to pass OIDC parameters to the API Server.