### PR TITLE
Add missing --cloud-provider parameter to kubelet

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -51,6 +51,7 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --require-kubeconfig
         - --lock-file=/var/run/lock/kubelet.lock
+        - --cloud-provider={{.CloudProvider}}
         env:
           - name: MY_POD_IP
             valueFrom:


### PR DESCRIPTION
https://github.com/kubernetes-incubator/bootkube/pull/105 introduces usage of --cloud-provider in bootkube, however the parameter isn't passed to the kubelet.

@aaronlevy