### PR TITLE
pkg/asset/internal: label key naming consistency

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -261,12 +261,12 @@ metadata:
   name: kube-proxy
   namespace: kube-system
   labels:
-    k8s_app: kube-proxy
+    k8s-app: kube-proxy
 spec:
   template:
     metadata:
       labels:
-        k8s_app: kube-proxy
+        k8s-app: kube-proxy
     spec:
       hostNetwork: true
       containers:


### PR DESCRIPTION
For consistency all kubernetes components have the `k8s-app` label, for the `kube-proxy` this was previously not the case. This matches the upstream [example manifest](https://github.com/kubernetes/kubernetes/blob/8fd414537b5143ab039cb910590237cabf4af783/cluster/images/hyperkube/kube-proxy-ds.yaml) in terms of the `k8s-app` label. Let me know if you want me to adapt any other changes from the upstream manifest in here.

@aaronlevy 