### PR TITLE
Add support for template overrides

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -41,15 +41,23 @@ const (
 // AssetConfig holds all configuration needed when generating
 // the default set of assets.
 type Config struct {
-	EtcdServers     []*url.URL
-	APIServers      []*url.URL
-	CACert          *x509.Certificate
-	CAPrivKey       *rsa.PrivateKey
-	AltNames        *tlsutil.AltNames
-	SelfHostKubelet bool
-	SelfHostedEtcd  bool
-	StorageBackend  string
-	CloudProvider   string
+	EtcdServers       []*url.URL
+	APIServers        []*url.URL
+	CACert            *x509.Certificate
+	CAPrivKey         *rsa.PrivateKey
+	AltNames          *tlsutil.AltNames
+	SelfHostKubelet   bool
+	SelfHostedEtcd    bool
+	StorageBackend    string
+	CloudProvider     string
+	TemplateOverrides map[string]Template
+}
+
+// Template holds a textual template as well as data that can be used during
+// generation.
+type Template struct {
+	Template []byte
+	Data     interface{}
 }
 
 // NewDefaultAssets returns a list of default assets, optionally


### PR DESCRIPTION
This PR enables developers who use bootkube as a library to override certain existing templates (with extra rendering data). For now, only dynamic assets may be overridden (API Server and Controller Manager).

When extra ConfigMaps are to be mounted (e.g. when `--authorization-policy-file=/etc/kubernetes/authz/policy.json` is used on the API server), I believe that they could be provided as part of the overridden template, as another resource.

This mainly is a draft and I'm indeed open to discussion.
  