### PR TITLE
checkpointer: rewrite for generic pod checkpoints

### DIFF
--- a/cmd/checkpoint/README.md
+++ b/cmd/checkpoint/README.md
@@ -1,16 +1,74 @@
 # Checkpoint
 
-`checkpoint` is a small utility that will convert an API server pod manifest
-into a static manifest which can be stored on disk. The pod manifest is
-obtained from the kubelets read only API.
+## Description
 
-This is useful for single-master clusters. A single-master cluster with this
-checkpointing is resilient to certain failure scenarios, such as a system
-reboot, or complete loss of the API server.
+`checkpoint` is a utility application which will manage "checkpoints" of pods scheduled to the local node.
 
-The tool waits until it detects an API server is no longer running.
-In that case, it will move the static pod manifest created earlier into the
-directory specified as the kubelets config directory. Once the tool detects our
-normal API server has started up again, it will move the static manifest out of
-the config directory, causing the kubelet to stop the checkpointed API server,
-enabling the self-hosted API server to take over once more.
+The purpose of a pod checkpoint is to ensure that existing local pod state can be recovered in the absence of an api-server.
+
+The kubelet will already attempt to ensure that local pods will continue to run in the absence of an API server (based on restartPolicy). However, if all local runtime state has been lost (for example after a reboot), the checkpoint utility will ensure the local state can be recovered until an api-server is contacted.
+
+This is accomplished by managing checkpoints as static pod manifests:
+
+- When the checkpointer sees that a "parent pod" (a pod which should be checkpointed), is succesfully running, the checkpointer will save a local copy of the manifest.
+
+- If the parent pod is detected as no longer running, the checkpointer will "activate" the checkpoint manifest. It will allow the checkpoint to continue running until the parent-pod is restarted on the local node, or it is able to contact an api-server to determine that the parent pod is no longer scheduled to this node.
+
+## Use
+
+Any pod which contains the `checkpointer.alpha.coreos.com/checkpoint=true` annotation will be considered a viable "parent pod" which should be checkpointed.
+The parent pod cannot itself be a static pod, and is not a checkpoint itself.
+
+Checkpoints are denoted by the `checkpointer.alpha.coreos.com/checkpoint-of` annotation. This annotation will point to the parent of this checkpoint by pod name.
+
+For example the pod:
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+  annotations:
+    checkpointer.alpha.coreos.com/checkpoint=true
+```
+
+Will generate a checkpointed pod as:
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+  annotations:
+    checkpointer.alpha.coreos.com/checkpoint-of=kube-apiserver
+```
+
+## Implementation Notes:
+
+### Asset Locations
+
+- Inactive checkpoint manifests: /srv/kubernetes/manifests
+- Active checkpoint manifests: /etc/kubernetes/manifests
+- Checkpointed secrets: /etc/kubernetes/checkpoint-secrets
+- Config Maps: TODO
+
+### Pod Manifest Sanitization
+
+Parts of the pod manifest will be scrubbed prior to being saved as checkpoints. This is to ensure that the pod does not interfere with the parent object, and is managed in isolation.
+
+ - All labels and non-checkpoint related annotations will be removed
+ - Service account details are removed
+ - Secrets are downloaded from the apiserver and converted to hostMounts
+ - When support is added for ConfigMaps, these will also be stored locally and converted to hostMounts
+ - Pod status is cleared
+
+### Secret Storage
+
+Secrets are stored using a path of:
+
+```
+/etc/kubernets/checkpoint-secrets/<namespace>/<pod-name>/<secret-name>
+```
+

--- a/cmd/checkpoint/main_test.go
+++ b/cmd/checkpoint/main_test.go
@@ -1,0 +1,474 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+)
+
+func TestProcess(t *testing.T) {
+	type testCase struct {
+		desc                string
+		localParents        map[string]*v1.Pod
+		apiParents          map[string]*v1.Pod
+		activeCheckpoints   map[string]*v1.Pod
+		inactiveCheckpoints map[string]*v1.Pod
+		expectStart         []string
+		expectStop          []string
+		expectRemove        []string
+	}
+
+	cases := []testCase{
+		{
+			desc:                "Inactive checkpoint and no local parent: should start",
+			inactiveCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+			expectStart:         []string{"AA"},
+		},
+		{
+			desc:                "Inactive checkpoint and local parent: no change",
+			inactiveCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+			localParents:        map[string]*v1.Pod{"AA": &v1.Pod{}},
+		},
+		{
+			desc:                "Inactive checkpoint and no api parent: should remove",
+			inactiveCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+			apiParents:          map[string]*v1.Pod{"BB": &v1.Pod{}},
+			expectRemove:        []string{"AA"},
+		},
+		{
+			desc:                "Inactive checkpoint and both api & local parent: no change",
+			inactiveCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+			localParents:        map[string]*v1.Pod{"AA": &v1.Pod{}},
+			apiParents:          map[string]*v1.Pod{"AA": &v1.Pod{}},
+		},
+		{
+			desc:                "Inactive checkpoint and only api parent: should start",
+			inactiveCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+			apiParents:          map[string]*v1.Pod{"AA": &v1.Pod{}},
+			expectStart:         []string{"AA"},
+		},
+		{
+			desc:              "Active checkpoint and no local parent: no change",
+			activeCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+		},
+		{
+			desc:              "Active checkpoint and local parent: should stop",
+			activeCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+			localParents:      map[string]*v1.Pod{"AA": &v1.Pod{}},
+			expectStop:        []string{"AA"},
+		},
+		{
+			desc:              "Active checkpoint and api parent: no change",
+			activeCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+			apiParents:        map[string]*v1.Pod{"AA": &v1.Pod{}},
+		},
+		{
+			desc:              "Active checkpoint and no api parent: remove",
+			activeCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+			apiParents:        map[string]*v1.Pod{"BB": &v1.Pod{}},
+			expectRemove:      []string{"AA"},
+		},
+		{
+			desc:              "Active checkpoint with local parent, and api parent: should stop",
+			activeCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+			localParents:      map[string]*v1.Pod{"AA": &v1.Pod{}},
+			apiParents:        map[string]*v1.Pod{"AA": &v1.Pod{}},
+			expectStop:        []string{"AA"},
+		},
+		{
+			desc:              "Active checkpoint with local parent, and no api parent: should remove",
+			activeCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+			localParents:      map[string]*v1.Pod{"AA": &v1.Pod{}},
+			apiParents:        map[string]*v1.Pod{"BB": &v1.Pod{}},
+			expectRemove:      []string{"AA"},
+		},
+		{
+			desc:                "Both active and inactive checkpoints, with no api parent: remove both",
+			activeCheckpoints:   map[string]*v1.Pod{"AA": &v1.Pod{}},
+			inactiveCheckpoints: map[string]*v1.Pod{"AA": &v1.Pod{}},
+			apiParents:          map[string]*v1.Pod{"BB": &v1.Pod{}},
+			expectRemove:        []string{"AA"}, // Only need single remove, we should clean up both active/inactive
+		},
+	}
+
+	for _, tc := range cases {
+		gotStart, gotStop, gotRemove := process(tc.localParents, tc.apiParents, tc.activeCheckpoints, tc.inactiveCheckpoints)
+		if !reflect.DeepEqual(tc.expectStart, gotStart) ||
+			!reflect.DeepEqual(tc.expectStop, gotStop) ||
+			!reflect.DeepEqual(tc.expectRemove, gotRemove) {
+			t.Errorf("For test: %s\nExpected start: %s Got: %s\nExpected stop: %s Got: %s\nExpected remove: %s Got: %s\n",
+				tc.desc, tc.expectStart, gotStart, tc.expectStop, gotStop, tc.expectRemove, gotRemove)
+		}
+	}
+}
+
+func TestSanitizeCheckpointPod(t *testing.T) {
+	type testCase struct {
+		desc     string
+		pod      *v1.Pod
+		expected *v1.Pod
+	}
+
+	cases := []testCase{
+		{
+			desc: "Pod name and namespace are preserved & checkpoint annotation added",
+			pod: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "podname",
+					Namespace: "podnamespace",
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "podname",
+					Namespace:   "podnamespace",
+					Annotations: map[string]string{checkpointParentAnnotation: "podname"},
+				},
+			},
+		},
+		{
+			desc: "Existing annotations are removed, checkpoint annotation added",
+			pod: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "podname",
+					Namespace:   "podnamespace",
+					Annotations: map[string]string{"foo": "bar"},
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "podname",
+					Namespace:   "podnamespace",
+					Annotations: map[string]string{checkpointParentAnnotation: "podname"},
+				},
+			},
+		},
+		{
+			desc: "Pod status is reset",
+			pod: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "podname",
+					Namespace: "podnamespace",
+				},
+				Status: v1.PodStatus{Phase: "Pending"},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "podname",
+					Namespace:   "podnamespace",
+					Annotations: map[string]string{checkpointParentAnnotation: "podname"},
+				},
+			},
+		},
+		{
+			desc: "Service acounts are cleared",
+			pod: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "podname",
+					Namespace: "podnamespace",
+				},
+				Spec: v1.PodSpec{ServiceAccountName: "foo", DeprecatedServiceAccount: "bar"},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "podname",
+					Namespace:   "podnamespace",
+					Annotations: map[string]string{checkpointParentAnnotation: "podname"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		got, err := sanitizeCheckpointPod(tc.pod)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if !api.Semantic.DeepEqual(tc.expected, got) {
+			t.Errorf("For Test: %s\n\nExpected:\n%+v\nGot:\n%+v\n", tc.desc, tc.expected, got)
+		}
+	}
+}
+
+func TestPodListToParentPods(t *testing.T) {
+	parentAPod := v1.Pod{ObjectMeta: v1.ObjectMeta{Name: "A", Namespace: "A", Annotations: map[string]string{shouldCheckpointAnnotation: "true"}}}
+	parentBPod := v1.Pod{ObjectMeta: v1.ObjectMeta{Name: "B", Namespace: "B", Annotations: map[string]string{shouldCheckpointAnnotation: "true"}}}
+	checkpointPod := v1.Pod{ObjectMeta: v1.ObjectMeta{Name: "C", Namespace: "C", Annotations: map[string]string{checkpointParentAnnotation: "foo/bar"}}}
+	regularPod := v1.Pod{ObjectMeta: v1.ObjectMeta{Name: "D", Namespace: "D", Annotations: map[string]string{"meta": "data"}}}
+
+	type testCase struct {
+		desc     string
+		podList  *v1.PodList
+		expected map[string]*v1.Pod
+	}
+
+	cases := []testCase{
+		{
+			desc:     "Both regular pods, none are parents",
+			podList:  &v1.PodList{Items: []v1.Pod{regularPod, regularPod}},
+			expected: nil,
+		},
+		{
+			desc:     "Regular and checkpoint pods, none are parents",
+			podList:  &v1.PodList{Items: []v1.Pod{regularPod, checkpointPod}},
+			expected: nil,
+		},
+		{
+			desc:     "One parent and one regular pod: Should return only parent",
+			podList:  &v1.PodList{Items: []v1.Pod{parentAPod, regularPod}},
+			expected: map[string]*v1.Pod{"A/A": &v1.Pod{}},
+		},
+		{
+			desc:     "Two parent pods, should return both",
+			podList:  &v1.PodList{Items: []v1.Pod{parentAPod, parentBPod}},
+			expected: map[string]*v1.Pod{"A/A": &v1.Pod{}, "B/B": &v1.Pod{}},
+		},
+	}
+
+	for _, tc := range cases {
+		got := podListToParentPods(tc.podList)
+		if len(got) != len(tc.expected) {
+			t.Errorf("Expected: %d pods but got %d for test: %s", len(tc.expected), len(got), tc.desc)
+		}
+		for e := range tc.expected {
+			if _, ok := got[e]; !ok {
+				t.Errorf("Missing expected PodFullName %s", e)
+			}
+		}
+	}
+}
+
+func TestIsRunning(t *testing.T) {
+	type testCase struct {
+		desc     string
+		pod      *v1.Pod
+		expected bool
+	}
+
+	cases := []testCase{
+		{
+			desc: "Single container ready",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{ContainerStatuses: []v1.ContainerStatus{{Ready: true}}},
+			},
+			expected: true,
+		},
+		{
+			desc: "Multiple containers, all ready",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{ContainerStatuses: []v1.ContainerStatus{{Ready: true}, {Ready: true}}},
+			},
+			expected: true,
+		},
+		{
+			desc: "Single container not ready",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{ContainerStatuses: []v1.ContainerStatus{{Ready: false}}},
+			},
+			expected: false,
+		},
+		{
+			desc: "Multiple containers, some not ready",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{ContainerStatuses: []v1.ContainerStatus{{Ready: true}, {Ready: false}}},
+			},
+			expected: false,
+		},
+		{
+			desc: "Multiple containers, all not ready",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{ContainerStatuses: []v1.ContainerStatus{{Ready: false}, {Ready: false}}},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		got := isRunning(tc.pod)
+		if tc.expected != got {
+			t.Errorf("Expected: %t Got: %t for test: %s", tc.expected, got, tc.desc)
+		}
+	}
+}
+
+func podWithAnnotations(a map[string]string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "podname",
+			Namespace:   "podnamespace",
+			Annotations: a,
+		},
+	}
+}
+
+func TestIsValidParent(t *testing.T) {
+	type testCase struct {
+		desc     string
+		pod      *v1.Pod
+		expected bool
+	}
+
+	cases := []testCase{
+		{
+			desc:     "Checkpoint pod",
+			pod:      podWithAnnotations(map[string]string{checkpointParentAnnotation: "foo/bar"}),
+			expected: false,
+		},
+		{
+			desc:     "Static pod",
+			pod:      podWithAnnotations(map[string]string{podSourceAnnotation: "file"}),
+			expected: false,
+		},
+		{
+			desc:     "Normal pod",
+			pod:      podWithAnnotations(map[string]string{"foo": "bar"}),
+			expected: false,
+		},
+		{
+			desc:     "Parent pod",
+			pod:      podWithAnnotations(map[string]string{shouldCheckpointAnnotation: "true"}),
+			expected: true,
+		},
+		{
+			desc:     "No annotation / normal pod",
+			pod:      podWithAnnotations(nil),
+			expected: false,
+		},
+		{
+			desc: "Parent and static pod",
+			pod: podWithAnnotations(map[string]string{
+				shouldCheckpointAnnotation: "true",
+				podSourceAnnotation:        "file",
+			}),
+			expected: false,
+		},
+		{
+			desc: "Parent and checkpoint", // This should never happen
+			pod: podWithAnnotations(map[string]string{
+				shouldCheckpointAnnotation: "true",
+				checkpointParentAnnotation: "foo/bar",
+			}),
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		got := isValidParent(tc.pod)
+		if tc.expected != got {
+			t.Errorf("Expected: %t Got: %t For test: %s", tc.expected, got, tc.desc)
+		}
+	}
+}
+
+func TestIsCheckpoint(t *testing.T) {
+	type testCase struct {
+		desc     string
+		pod      *v1.Pod
+		expected bool
+	}
+
+	cases := []testCase{
+		{
+			desc: fmt.Sprintf("Pod is checkpoint and contains %s annotation key and value", checkpointParentAnnotation),
+			pod: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{checkpointParentAnnotation: "podnamespace/podname"},
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: fmt.Sprintf("Pod is checkpoint contains %s annotation key and no value", checkpointParentAnnotation),
+			pod: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{checkpointParentAnnotation: ""},
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: "Pod is not checkpoint & contains unrelated annotations",
+			pod: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{"foo": "bar"},
+				},
+			},
+			expected: false,
+		},
+		{
+			desc: "Pod is not checkpoint & contains no annotations",
+			pod: &v1.Pod{
+				ObjectMeta: v1.ObjectMeta{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		got := isCheckpoint(tc.pod)
+		if tc.expected != got {
+			t.Errorf("Expected: %t Got: %t for test: %s", tc.expected, got, tc.desc)
+		}
+	}
+}
+
+func TestCopyPod(t *testing.T) {
+	pod := v1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "podname",
+			Namespace: "podnamespace",
+		},
+		Spec: v1.PodSpec{Containers: []v1.Container{{VolumeMounts: []v1.VolumeMount{{Name: "default-token"}}}}},
+	}
+	got, err := copyPod(&pod)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !api.Semantic.DeepEqual(pod, *got) {
+		t.Errorf("Expected:\n%+v\nGot:\n%+v", pod, got)
+	}
+}
+
+func TestPodID(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "podname",
+			Namespace: "podnamespace",
+		},
+	}
+	expected := "podnamespace/podname"
+	got := PodFullName(pod)
+	if expected != got {
+		t.Errorf("Expected: %s Got: %s", expected, got)
+	}
+}
+
+func TestPodIDToInactiveCheckpointPath(t *testing.T) {
+	id := "foo/bar"
+	expected := inactiveCheckpointPath + "/foo-bar.json"
+	got := PodFullNameToInactiveCheckpointPath(id)
+	if expected != got {
+		t.Errorf("Expected: %s Got: %s", expected, got)
+	}
+}
+
+func TestPodIDToActiveCheckpointPath(t *testing.T) {
+	id := "foo/bar"
+	expected := activeCheckpointPath + "/foo-bar.json"
+	got := PodFullNameToActiveCheckpointPath(id)
+	if expected != got {
+		t.Errorf("Expected: %s Got: %s", expected, got)
+	}
+}
+
+func TestPodIDToSecretPath(t *testing.T) {
+	id := "foo/bar"
+	expected := checkpointSecretPath + "/foo/bar"
+	got := PodFullNameToSecretPath(id)
+	if expected != got {
+		t.Errorf("Expected %s Got %s", expected, got)
+	}
+}

--- a/image/checkpoint/checkpoint-pod.yaml
+++ b/image/checkpoint/checkpoint-pod.yaml
@@ -11,6 +11,11 @@ spec:
     image: {{ REPO }}:{{ TAG }}
     command:
     - /checkpoint
+    env:
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
     imagePullPolicy: Always
     volumeMounts:
     - mountPath: /etc/kubernetes

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -118,6 +118,8 @@ spec:
     metadata:
       labels:
         k8s-app: kube-apiserver
+      annotations:
+        checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:
       nodeSelector:
         master: "true"


### PR DESCRIPTION
Rewrite of the checkpointer to support checkpointing of arbitrary pods.

Will checkpoint pods based on annotation, then also supports garbage collection of pods and secrets by tracking the parents of the checkpoints. I've called out TODOs in the code for some minor tweaks that can be follow ups.

Big change, so hopefully can get a few eyes on this.

/cc @yifan-gu @xiang90 @ericchiang @dghubble @derekparker 