### PR TITLE
Use etcd3 for both the temporary and self-hosted control planes

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -34,7 +34,6 @@ var (
 		apiServers        string
 		altNames          string
 		selfHostKubelet   bool
-		storageBackend    string
 		cloudProvider     string
 		selfHostedEtcd    bool
 	}
@@ -46,7 +45,6 @@ func init() {
 	cmdRender.Flags().StringVar(&renderOpts.caCertificatePath, "ca-certificate-path", "", "Path to an existing PEM encoded CA. If provided, TLS assets will be generated using this certificate authority.")
 	cmdRender.Flags().StringVar(&renderOpts.caPrivateKeyPath, "ca-private-key-path", "", "Path to an existing Certificate Authority RSA private key. Required if --ca-certificate is set.")
 	cmdRender.Flags().StringVar(&renderOpts.etcdServers, "etcd-servers", "http://127.0.0.1:2379", "List of etcd servers URLs including host:port, comma separated")
-	cmdRender.Flags().StringVar(&renderOpts.storageBackend, "storage-backend", "etcd2", "storage backend for APIServer. Supports: etcd2, etcd3.")
 	cmdRender.Flags().StringVar(&renderOpts.apiServers, "api-servers", "https://127.0.0.1:443", "List of API server URLs including host:port, commma seprated")
 	cmdRender.Flags().StringVar(&renderOpts.altNames, "api-server-alt-names", "", "List of SANs to use in api-server certificate. Example: 'IP=127.0.0.1,IP=127.0.0.2,DNS=localhost'. If empty, SANs will be extracted from the --api-servers flag.")
 	cmdRender.Flags().BoolVar(&renderOpts.selfHostKubelet, "self-host-kubelet", false, "Create a self-hosted kubelet daemonset.")
@@ -120,7 +118,6 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 		APIServers:      apiServers,
 		AltNames:        altNames,
 		SelfHostKubelet: renderOpts.selfHostKubelet,
-		StorageBackend:  renderOpts.storageBackend,
 		CloudProvider:   renderOpts.cloudProvider,
 		SelfHostedEtcd:  renderOpts.selfHostedEtcd,
 	}, nil

--- a/hack/multi-node/Vagrantfile
+++ b/hack/multi-node/Vagrantfile
@@ -85,11 +85,11 @@ Vagrant.configure("2") do |config|
     (1..$etcd_count).each do |i|
       config.vm.define vm_name = "e%d" % i do |etcd|
 
-        data = YAML.load(IO.readlines(ETCD_CLOUD_CONFIG_PATH)[1..-1].join)
-        data['coreos']['etcd2']['initial-cluster'] = initial_etcd_cluster
-        data['coreos']['etcd2']['name'] = vm_name
+        data = File.read(ETCD_CLOUD_CONFIG_PATH)
+        data = data.gsub("{{ETCD_NODE_NAME}}", vm_name)
+        data = data.gsub("{{ETCD_INITIAL_CLUSTER}}", initial_etcd_cluster)
         etcd_config_file = Tempfile.new('etcd_config')
-        etcd_config_file.write("#cloud-config\n#{data.to_yaml}")
+        etcd_config_file.write(data)
         etcd_config_file.close
 
         etcd.vm.hostname = vm_name

--- a/hack/multi-node/etcd-cloud-config.yaml
+++ b/hack/multi-node/etcd-cloud-config.yaml
@@ -4,16 +4,18 @@ coreos:
   update:
     reboot-strategy: "off"
 
-  etcd2:
-    name: {{ETCD_NODE_NAME}}
-    initial-cluster: {{ETCD_INITIAL_CLUSTER}}
-    advertise-client-urls: http://$private_ipv4:2379
-    listen-client-urls: http://0.0.0.0:2379
-    initial-advertise-peer-urls: http://$private_ipv4:2380
-    listen-peer-urls: http://$private_ipv4:2380
-
   units:
 
-  - name: etcd2.service
+  - name: etcd-member.service
+    enable: true
     command: start
-
+    drop-ins:
+      - name: 40-etcd-cluster.conf
+        content: |
+          [Service]
+          Environment="ETCD_NAME={{ETCD_NODE_NAME}}"
+          Environment="ETCD_ADVERTISE_CLIENT_URLS=http://$private_ipv4:2379"
+          Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://$private_ipv4:2380"
+          Environment="ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379"
+          Environment="ETCD_LISTEN_PEER_URLS=http://$private_ipv4:2380"
+          Environment="ETCD_INITIAL_CLUSTER={{ETCD_INITIAL_CLUSTER}}"

--- a/hack/multi-node/etcd-cloud-config.yaml
+++ b/hack/multi-node/etcd-cloud-config.yaml
@@ -13,6 +13,7 @@ coreos:
       - name: 40-etcd-cluster.conf
         content: |
           [Service]
+          Environment="ETCD_IMAGE_TAG=v3.1.0"
           Environment="ETCD_NAME={{ETCD_NODE_NAME}}"
           Environment="ETCD_ADVERTISE_CLIENT_URLS=http://$private_ipv4:2379"
           Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://$private_ipv4:2380"

--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -17,9 +17,9 @@ function usage() {
 }
 
 function configure_etcd() {
-    [ -f "/etc/systemd/system/etcd2.service.d/10-etcd2.conf" ] || {
-        mkdir -p /etc/systemd/system/etcd2.service.d
-        cat << EOF > /etc/systemd/system/etcd2.service.d/10-etcd2.conf
+    [ -f "/etc/systemd/system/etcd-member.service.d/10-etcd-member.conf" ] || {
+        mkdir -p /etc/systemd/system/etcd-member.service.d
+        cat << EOF > /etc/systemd/system/etcd-member.service.d/10-etcd-member.conf
 [Service]
 Environment="ETCD_NAME=controller"
 Environment="ETCD_INITIAL_CLUSTER=controller=http://${COREOS_PRIVATE_IPV4}:2380"
@@ -36,9 +36,9 @@ function init_master_node() {
     systemctl daemon-reload
     systemctl stop update-engine; systemctl mask update-engine
 
-    # Start etcd and configure network settings
+    # Start etcd.
     configure_etcd
-    systemctl enable etcd2; sudo systemctl start etcd2
+    systemctl enable etcd-member; sudo systemctl start etcd-member
 
     # Render cluster assets
     /usr/bin/rkt run \

--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -21,6 +21,7 @@ function configure_etcd() {
         mkdir -p /etc/systemd/system/etcd-member.service.d
         cat << EOF > /etc/systemd/system/etcd-member.service.d/10-etcd-member.conf
 [Service]
+Environment="ETCD_IMAGE_TAG=v3.1.0"
 Environment="ETCD_NAME=controller"
 Environment="ETCD_INITIAL_CLUSTER=controller=http://${COREOS_PRIVATE_IPV4}:2380"
 Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://${COREOS_PRIVATE_IPV4}:2380"

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -1,6 +1,6 @@
 [Service]
 Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-Environment=KUBELET_VERSION=v1.5.1_coreos.0
+Environment=KUBELET_VERSION=v1.5.2_coreos.1
 Environment="RKT_OPTS=\
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
 --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -1,6 +1,6 @@
 [Service]
 Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-Environment=KUBELET_VERSION=v1.5.1_coreos.0
+Environment=KUBELET_VERSION=v1.5.2_coreos.1
 Environment="RKT_OPTS=\
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
 --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -4,6 +4,11 @@ coreos:
   units:
     - name: etcd-member.service
       enable: true
+      drop-ins:
+        - name: 10-version.conf
+          content: |
+            [Service]
+            Environment="ETCD_IMAGE_TAG=v3.1.0"
       command: start
     - name: kubelet.service
       enable: true

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -2,7 +2,8 @@
 
 coreos:
   units:
-    - name: etcd2.service
+    - name: etcd-member.service
+      enable: true
       command: start
     - name: kubelet.service
       enable: true

--- a/hack/tests/conformance-gce.sh
+++ b/hack/tests/conformance-gce.sh
@@ -55,7 +55,7 @@ function init {
 
 function add_master {
     gcloud compute instances create ${GCE_PREFIX}-m1 \
-        --image-project coreos-cloud --image-family ${COREOS_CHANNEL} --zone us-central1-a --machine-type n1-standard-4 --boot-disk-size=10GB
+        --image-project coreos-cloud --image-family ${COREOS_CHANNEL} --zone us-central1-a --machine-type n1-standard-4 --boot-disk-size=30GB
 
     gcloud compute instances add-tags --zone us-central1-a ${GCE_PREFIX}-m1 --tags ${GCE_PREFIX}-apiserver
     gcloud compute firewall-rules create ${GCE_PREFIX}-api-443 --target-tags=${GCE_PREFIX}-apiserver --allow tcp:443
@@ -72,7 +72,7 @@ function add_workers {
     for i in $(seq 1 ${WORKER_COUNT}); do
         echo "Launching worker"
         gcloud compute instances create ${GCE_PREFIX}-w${i} \
-            --image-project coreos-cloud --image-family ${COREOS_CHANNEL} --zone us-central1-a --machine-type n1-standard-1
+            --image-project coreos-cloud --image-family ${COREOS_CHANNEL} --zone us-central1-a --machine-type n1-standard-2 --boot-disk-size=15GB
 
         echo "Adding ssh-key to worker metadata"
         gcloud compute instances add-metadata ${GCE_PREFIX}-w${i} --zone us-central1-a --metadata-from-file ssh-keys=/root/.ssh/gce-format.pub

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -50,7 +50,6 @@ type Config struct {
 	AltNames        *tlsutil.AltNames
 	SelfHostKubelet bool
 	SelfHostedEtcd  bool
-	StorageBackend  string
 	CloudProvider   string
 }
 

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -145,7 +145,7 @@ spec:
         - --insecure-port=8080
         - --advertise-address=$(POD_IP)
         - --etcd-servers={{ range $i, $e := .EtcdServers }}{{ if $i }},{{end}}{{ $e }}{{end}}
-        - --storage-backend={{.StorageBackend}}
+        - --storage-backend=etcd3
         - --allow-privileged=true
         - --service-cluster-ip-range=10.3.0.0/24
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota

--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -93,9 +93,7 @@ func makeAPIServerFlags(config Config) []string {
 		"--service-account-key-file=" + filepath.Join(config.AssetDir, asset.AssetPathServiceAccountPubKey),
 		"--admission-control=NamespaceLifecycle,ServiceAccount",
 		"--runtime-config=api/all=true",
-	}
-	if config.SelfHostedEtcd {
-		res = append(res, "--storage-backend=etcd3")
+		"--storage-backend=etcd3",
 	}
 	return res
 }


### PR DESCRIPTION
The existing `--storage-backend=etcd3` parameter can lead to unexpected
and confusing behavior when used without the experimental self-hosted
etcd (`--experimental-self-hosted-etcd=true`) or with the examples.

When specified, Bootkube runs the temporary control plane against etcd
v2 and then the self-hosted plane using etcd v3. However, etcd uses two
separate data stores for v2 and v3 APIs (https://git.io/v1NxV).
Therefore when the transition occurs after the self-hosted control plane
has been created, everything basically disappears.

Instead of adding yet another flag to Bootkube to enable etcd3 with the
temporary control-plane, this commit makes a leap forward and use etcd3
as the default storage backend for both control-planes, which will be the 
default in Kubernetes 1.6.

**Note: This PR shouldn't be merged before CoreOS Linux Container 1214+ is promoted Stable, on Jan 3, 2017.**