### PR TITLE
Configure pod-network via flannel CNI daemonset

### DIFF
--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -1,24 +1,7 @@
 #cloud-config
 
 coreos:
-  flannel:
-    interface: $public_ipv4
-    etcd_endpoints: http://172.17.4.51:2379
   units:
-    - name: flanneld.service
-      command: start
-      drop-ins:
-      - name: 50-network-config.conf
-        content: |
-          [Service]
-          ExecStartPre=/usr/bin/etcdctl --endpoint=http://172.17.4.51:2379 set /coreos.com/network/config '{ "Network": "10.2.0.0/16" }'
-    - name: docker.service
-      drop-ins:
-      - name: 50-flannel.conf
-        content: |
-          [Unit]
-          Requires=flanneld.service
-          After=flanneld.service
     - name: kubelet.service
       enable: true
       command: start
@@ -27,12 +10,17 @@ coreos:
         EnvironmentFile=/etc/environment
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
         Environment=KUBELET_VERSION=v1.5.1_coreos.0
+        Environment="RKT_OPTS=--volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
+        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --require-kubeconfig \
+          --cni-conf-dir=/etc/kubernetes/cni/net.d \
+          --network-plugin=cni \
           --lock-file=/var/run/lock/kubelet.lock \
           --exit-on-lock-contention \
           --pod-manifest-path=/etc/kubernetes/manifests \

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -1,19 +1,20 @@
-[Unit]
-Requires=docker.service etcd2.service flanneld.service
-After=docker.service etcd2.service flanneld.service
-
 [Service]
 Environment=KUBELET_ACI=quay.io/coreos/hyperkube
 Environment=KUBELET_VERSION=v1.5.1_coreos.0
-Environment="RKT_OPTS=--volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf"
+Environment="RKT_OPTS=\
+--volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
+--volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
 EnvironmentFile=/etc/environment
-
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
+ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+ExecStartPre=/bin/mkdir -p /var/lib/cni
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://${COREOS_PRIVATE_IPV4}:443 \
   --kubeconfig=/etc/kubernetes/kubeconfig \
+  --cni-conf-dir=/etc/kubernetes/cni/net.d \
+  --network-plugin=cni \
   --lock-file=/var/run/lock/kubelet.lock \
   --exit-on-lock-contention \
   --allow-privileged \

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -1,17 +1,18 @@
-[Unit]
-Requires=docker.service flanneld.service
-After=docker.service flanneld.service
-
 [Service]
 Environment=KUBELET_ACI=quay.io/coreos/hyperkube
 Environment=KUBELET_VERSION=v1.5.1_coreos.0
-Environment="RKT_OPTS=--volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf"
+Environment="RKT_OPTS=\
+--volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
+--volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
 EnvironmentFile=/etc/environment
-
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
+ExecStartPre=/bin/mkdir -p /var/lib/cni
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://{{apiserver}}:443 \
   --kubeconfig=/etc/kubernetes/kubeconfig \
+  --cni-conf-dir=/etc/kubernetes/cni/net.d \
+  --network-plugin=cni \
   --lock-file=/var/run/lock/kubelet.lock \
   --exit-on-lock-contention \
   --allow-privileged \

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -1,25 +1,9 @@
 #cloud-config
 
 coreos:
-  flannel:
-    interface: $public_ipv4
   units:
     - name: etcd2.service
       command: start
-    - name: flanneld.service
-      command: start
-      drop-ins:
-      - name: 50-network-config.conf
-        content: |
-          [Service]
-          ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ "Network": "10.2.0.0/16" }'
-    - name: docker.service
-      drop-ins:
-      - name: 50-flannel.conf
-        content: |
-          [Unit]
-          Requires=flanneld.service
-          After=flanneld.service
     - name: kubelet.service
       enable: true
       command: start
@@ -28,19 +12,23 @@ coreos:
         EnvironmentFile=/etc/environment
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
         Environment=KUBELET_VERSION=v1.5.1_coreos.0
+        Environment="RKT_OPTS=--volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
+        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --require-kubeconfig \
+          --cni-conf-dir=/etc/kubernetes/cni/net.d \
+          --network-plugin=cni \
           --lock-file=/var/run/lock/kubelet.lock \
           --exit-on-lock-contention=true \
           --allow-privileged \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --hostname-override=${COREOS_PUBLIC_IPV4} \
           --node-labels=master=true \
-          --minimum-container-ttl-duration=3m0s \
           --cluster_dns=10.3.0.10 \
           --cluster_domain=cluster.local
 

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -25,6 +25,8 @@ const (
 	AssetPathManifests               = "manifests"
 	AssetPathKubelet                 = "manifests/kubelet.yaml"
 	AssetPathProxy                   = "manifests/kube-proxy.yaml"
+	AssetPathKubeFlannel             = "manifests/kube-flannel.yaml"
+	AssetPathKubeFlannelCfg          = "manifests/kube-flannel-cfg.yaml"
 	AssetPathAPIServerSecret         = "manifests/kube-apiserver-secret.yaml"
 	AssetPathAPIServer               = "manifests/kube-apiserver.yaml"
 	AssetPathControllerManager       = "manifests/kube-controller-manager.yaml"

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -25,6 +25,8 @@ func newStaticAssets(selfHostKubelet, selfHostedEtcd bool) Assets {
 		mustCreateAssetFromTemplate(AssetPathKubeDNSDeployment, internal.DNSDeploymentTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeDNSSvc, internal.DNSSvcTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathCheckpointer, internal.CheckpointerTemplate, noData),
+		mustCreateAssetFromTemplate(AssetPathKubeFlannel, internal.KubeFlannelTemplate, noData),
+		mustCreateAssetFromTemplate(AssetPathKubeFlannelCfg, internal.KubeFlannelCfgTemplate, noData),
 	}
 	if selfHostKubelet {
 		assets = append(assets, mustCreateAssetFromTemplate(AssetPathKubelet, internal.KubeletTemplate, noData))

--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -56,6 +56,9 @@ func NewBootkube(config Config) (*bootkube, error) {
 		"--master=" + insecureAPIAddr,
 		"--service-account-private-key-file=" + filepath.Join(config.AssetDir, asset.AssetPathServiceAccountPrivKey),
 		"--root-ca-file=" + filepath.Join(config.AssetDir, asset.AssetPathCACert),
+		"--allocate-node-cidrs=true",
+		"--cluster-cidr=10.2.0.0/16",
+		"--configure-cloud-routes=false",
 		"--leader-elect=true",
 	})
 


### PR DESCRIPTION
This change involves a switch to using the Container Network Interface (CNI) plugins for configuring the pod network. See the http://kubernetes.io/docs/admin/network-plugins/ for more information  on kubernetes + CNI plugin integration.

There is a known issue with using CNI plugins that setting a `hostPort` on a pod will no longer work. This is because the `hostPort` relies on docker to configure the host -> pod bridge, but in the case of CNI network plugins, docker does not know about the pod, network and the CNI plugin is used instead. 

See upstream issues for more information:
https://github.com/kubernetes/kubernetes/issues/23920
https://github.com/kubernetes/kubernetes/issues/31307

The most common place I've seen this being surfaced as an issue is with ingress controllers, which make use of pod hostPorts. Workarounds to this include:

- Using `hostNetwork=true` on the pod so that all containers in the pod will use the host network namespace, but then also setting the `hostPort` so that the scheduler can take this constraint into account when scheduling pods (one pod per host, as it will already be taken). The downside to this is that all containers in the pod will use the host network, not just a specific container.

- Another option is to use a [nodePort service](http://kubernetes.io/docs/user-guide/services/#type-nodeport) in front of the ingress controller so that a port will be available on all nodes running kube-proxy, which can then route to the ingress controller. The downside to this option is that the port will be in the (default) range of 30000-32000, and if you want a service exposed on `:443`, for example, the port mapping must be done externally.
