### PR TITLE
asset: set the advertise address based on pod ip

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -139,6 +139,7 @@ spec:
         - --bind-address=0.0.0.0
         - --secure-port=443
         - --insecure-port=8080
+        - --advertise-address=$(POD_IP)
         - --etcd-servers={{ range $i, $e := .EtcdServers }}{{ if $i }},{{end}}{{ $e }}{{end}}
         - --storage-backend={{.StorageBackend}}
         - --allow-privileged=true
@@ -151,6 +152,11 @@ spec:
         - --client-ca-file=/etc/kubernetes/secrets/ca.crt
         - --cloud-provider={{ .CloudProvider  }}
         - --anonymous-auth=false
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: ssl-certs-host


### PR DESCRIPTION
This flag was removed in https://github.com/kubernetes-incubator/bootkube/pull/151, but looks like we do still need this in some cases.

The bootkube-apiserver was setting the correct endpoint record for the default kubernetes service (`kubectl get endpoint/kubernetes`). However, after bootkube exits, the self-hosted api-server will eventually overwrite the endpoint again -- and it was using the host's default interface, which is not routable in some cases (e.g. virtualbox).

There may be some other options here (e.g. why does bootkube apiserver use correct interface, but hostNetwork api-server pod does not) -- but going to revert this part of the change so we avoid the regression until we have a better option.

/cc @dghubble @quentin-m @bassam 