### PR TITLE
Rename label master=true to kubernetes.io/role=master & Pin controller services

### DIFF
--- a/Documentation/upgrading.md
+++ b/Documentation/upgrading.md
@@ -10,10 +10,10 @@ Let's upgrade a self-hosted Kubernetes v1.4.1 cluster to v1.4.3 as an example.
 Show the control plane daemonsets and deployments which will need to be updated.
 
     $ kubectl get daemonsets -n=kube-system
-    NAME             DESIRED   CURRENT   NODE-SELECTOR   AGE
-    kube-apiserver   1         1         master=true     5m
-    kube-proxy       3         3         <none>          5m
-    kubelet          3         3         <none>          5m
+    NAME             DESIRED   CURRENT   NODE-SELECTOR                AGE
+    kube-apiserver   1         1         kubernetes.io/role=master    5m
+    kube-proxy       3         3         <none>                       5m
+    kubelet          3         3         <none>                       5m
 
     $ kubectl get deployments -n=kube-system
     NAME                      DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE

--- a/hack/multi-node/bootkube-up
+++ b/hack/multi-node/bootkube-up
@@ -14,7 +14,7 @@ if [ ! -d "cluster" ]; then
   cat user-data.sample > cluster/user-data && sed 's/^/      /' cluster/auth/kubeconfig >> cluster/user-data
   cp cluster/user-data{,-worker}
   cp cluster/user-data{,-controller}
-  sed -i.bak -e '/--node-labels=master=true/d' cluster/user-data-worker
+  sed -i.bak -e 's/--node-labels=kubernetes.io\/role=master/--node-labels=kubernetes.io\/role=node/' cluster/user-data-worker
 fi
 
 # Start the VM

--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -26,7 +26,7 @@ coreos:
           --pod-manifest-path=/etc/kubernetes/manifests \
           --allow-privileged \
           --hostname-override=${COREOS_PUBLIC_IPV4} \
-          --node-labels=master=true \
+          --node-labels=kubernetes.io/role=master \
           --cluster_dns=10.3.0.10 \
           --cluster_domain=cluster.local
         Restart=always

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -19,7 +19,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --exit-on-lock-contention \
   --allow-privileged \
   --hostname-override=${COREOS_PRIVATE_IPV4} \
-  --node-labels=master=true \
+  --node-labels=kubernetes.io/role=master \
   --minimum-container-ttl-duration=3m0s \
   --cluster_dns=10.3.0.10 \
   --cluster_domain=cluster.local \

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -17,6 +17,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --exit-on-lock-contention \
   --allow-privileged \
   --hostname-override=${COREOS_PRIVATE_IPV4} \
+  --node-labels=kubernetes.io/role=node \
   --minimum-container-ttl-duration=3m0s \
   --cluster_dns=10.3.0.10 \
   --cluster_domain=cluster.local \

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -28,7 +28,7 @@ coreos:
           --allow-privileged \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --hostname-override=${COREOS_PUBLIC_IPV4} \
-          --node-labels=master=true \
+          --node-labels=kubernetes.io/role=master \
           --cluster_dns=10.3.0.10 \
           --cluster_domain=cluster.local
 

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -128,7 +128,7 @@ spec:
         checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:
       nodeSelector:
-        master: "true"
+        kubernetes.io/role: "master"
       hostNetwork: true
       containers:
       - name: kube-apiserver
@@ -180,7 +180,7 @@ spec:
         k8s-app: pod-checkpoint-installer
     spec:
       nodeSelector:
-        master: "true"
+        kubernetes.io/role: "master"
       hostNetwork: true
       containers:
       - name: checkpoint-installer

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -209,6 +209,8 @@ spec:
       labels:
         k8s-app: kube-controller-manager
     spec:
+      nodeSelector:
+        kubernetes.io/role: "master"
       containers:
       - name: kube-controller-manager
         image: quay.io/coreos/hyperkube:v1.5.1_coreos.0
@@ -253,6 +255,8 @@ spec:
       labels:
         k8s-app: kube-scheduler
     spec:
+      nodeSelector:
+        kubernetes.io/role: "master"
       containers:
       - name: kube-scheduler
         image: quay.io/coreos/hyperkube:v1.5.1_coreos.0
@@ -335,6 +339,8 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
+      nodeSelector:
+        kubernetes.io/role: "master"
       containers:
       - name: kubedns
         image: gcr.io/google_containers/kubedns-amd64:1.9


### PR DESCRIPTION
```
=== all: Rename label master=true to kubernetes.io/role=master  …
This commit reconciles with the upstream Kubernetes' preferences
regarding to role labeling (https://git.io/vMckM). This also enables
users to find the nodes' role using `kubectl describe`
(https://git.io/vMckb).

Additionally, label the minions with the `node` role in the
multi-node example.
```

```
=== pkg/asset: Pin Controller-Manager, Scheduler and KubeDNS to master nodes  …
Because master nodes are considered first-class citizens and more stable
than worker nodes, it is safer to schedule these services onto them.
This is also a step forward to actually making master nodes controller
nodes.
```

Fixes #246.