### PR TITLE
pkg/asset/internal: Introduce a Flock around the API server

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -134,6 +134,10 @@ spec:
       - name: kube-apiserver
         image: quay.io/coreos/hyperkube:v1.5.1_coreos.0
         command:
+        - /usr/bin/flock
+        - --exclusive
+        - --timeout=30
+        - /var/lock/api-server.lock
         - /hyperkube
         - apiserver
         - --bind-address=0.0.0.0
@@ -164,6 +168,9 @@ spec:
         - mountPath: /etc/kubernetes/secrets
           name: secrets
           readOnly: true
+        - mountPath: /var/lock
+          name: var-lock
+          readOnly: false
       volumes:
       - name: ssl-certs-host
         hostPath:
@@ -171,6 +178,9 @@ spec:
       - name: secrets
         secret:
           secretName: kube-apiserver
+      - name: var-lock
+        hostPath:
+          path: /var/lock
 `)
 	CheckpointerTemplate = []byte(`apiVersion: "extensions/v1beta1"
 kind: DaemonSet


### PR DESCRIPTION
This commit represents a workaround for #262. By maintaining
a file lock while the API server is running (either temporary
or self-hosted), we prevent the self-hosted API server from
starting and trying to bind ports, until the temporary one is
stopped. Therefore, we avoid the loop where the self-hosted
API server would crash as soon as it is brought up due to the
ports already being bound by the stopping temporary server.

cc @aaronlevy