### PR TITLE
hack/multi-node: Add option to launch with self-hosted etcd

### DIFF
--- a/hack/multi-node/Vagrantfile
+++ b/hack/multi-node/Vagrantfile
@@ -13,15 +13,12 @@ $controller_count = 1
 $controller_vm_memory = 2048
 $worker_count = 1
 $worker_vm_memory = 1024
-$etcd_count = 1
-$etcd_vm_memory = 512
 
 if $worker_vm_memory < 1024
   puts "Workers should have at least 1024 MB of memory"
 end
 
 CONTROLLER_CLUSTER_IP="10.3.0.1"
-ETCD_CLOUD_CONFIG_PATH = File.expand_path("./etcd-cloud-config.yaml")
 CONTROLLER_USER_DATA_PATH = File.expand_path("./cluster/user-data-controller")
 WORKER_USER_DATA_PATH = File.expand_path("./cluster/user-data-worker")
 
@@ -37,8 +34,14 @@ def workerIP(num)
   return "172.17.4.#{num+200}"
 end
 
-etcdIPs = [*1..$etcd_count].map{ |i| etcdIP(i) }
-initial_etcd_cluster = etcdIPs.map.with_index{ |ip, i| "e#{i+1}=http://#{ip}:2380" }.join(",")
+$self_host_etcd = true if ENV['SELF_HOST_ETCD'] == "true"
+if !$self_host_etcd
+    $etcd_count = 1
+    $etcd_vm_memory = 512
+    ETCD_CLOUD_CONFIG_PATH = File.expand_path("./etcd-cloud-config.yaml")
+    etcdIPs = [*1..$etcd_count].map{ |i| etcdIP(i) }
+    initial_etcd_cluster = etcdIPs.map.with_index{ |ip, i| "e#{i+1}=http://#{ip}:2380" }.join(",")
+end
 
 Vagrant.configure("2") do |config|
   # always use Vagrant's insecure key
@@ -78,32 +81,34 @@ Vagrant.configure("2") do |config|
     vb.gui = false
   end
 
-  (1..$etcd_count).each do |i|
-    config.vm.define vm_name = "e%d" % i do |etcd|
+  if !$self_host_etcd
+    (1..$etcd_count).each do |i|
+      config.vm.define vm_name = "e%d" % i do |etcd|
 
-      data = YAML.load(IO.readlines(ETCD_CLOUD_CONFIG_PATH)[1..-1].join)
-      data['coreos']['etcd2']['initial-cluster'] = initial_etcd_cluster
-      data['coreos']['etcd2']['name'] = vm_name
-      etcd_config_file = Tempfile.new('etcd_config')
-      etcd_config_file.write("#cloud-config\n#{data.to_yaml}")
-      etcd_config_file.close
+        data = YAML.load(IO.readlines(ETCD_CLOUD_CONFIG_PATH)[1..-1].join)
+        data['coreos']['etcd2']['initial-cluster'] = initial_etcd_cluster
+        data['coreos']['etcd2']['name'] = vm_name
+        etcd_config_file = Tempfile.new('etcd_config')
+        etcd_config_file.write("#cloud-config\n#{data.to_yaml}")
+        etcd_config_file.close
 
-      etcd.vm.hostname = vm_name
+        etcd.vm.hostname = vm_name
 
-      ["vmware_fusion", "vmware_workstation"].each do |vmware|
-        etcd.vm.provider vmware do |v|
-          v.vmx['memsize'] = $etcd_vm_memory
+        ["vmware_fusion", "vmware_workstation"].each do |vmware|
+          etcd.vm.provider vmware do |v|
+            v.vmx['memsize'] = $etcd_vm_memory
+          end
         end
+
+        etcd.vm.provider :virtualbox do |vb|
+          vb.memory = $etcd_vm_memory
+        end
+
+        etcd.vm.network :private_network, ip: etcdIP(i)
+
+        etcd.vm.provision :file, source: etcd_config_file.path, destination: "/tmp/vagrantfile-user-data"
+        etcd.vm.provision :shell, inline: "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", privileged: true
       end
-
-      etcd.vm.provider :virtualbox do |vb|
-        vb.memory = $etcd_vm_memory
-      end
-
-      etcd.vm.network :private_network, ip: etcdIP(i)
-
-      etcd.vm.provision :file, source: etcd_config_file.path, destination: "/tmp/vagrantfile-user-data"
-      etcd.vm.provision :shell, inline: "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", privileged: true
     end
   end
 

--- a/hack/multi-node/bootkube-up
+++ b/hack/multi-node/bootkube-up
@@ -7,9 +7,18 @@ if [ ${un} == 'Darwin' ]; then
     local_os="darwin"
 fi
 
+SELF_HOST_ETCD=${SELF_HOST_ETCD:-false}
+if [ ${SELF_HOST_ETCD} = "true" ]; then
+    etcd_render_flags="--etcd-servers=http://10.3.0.15:2379 --storage-backend=etcd3 --experimental-self-hosted-etcd"
+    etcd_start_flags="--etcd-server=http://172.17.4.101:12379,http://10.3.0.15:2379 --experimental-self-hosted-etcd"
+else
+    etcd_render_flags="--etcd-servers=http://172.17.4.51:2379"
+    etcd_start_flags="--etcd-server=http://172.17.4.51:2379"
+fi
+
 # Render assets
 if [ ! -d "cluster" ]; then
-  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.101:443 --etcd-servers=http://172.17.4.51:2379
+  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.101:443 ${etcd_render_flags}
   # Add rendered kubeconfig to the node user-data
   cat user-data.sample > cluster/user-data && sed 's/^/      /' cluster/auth/kubeconfig >> cluster/user-data
   cp cluster/user-data{,-worker}
@@ -26,7 +35,7 @@ scp -q -F ssh_config -r cluster core@c1:/home/core/cluster
 scp -q -F ssh_config ../../_output/bin/linux/bootkube core@c1:/home/core
 
 # Run bootkube
-ssh -q -F ssh_config core@c1 "sudo /home/core/bootkube start --asset-dir=/home/core/cluster --etcd-server=http://172.17.4.51:2379 2>> /home/core/bootkube.log"
+ssh -q -F ssh_config core@c1 "sudo /home/core/bootkube start --asset-dir=/home/core/cluster ${etcd_start_flags} 2>> /home/core/bootkube.log"
 
 echo
 echo "Bootstrap complete. Access your kubernetes cluster using:"


### PR DESCRIPTION
This is against yet to be merged code (https://github.com/kubernetes-incubator/bootkube/pull/259)

This is to help test that PR more easily.

Usage is:

```
cd hack/multi-node
rm -rf cluster
vagrant destroy -f
SELF_HOST_ETCD=true ./bootkube-up
```