### PR TITLE
hack/quickstart: Bump Kubelet to 1.5.2

### DIFF
--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -1,6 +1,6 @@
 [Service]
 Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-Environment=KUBELET_VERSION=v1.5.1_coreos.0
+Environment=KUBELET_VERSION=v1.5.2_coreos.1
 Environment="RKT_OPTS=\
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
 --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -1,6 +1,6 @@
 [Service]
 Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-Environment=KUBELET_VERSION=v1.5.1_coreos.0
+Environment=KUBELET_VERSION=v1.5.2_coreos.1
 Environment="RKT_OPTS=\
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
 --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"


### PR DESCRIPTION
Otherwise the conformance tests are still running Kubelet 1.5.1.