### PR TITLE
Add etcd-operator to requiredPods when selfHostedEtcd is true

### DIFF
--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -110,6 +110,9 @@ func (b *bootkube) Run() error {
 			errch <- err
 		}
 	}()
+	if b.selfHostedEtcd {
+		requiredPods = append(requiredPods, "etcd-operator")
+	}
 	go func() { errch <- WaitUntilPodsRunning(requiredPods, assetTimeout, b.selfHostedEtcd) }()
 
 	// If any of the bootkube services exit, it means it is unrecoverable and we should exit.


### PR DESCRIPTION
In some environments, pulling image from `gcr.io` is faster than `quay.io`. We might call `etcdutil.Migrate()` too early even before `etcd-operator` got started.

In this case, the user will have `fail to wait etcd TPR to be ready: timed out waiting for the condition` error and the bootstrap process got terminated.

This PR add `etcd-operator` to `requiredPods` when `selfHostedEtcd` is true. We'll make sure `etcd-operator` is running before calling `etcdutil.Migrate()`.  Making the bootstrap process less likely to fail.