### PR TITLE
templates: ensure critical components dont coexist

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -270,6 +270,26 @@ spec:
     metadata:
       labels:
         k8s-app: kube-controller-manager
+      annotations:
+        scheduler.alpha.kubernetes.io/affinity: |
+          {
+            "podAntiAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "weight": 100,
+                  "labelSelector": {
+                    "matchExpressions": [
+                      {
+                        "key": "k8s-app",
+                        "operator": "In",
+                        "values": ["kube-controller-manager"]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
     spec:
       nodeSelector:
         master: "true"
@@ -329,6 +349,26 @@ spec:
     metadata:
       labels:
         k8s-app: kube-scheduler
+      annotations:
+        scheduler.alpha.kubernetes.io/affinity: |
+          {
+            "podAntiAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "weight": 100,
+                  "labelSelector": {
+                    "matchExpressions": [
+                      {
+                        "key": "k8s-app",
+                        "operator": "In",
+                        "values": ["kube-scheduler"]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
     spec:
       nodeSelector:
         master: "true"


### PR DESCRIPTION
This commit adds antiaffinity rules to the controller manager and the
sheduler to ensure that these deployments' pods do not all end up on the
same master node, especially now that they are pinned with node
selectors. To make this possible on small clusters, e.g. those with 1
master node, this is specified with "preferred" rather than "required".