### PR TITLE
pkg/bootkube: increase timeout for asset creation

### DIFF
--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	assetTimeout    = 10 * time.Minute
+	assetTimeout    = 20 * time.Minute
 	insecureAPIAddr = "http://127.0.0.1:8080"
 )
 


### PR DESCRIPTION
I was consistently hitting this timeout during development - bump it to give a little more wiggle room. We could be a little more intelligent about this in the future.