### PR TITLE
Detect pod and service CIDR from manifests

### DIFF
--- a/pkg/bootkube/parse.go
+++ b/pkg/bootkube/parse.go
@@ -1,0 +1,87 @@
+package bootkube
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"path/filepath"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/kubernetes-incubator/bootkube/pkg/asset"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+)
+
+const (
+	apiServerContainerName         = "kube-apiserver"
+	controllerManagerContainerName = "kube-controller-manager"
+)
+
+// detectServiceCIDR deserializes the '--service-cluster-ip-range' from the
+// kube-apiserver manifest
+func detectServiceCIDR(config Config) (string, error) {
+	b, err := ioutil.ReadFile(filepath.Join(config.AssetDir, asset.AssetPathAPIServer))
+	if err != nil {
+		return "", fmt.Errorf("can't read file %s: %v", asset.AssetPathAPIServer, err)
+	}
+	var apiServer v1beta1.DaemonSet
+	err = yaml.Unmarshal(b, &apiServer)
+	if err != nil {
+		return "", fmt.Errorf("cant unmarshal %s: %v", asset.AssetPathAPIServer, err)
+	}
+
+	containers := map[string]v1.Container{}
+	for _, container := range apiServer.Spec.Template.Spec.Containers {
+		containers[container.Name] = container
+	}
+
+	if container, exists := containers[apiServerContainerName]; exists {
+		cidr := findFlag("--service-cluster-ip-range", container.Command)
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return "", fmt.Errorf("invalid --cluster-cidr CIDR: %v", err)
+		}
+		return cidr, nil
+	}
+	return "", fmt.Errorf("can't detect --service-cluster-ip-range in %s", asset.AssetPathAPIServer)
+}
+
+// detectPodCIDR deserializes the '--cluster-cidr' from the
+// kube-controller-manager manifest.
+func detectPodCIDR(config Config) (string, error) {
+	b, err := ioutil.ReadFile(filepath.Join(config.AssetDir, asset.AssetPathControllerManager))
+	if err != nil {
+		return "", fmt.Errorf("can't read file %s: %v", asset.AssetPathControllerManager, err)
+	}
+	var manager v1beta1.Deployment
+	err = yaml.Unmarshal(b, &manager)
+	if err != nil {
+		return "", fmt.Errorf("can't unmarshal %s: %v", asset.AssetPathControllerManager, err)
+	}
+
+	containers := map[string]v1.Container{}
+	for _, container := range manager.Spec.Template.Spec.Containers {
+		containers[container.Name] = container
+	}
+
+	if container, exists := containers[controllerManagerContainerName]; exists {
+		cidr := findFlag("--cluster-cidr", container.Command)
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return "", fmt.Errorf("invalid --cluster-cidr CIDR: %v", err)
+		}
+		return cidr, nil
+	}
+	return "", fmt.Errorf("can't detect --cluster-cidr flag in %s", asset.AssetPathControllerManager)
+}
+
+func findFlag(flagName string, args []string) string {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, flagName+"=") {
+			return strings.TrimPrefix(arg, flagName+"=")
+		}
+		if strings.HasPrefix(arg, flagName+" ") {
+			return strings.TrimSpace(strings.TrimPrefix(arg, flagName+" "))
+		}
+	}
+	return ""
+}

--- a/pkg/bootkube/parse_test.go
+++ b/pkg/bootkube/parse_test.go
@@ -1,0 +1,37 @@
+package bootkube
+
+import (
+	"testing"
+)
+
+const (
+	defaultServiceCIDR = "10.3.0.0/24"
+	defaultPodCIDR     = "10.2.0.0/24"
+)
+
+func TestFindFlag(t *testing.T) {
+	flags := []string{
+		"--key1=value",
+		"--key2 val",
+		"--service-cluster-ip-range=10.3.0.0/24",
+		"--cluster-cidr=10.2.0.0/24",
+		"--foobar baz",
+	}
+	cases := []struct {
+		flag     string
+		expected string
+	}{
+		{"--service-cluster-ip-range", defaultServiceCIDR},
+		{"--cluster-cidr", defaultPodCIDR},
+		{"--key1", "value"},
+		{"--key2", "val"},
+		{"--missing-flag", ""},
+		{"--foo", ""},
+		{"--foobar", "baz"},
+	}
+	for _, c := range cases {
+		if v := findFlag(c.flag, flags); v != c.expected {
+			t.Errorf("exected %s, got %s", c.expected, v)
+		}
+	}
+}


### PR DESCRIPTION
* Temporary apiserver should use service CIDR detected from `kube-apiserver.yaml`
* Temporary controller-manager should use pod CIDR detected from `kube-controller-manager.yaml`
* Eliminates the need for coordination btw render and start and unblocks pod/service CIDR customization

Full discussion about why we're taking this approach over others: https://github.com/kubernetes-incubator/bootkube/issues/236#issuecomment-279797787

related. #236

#### Examples of edge cases

Missing assets:

```
$ bootkube start --asset-dir=empty
Error: can't read file manifests/kube-apiserver.yaml: open empty/manifests/kube-apiserver.yaml: no such file or directory
can't read file manifests/kube-apiserver.yaml: open empty/manifests/kube-apiserver.yaml: no such file or directory
```

kube-apiserver.yaml (or controller manager) named container not found.

```
Error: can't detect --service-cluster-ip-range in manifests/kube-apiserver.yaml
can't detect --service-cluster-ip-range in manifests/kube-apiserver.yaml
```

kube-apiserver.yaml (or controller manager) uses an invalid CIDR.

```
bootkube start --asset-dir=assets
Error: invalid --cluster-cidr CIDR: invalid CIDR address: pickles
invalid --cluster-cidr CIDR: invalid CIDR address: pickles
```

kube-apiserver.yaml (or controller manager) is missing the required flag entirely.

```
Error: invalid --cluster-cidr CIDR: invalid CIDR address: 
invalid --cluster-cidr CIDR: invalid CIDR address: 
```

kube-apiserver.yaml (or controller manager) isn't valid YAML

```
Error: cant unmarshal manifests/kube-apiserver.yaml: error converting YAML to JSON: yaml: line 1: did not find expected <document start>
cant unmarshal manifests/kube-apiserver.yaml: error converting YAML to JSON: yaml: line 1: did not find expected <document start>
```
