### PR TITLE
hack/tests: update conformance scripts for tls-bootstraping

### DIFF
--- a/hack/tests/conformance-gce.sh
+++ b/hack/tests/conformance-gce.sh
@@ -81,7 +81,7 @@ function add_workers {
         sleep 30 # TODO(aaron) Have seen "Too many authentication failures" in CI jobs. This seems to help, but should dig into why
         echo "Getting worker public IP"
         local WORKER_IP=$(gcloud compute instances list ${GCE_PREFIX}-w${i} --format=json | jq --raw-output '.[].networkInterfaces[].accessConfigs[].natIP')
-        cd /build/bootkube/hack/quickstart && SSH_OPTS="-o StrictHostKeyChecking=no" ./init-worker.sh ${WORKER_IP} /build/cluster/auth/kubeconfig
+        cd /build/bootkube/hack/quickstart && SSH_OPTS="-o StrictHostKeyChecking=no" CLUSTER_DIR=/build/cluster ./init-worker.sh ${WORKER_IP} 
     done
 }
 
@@ -92,7 +92,7 @@ if [ "${IN_CONTAINER}" == true ]; then
     init
     add_master
     add_workers
-    KUBECONFIG=/etc/kubernetes/kubeconfig WORKER_COUNT=${WORKER_COUNT} /build/bootkube/hack/tests/conformance-test.sh ${MASTER_IP} 22 /root/.ssh/id_rsa
+    KUBECONFIG=/etc/kubernetes/admin-kubeconfig WORKER_COUNT=${WORKER_COUNT} /build/bootkube/hack/tests/conformance-test.sh ${MASTER_IP} 22 /root/.ssh/id_rsa
 else
     BUILD_ROOT=${BUILD_ROOT:-}
     if [ -z "$BUILD_ROOT" ]; then

--- a/hack/tests/conformance-test.sh
+++ b/hack/tests/conformance-test.sh
@@ -20,7 +20,7 @@ ssh_host=$1
 ssh_port=$2
 ssh_key=$3
 
-KUBECONFIG=${KUBECONFIG:-/home/core/cluster/auth/kubeconfig}
+KUBECONFIG=${KUBECONFIG:-/home/core/cluster/auth/admin-kubeconfig}
 K8S_SRC=/home/core/go/src/k8s.io/kubernetes
 ssh -q -o stricthostkeychecking=no -i ${ssh_key} -p ${ssh_port} core@${ssh_host} \
     "mkdir -p ${K8S_SRC} && [[ -d ${K8S_SRC}/.git ]] || git clone https://${CONFORMANCE_REPO} ${K8S_SRC}"


### PR DESCRIPTION
Forgot to update this when merging the tls bootstraping feature. 

cc @Quentin-M 