### PR TITLE
Revert "self hosted etcd: bump version"

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -587,7 +587,7 @@ spec:
     spec:
       containers:
       - name: etcd-operator
-        image: quay.io/coreos/etcd-operator:v0.2.0
+        image: quay.io/coreos/etcd-operator:c391d8b7638deb81aa877773a0acce389f602415
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:

--- a/pkg/util/etcdutil/migrate.go
+++ b/pkg/util/etcdutil/migrate.go
@@ -126,7 +126,7 @@ func createMigratedEtcdCluster(restclient restclient.Interface, host, podIP stri
   },
   "spec": {
     "size": 1,
-    "version": "v3.1.0",
+    "version": "v3.1.0-alpha.1",
     "selfHosted": {
 		"bootMemberClientEndpoint": "http://%s:12379"
     }

--- a/pkg/util/etcdutil/start_etcd.go
+++ b/pkg/util/etcdutil/start_etcd.go
@@ -62,7 +62,7 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: status.podIP
-    image: quay.io/coreos/etcd:v3.1.0
+    image: quay.io/coreos/etcd:v3.1.0-alpha.1
     name: etcd
   hostNetwork: true
   restartPolicy: Never


### PR DESCRIPTION
Reverts kubernetes-incubator/bootkube#306

We have the problem of incompatible client-go versions.
We need to keep using the old version of image until we figure out the solution.