### PR TITLE
pkg/asset: Add a kubelet CSR auto-approver

### DIFF
--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -7,6 +7,10 @@ CLUSTER_DIR=${CLUSTER_DIR:-cluster}
 IDENT=${IDENT:-${HOME}/.ssh/id_rsa}
 SSH_OPTS=${SSH_OPTS:-}
 
+# WARNING: This deployment should not be used in production clusters as it will
+# automatically approve every kubelet CSRs without making any kind of validation
+CSR_AUTOAPPROVE=${CSR_AUTOAPPROVE:-false}
+
 BOOTKUBE_REPO=${BOOTKUBE_REPO:-quay.io/coreos/bootkube}
 BOOTKUBE_VERSION=${BOOTKUBE_VERSION:-v0.3.8}
 
@@ -64,6 +68,11 @@ function init_master_node() {
         --mount volume=home,target=/core \
         --net=host ${BOOTKUBE_REPO}:${BOOTKUBE_VERSION} --exec \
         /bootkube -- start --asset-dir=/core/assets
+
+    # Add auto-approver asset.
+    if [[ "${CSR_AUTOAPPROVE}" == "true" ]]; then
+        curl -H "Content-Type: application/yaml" -XPOST -d"$(cat /home/core/assets/extra/kubelet-approver.yaml)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments"
+    fi
 }
 
 [ "$#" == 1 ] || usage

--- a/hack/tests/conformance-gce.sh
+++ b/hack/tests/conformance-gce.sh
@@ -63,7 +63,7 @@ function add_master {
     gcloud compute instances add-metadata ${GCE_PREFIX}-m1 --zone us-central1-a --metadata-from-file ssh-keys=/root/.ssh/gce-format.pub
 
     MASTER_IP=$(gcloud compute instances list ${GCE_PREFIX}-m1 --format=json | jq --raw-output '.[].networkInterfaces[].accessConfigs[].natIP')
-    cd /build/bootkube/hack/quickstart && SSH_OPTS="-o StrictHostKeyChecking=no" \
+    cd /build/bootkube/hack/quickstart && SSH_OPTS="-o StrictHostKeyChecking=no" CSR_AUTOAPPROVE="true" \
         CLUSTER_DIR=/build/cluster BOOTKUBE_REPO=${BOOTKUBE_REPO} BOOTKUBE_VERSION=${BOOTKUBE_VERSION} ./init-master.sh ${MASTER_IP}
 }
 

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -43,6 +43,7 @@ const (
 	AssetPathCheckpointer                = "manifests/pod-checkpoint-installer.yaml"
 	AssetPathEtcdOperator                = "manifests/etcd-operator.yaml"
 	AssetPathEtcdSvc                     = "manifests/etcd-service.yaml"
+	AssetPathExtraKubeletApprover        = "extra/kubelet-approver.yaml"
 )
 
 // AssetConfig holds all configuration needed when generating

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -156,6 +156,36 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 `)
 
+	KubeletApproverTemplate = []byte(`
+# WARNING: This deployment should not be used in production clusters as it will
+# automatically approve every kubelet CSRs without making any kind of validation
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kubelet-approver
+  namespace: kube-system
+  labels:
+    k8s-app: kubelet-approver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: kubelet-approver
+      labels:
+        k8s-app: kubelet-approver
+    spec:
+      containers:
+      - name: kubelet-approver
+        image: quay.io/coreos/kapprover:v0.0.1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 50Mi
+`)
+
 	APIServerTemplate = []byte(`apiVersion: "extensions/v1beta1"
 kind: DaemonSet
 metadata:

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -30,6 +30,7 @@ func newStaticAssets(selfHostKubelet, selfHostedEtcd bool) Assets {
 		mustCreateAssetFromTemplate(AssetPathKubeFlannel, internal.KubeFlannelTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeFlannelCfg, internal.KubeFlannelCfgTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeletBootstrapRoleBinding, internal.KubeletBootstrapRoleBindingTemplate, noData),
+		mustCreateAssetFromTemplate(AssetPathExtraKubeletApprover, internal.KubeletApproverTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeSystemSARoleBinding, internal.KubeSystemSARoleBindingTemplate, noData),
 	}
 	if selfHostKubelet {


### PR DESCRIPTION
It appears that bootkube (and its auto-approver) might die before the
workers are approved during the conformance tests. This adds a simple
auto-approver deployment to cope with this situation.

The policy is to always approve any pending CSRs submitted by kubelets.
There is currently no time limit nor nodes limits. Might be added later once 
we figure out what we want.

Users who want to have their own approval policies can overwrite
the asset after the render step.

Ref https://github.com/kubernetes-incubator/bootkube/pull/309