### PR TITLE
pkg,cmd: Add Kubernetes pod and service CIDR customziation

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -17,10 +17,10 @@ import (
 )
 
 const (
-	apiOffset           = 1
-	dnsOffset           = 10
-	etcdOffset          = 15
-	defaultDNSServiceIP = "10.3.0.10"
+	apiOffset            = 1
+	dnsOffset            = 10
+	etcdOffset           = 15
+	defaultServiceBaseIP = "10.3.0.0"
 )
 
 var (
@@ -152,7 +152,8 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 		return nil, err
 	}
 
-	if dnsServiceIP.String() != defaultDNSServiceIP {
+	// TODO: Find better option than asking users to make manual changes
+	if serviceNet.IP.String() != defaultServiceBaseIP {
 		fmt.Printf("You have selected a non-default service CIDR %s - be sure your kubelet service file uses --cluster-dns=%s\n", serviceNet.String(), dnsServiceIP.String())
 	}
 

--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -16,6 +16,13 @@ import (
 	"github.com/kubernetes-incubator/bootkube/pkg/tlsutil"
 )
 
+const (
+	apiOffset           = 1
+	dnsOffset           = 10
+	etcdOffset          = 15
+	defaultDNSServiceIP = "10.3.0.10"
+)
+
 var (
 	cmdRender = &cobra.Command{
 		Use:          "render",
@@ -33,6 +40,8 @@ var (
 		etcdServers       string
 		apiServers        string
 		altNames          string
+		podCIDR           string
+		serviceCIDR       string
 		selfHostKubelet   bool
 		cloudProvider     string
 		selfHostedEtcd    bool
@@ -47,6 +56,8 @@ func init() {
 	cmdRender.Flags().StringVar(&renderOpts.etcdServers, "etcd-servers", "http://127.0.0.1:2379", "List of etcd servers URLs including host:port, comma separated")
 	cmdRender.Flags().StringVar(&renderOpts.apiServers, "api-servers", "https://127.0.0.1:443", "List of API server URLs including host:port, commma seprated")
 	cmdRender.Flags().StringVar(&renderOpts.altNames, "api-server-alt-names", "", "List of SANs to use in api-server certificate. Example: 'IP=127.0.0.1,IP=127.0.0.2,DNS=localhost'. If empty, SANs will be extracted from the --api-servers flag.")
+	cmdRender.Flags().StringVar(&renderOpts.podCIDR, "pod-cidr", "10.2.0.0/16", "The CIDR range of cluster pods.")
+	cmdRender.Flags().StringVar(&renderOpts.serviceCIDR, "service-cidr", "10.3.0.0/24", "The CIDR range of cluster services.")
 	cmdRender.Flags().BoolVar(&renderOpts.selfHostKubelet, "self-host-kubelet", false, "Create a self-hosted kubelet daemonset.")
 	cmdRender.Flags().StringVar(&renderOpts.cloudProvider, "cloud-provider", "", "The provider for cloud services.  Empty string for no provider")
 	cmdRender.Flags().BoolVar(&renderOpts.selfHostedEtcd, "experimental-self-hosted-etcd", false, "Create self-hosted etcd assets.")
@@ -111,12 +122,51 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 			return nil, err
 		}
 	}
+
+	_, podNet, err := net.ParseCIDR(renderOpts.podCIDR)
+	if err != nil {
+		return nil, err
+	}
+
+	_, serviceNet, err := net.ParseCIDR(renderOpts.serviceCIDR)
+	if err != nil {
+		return nil, err
+	}
+
+	if podNet.Contains(serviceNet.IP) || serviceNet.Contains(podNet.IP) {
+		return nil, fmt.Errorf("Pod CIDR %s and service CIDR %s must not overlap", podNet.String(), serviceNet.String())
+	}
+
+	apiServiceIP, err := offsetServiceIP(serviceNet, apiOffset)
+	if err != nil {
+		return nil, err
+	}
+
+	dnsServiceIP, err := offsetServiceIP(serviceNet, dnsOffset)
+	if err != nil {
+		return nil, err
+	}
+
+	etcdServiceIP, err := offsetServiceIP(serviceNet, etcdOffset)
+	if err != nil {
+		return nil, err
+	}
+
+	if dnsServiceIP.String() != defaultDNSServiceIP {
+		fmt.Printf("You have selected a non-default service CIDR %s - be sure your kubelet service file uses --cluster-dns=%s\n", serviceNet.String(), dnsServiceIP.String())
+	}
+
 	return &asset.Config{
 		EtcdServers:     etcdServers,
 		CACert:          caCert,
 		CAPrivKey:       caPrivKey,
 		APIServers:      apiServers,
 		AltNames:        altNames,
+		PodCIDR:         podNet,
+		ServiceCIDR:     serviceNet,
+		APIServiceIP:    apiServiceIP,
+		DNSServiceIP:    dnsServiceIP,
+		ETCDServiceIP:   etcdServiceIP,
 		SelfHostKubelet: renderOpts.selfHostKubelet,
 		CloudProvider:   renderOpts.cloudProvider,
 		SelfHostedEtcd:  renderOpts.selfHostedEtcd,
@@ -194,4 +244,27 @@ func altNamesFromURLs(urls []*url.URL) *tlsutil.AltNames {
 		}
 	}
 	return &an
+}
+
+// offsetServiceIP returns an IP offset by up to 255.
+// TODO: do numeric conversion to generalize this utility.
+func offsetServiceIP(ipnet *net.IPNet, offset int) (net.IP, error) {
+	ip := make(net.IP, len(ipnet.IP))
+	copy(ip, ipnet.IP)
+	for i := 0; i < offset; i++ {
+		incIPv4(ip)
+	}
+	if ipnet.Contains(ip) {
+		return ip, nil
+	}
+	return net.IP([]byte("")), fmt.Errorf("Service IP %v is not in %s", ip, ipnet)
+}
+
+func incIPv4(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
 }

--- a/cmd/bootkube/render_test.go
+++ b/cmd/bootkube/render_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+func TestOffsetIP(t *testing.T) {
+	cases := []struct {
+		input    string
+		offset   int
+		expected string
+	}{
+		{"10.3.0.0/24", 1, "10.3.0.1"},
+		{"10.3.0.0/24", 10, "10.3.0.10"},
+		{"10.3.0.0/24", 15, "10.3.0.15"},
+		{"10.3.0.0/16", 1, "10.3.0.1"},
+		{"10.3.0.0/16", 10, "10.3.0.10"},
+		{"10.3.0.0/16", 15, "10.3.0.15"},
+		{"10.33.1.200/16", 1, "10.33.0.1"},
+		{"10.33.1.200/16", 10, "10.33.0.10"},
+		{"10.33.1.200/16", 15, "10.33.0.15"},
+		{"192.168.1.0/24", 15, "192.168.1.15"},
+	}
+
+	for _, c := range cases {
+		_, cidr, err := net.ParseCIDR(c.input)
+		if err != nil {
+			t.Errorf("unexpected CIDR parse error: %v", err)
+		}
+		ip, err := offsetServiceIP(cidr, c.offset)
+		if ip.String() != c.expected {
+			t.Errorf("expected %s, got %s", c.expected, ip.String())
+		}
+	}
+}

--- a/hack/multi-node/Vagrantfile
+++ b/hack/multi-node/Vagrantfile
@@ -18,7 +18,6 @@ if $worker_vm_memory < 1024
   puts "Workers should have at least 1024 MB of memory"
 end
 
-CONTROLLER_CLUSTER_IP="10.3.0.1"
 CONTROLLER_USER_DATA_PATH = File.expand_path("./cluster/user-data-controller")
 WORKER_USER_DATA_PATH = File.expand_path("./cluster/user-data-worker")
 

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -45,7 +45,7 @@ spec:
         - --pod-manifest-path=/etc/kubernetes/manifests
         - --allow-privileged
         - --hostname-override=$(NODE_NAME)
-        - --cluster-dns=10.3.0.10
+        - --cluster-dns={{ .DNSServiceIP }}
         - --cluster-domain=cluster.local
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --require-kubeconfig
@@ -147,7 +147,7 @@ spec:
         - --etcd-servers={{ range $i, $e := .EtcdServers }}{{ if $i }},{{end}}{{ $e }}{{end}}
         - --storage-backend=etcd3
         - --allow-privileged=true
-        - --service-cluster-ip-range=10.3.0.0/24
+        - --service-cluster-ip-range={{ .ServiceCIDR }}
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota
         - --runtime-config=api/all=true
         - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
@@ -235,7 +235,7 @@ spec:
         - controller-manager
         - --allocate-node-cidrs=true
         - --configure-cloud-routes=false
-        - --cluster-cidr=10.2.0.0/16
+        - --cluster-cidr={{ .PodCIDR }}
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
         - --leader-elect=true
@@ -326,7 +326,7 @@ spec:
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --proxy-mode=iptables
         - --hostname-override=$(NODE_NAME)
-        - --cluster-cidr=10.2.0.0/16
+        - --cluster-cidr={{ .PodCIDR }}
         env:
           - name: NODE_NAME
             valueFrom:
@@ -513,7 +513,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: 10.3.0.10
+  clusterIP: {{ .DNSServiceIP }}
   ports:
   - name: dns
     port: 53
@@ -556,7 +556,7 @@ spec:
   selector:
     app: etcd
     etcd_cluster: kube-etcd
-  clusterIP: 10.3.0.15
+  clusterIP: {{ .ETCDServiceIP }}
   ports:
   - name: client
     port: 2379
@@ -582,7 +582,7 @@ data:
     }
   net-conf.json: |
     {
-      "Network": "10.2.0.0/16",
+      "Network": "{{ .PodCIDR }}",
       "Backend": {
         "Type": "vxlan"
       }

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -17,37 +17,37 @@ const (
 	secretCMName        = "kube-controller-manager"
 )
 
-func newStaticAssets(selfHostKubelet, selfHostedEtcd bool) Assets {
+func newStaticAssets() Assets {
 	var noData interface{}
 	assets := Assets{
 		mustCreateAssetFromTemplate(AssetPathScheduler, internal.SchedulerTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathSchedulerDisruption, internal.SchedulerDisruptionTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathControllerManagerDisruption, internal.ControllerManagerDisruptionTemplate, noData),
-		mustCreateAssetFromTemplate(AssetPathProxy, internal.ProxyTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeDNSDeployment, internal.DNSDeploymentTemplate, noData),
-		mustCreateAssetFromTemplate(AssetPathKubeDNSSvc, internal.DNSSvcTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathCheckpointer, internal.CheckpointerTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeFlannel, internal.KubeFlannelTemplate, noData),
-		mustCreateAssetFromTemplate(AssetPathKubeFlannelCfg, internal.KubeFlannelCfgTemplate, noData),
 	}
-	if selfHostKubelet {
-		assets = append(assets, mustCreateAssetFromTemplate(AssetPathKubelet, internal.KubeletTemplate, noData))
-	}
-	if selfHostedEtcd {
-		assets = append(assets,
-			mustCreateAssetFromTemplate(AssetPathEtcdOperator, internal.EtcdOperatorTemplate, noData),
-			mustCreateAssetFromTemplate(AssetPathEtcdSvc, internal.EtcdSvcTemplate, noData),
-		)
-	}
-
 	return assets
 }
 
 func newDynamicAssets(conf Config) Assets {
-	return Assets{
+	assets := Assets{
 		mustCreateAssetFromTemplate(AssetPathControllerManager, internal.ControllerManagerTemplate, conf),
 		mustCreateAssetFromTemplate(AssetPathAPIServer, internal.APIServerTemplate, conf),
+		mustCreateAssetFromTemplate(AssetPathProxy, internal.ProxyTemplate, conf),
+		mustCreateAssetFromTemplate(AssetPathKubeFlannelCfg, internal.KubeFlannelCfgTemplate, conf),
+		mustCreateAssetFromTemplate(AssetPathKubeDNSSvc, internal.DNSSvcTemplate, conf),
 	}
+	if conf.SelfHostKubelet {
+		assets = append(assets, mustCreateAssetFromTemplate(AssetPathKubelet, internal.KubeletTemplate, conf))
+	}
+	if conf.SelfHostedEtcd {
+		assets = append(assets,
+			mustCreateAssetFromTemplate(AssetPathEtcdOperator, internal.EtcdOperatorTemplate, conf),
+			mustCreateAssetFromTemplate(AssetPathEtcdSvc, internal.EtcdSvcTemplate, conf),
+		)
+	}
+	return assets
 }
 
 func newKubeConfigAsset(assets Assets, conf Config) (Asset, error) {

--- a/pkg/asset/tls.go
+++ b/pkg/asset/tls.go
@@ -3,7 +3,6 @@ package asset
 import (
 	"crypto/rsa"
 	"crypto/x509"
-	"net"
 
 	"github.com/kubernetes-incubator/bootkube/pkg/tlsutil"
 )
@@ -78,7 +77,6 @@ func newAPIKeyAndCert(caCert *x509.Certificate, caPrivKey *rsa.PrivateKey, altNa
 	if err != nil {
 		return nil, nil, err
 	}
-	altNames.IPs = append(altNames.IPs, net.ParseIP("10.3.0.1"))
 	altNames.DNSNames = append(altNames.DNSNames, []string{
 		"kubernetes",
 		"kubernetes.default",

--- a/pkg/bootkube/parse.go
+++ b/pkg/bootkube/parse.go
@@ -74,6 +74,20 @@ func detectPodCIDR(config Config) (string, error) {
 	return "", fmt.Errorf("can't detect --cluster-cidr flag in %s", asset.AssetPathControllerManager)
 }
 
+// detectEtcdIP deserializes the etcd-service ClusterIP.
+func detectEtcdIP(assetDir string) (string, error) {
+	b, err := ioutil.ReadFile(filepath.Join(assetDir, asset.AssetPathEtcdSvc))
+	if err != nil {
+		return "", fmt.Errorf("can't read file %s: %v", asset.AssetPathEtcdSvc, err)
+	}
+	var service v1.Service
+	err = yaml.Unmarshal(b, &service)
+	if err != nil {
+		return "", fmt.Errorf("can't unmarshal %s: %v", asset.AssetPathEtcdSvc, err)
+	}
+	return service.Spec.ClusterIP, nil
+}
+
 func findFlag(flagName string, args []string) string {
 	for _, arg := range args {
 		if strings.HasPrefix(arg, flagName+"=") {

--- a/pkg/bootkube/status.go
+++ b/pkg/bootkube/status.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/kubernetes-incubator/bootkube/pkg/util/etcdutil"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/cache"
@@ -25,7 +24,7 @@ const (
 	doesNotExist = "DoesNotExist"
 )
 
-func WaitUntilPodsRunning(pods []string, timeout time.Duration, selfHostedEtcd bool) error {
+func WaitUntilPodsRunning(pods []string, timeout time.Duration) error {
 	sc, err := NewStatusController(pods)
 	if err != nil {
 		return err
@@ -34,12 +33,6 @@ func WaitUntilPodsRunning(pods []string, timeout time.Duration, selfHostedEtcd b
 
 	if err := wait.Poll(5*time.Second, timeout, sc.AllRunning); err != nil {
 		return fmt.Errorf("error while checking pod status: %v", err)
-	}
-
-	if selfHostedEtcd {
-		if err := etcdutil.Migrate(); err != nil {
-			return err
-		}
 	}
 
 	UserOutput("All self-hosted control plane components successfully started\n")

--- a/pkg/util/etcdutil/migrate.go
+++ b/pkg/util/etcdutil/migrate.go
@@ -20,9 +20,7 @@ import (
 )
 
 const (
-	apiserverAddr = "http://127.0.0.1:8080"
-	etcdServiceIP = "10.3.0.15"
-
+	apiserverAddr   = "http://127.0.0.1:8080"
 	etcdClusterName = "kube-etcd"
 )
 
@@ -31,7 +29,7 @@ var (
 	waitBootEtcdRemovedTime    = 300 * time.Second
 )
 
-func Migrate() error {
+func Migrate(etcdServiceIP string) error {
 	kubecli, err := clientset.NewForConfig(&restclient.Config{
 		Host: apiserverAddr,
 	})
@@ -62,7 +60,7 @@ func Migrate() error {
 	}
 	glog.Info("etcd cluster for migration is now running")
 
-	if err := waitBootEtcdRemoved(); err != nil {
+	if err := waitBootEtcdRemoved(etcdServiceIP); err != nil {
 		return fmt.Errorf("wait boot etcd deleted failed: %v", err)
 	}
 	glog.Info("the boot etcd is removed from the migration cluster")
@@ -169,7 +167,7 @@ func waitEtcdClusterRunning(restclient restclient.Interface) error {
 	return err
 }
 
-func waitBootEtcdRemoved() error {
+func waitBootEtcdRemoved(etcdServiceIP string) error {
 	err := wait.Poll(10*time.Second, waitBootEtcdRemovedTime, func() (bool, error) {
 		cfg := clientv3.Config{
 			Endpoints:   []string{fmt.Sprintf("http://%s:2379", etcdServiceIP)},


### PR DESCRIPTION
u* Add cmd flags --pod-cidr and --service-cidr
* Pick an appropriate apiserver service IP, DNS Service IP, and etcd Service IP (experimental) from the service range

Fixes/unblocks/replaces #236 #245 #250

#### Examples

Default (same behavior).

```
bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com
Writing asset: assets/manifests/kube-scheduler.yaml
...
```

Customize the pod or service CIDR range.

```
bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --pod-cidr 10.2.1.1/16 --service-cidr 10.33.1.200/16
You have selected a non-default service CIDR 10.33.0.0/16 - be sure your kubelet service file uses --cluster-dns=10.33.0.10
Writing asset: assets/manifests/kube-scheduler.yaml
...
```

Conflicting CIDRs

```
$ bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --pod-cidr 10.0.2.0/24 --service-cidr=10.0.0.0/16
Error: Pod CIDR 10.0.2.0/24 and service CIDR 10.0.0.0/16 must not overlap
Pod CIDR 10.0.2.0/24 and service CIDR 10.0.0.0/16 must not overlap

$ bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --service-cidr=10.2.0.0/16
Error: Pod CIDR 10.2.0.0/16 and service CIDR 10.2.0.0/16 must not overlap
Pod CIDR 10.2.0.0/16 and service CIDR 10.2.0.0/16 must not overlap
...
```

An (apiserver service, dns service, or etcd service) IP can't be picked from the service range

```
bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --pod-cidr 10.2.1.1/16 --service-cidr 10.33.1.200/30
Error: Service IP 10.33.1.210 is not in 10.33.1.200/30
Service IP 10.33.1.210 is not in 10.33.1.200/30
``` 


