### PR TITLE
pkg/assets/tls: Update organization name

### DIFF
--- a/pkg/asset/tls.go
+++ b/pkg/asset/tls.go
@@ -73,7 +73,7 @@ func newCACert() (*rsa.PrivateKey, *x509.Certificate, error) {
 
 	config := tlsutil.CertConfig{
 		CommonName:   "kube-ca",
-		Organization: []string{"kube-aws"},
+		Organization: []string{"bootkube"},
 	}
 
 	cert, err := tlsutil.NewSelfSignedCACertificate(config, key)


### PR DESCRIPTION
nit: Organization kube-aws is from the kube-aws era. The old name can cause user confusion.