### PR TITLE
pkg: re-enable RBAC

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -41,6 +41,7 @@ const (
 	AssetPathCheckpointer                = "manifests/pod-checkpoint-installer.yaml"
 	AssetPathEtcdOperator                = "manifests/etcd-operator.yaml"
 	AssetPathEtcdSvc                     = "manifests/etcd-service.yaml"
+	AssetPathKubeSystemSARoleBinding     = "manifests/kube-system-rbac-role-binding.yaml"
 )
 
 // AssetConfig holds all configuration needed when generating

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -20,6 +20,21 @@ contexts:
     user: kubelet
 `)
 
+	KubeSystemSARoleBindingTemplate = []byte(`apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: system:default-sa
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+`)
+
 	KubeletTemplate = []byte(`apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -154,6 +169,7 @@ spec:
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --client-ca-file=/etc/kubernetes/secrets/ca.crt
+        - --authorization-mode=RBAC
         - --cloud-provider={{ .CloudProvider  }}
         - --anonymous-auth=false
         env:

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -26,6 +26,7 @@ func newStaticAssets() Assets {
 		mustCreateAssetFromTemplate(AssetPathKubeDNSDeployment, internal.DNSDeploymentTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathCheckpointer, internal.CheckpointerTemplate, noData),
 		mustCreateAssetFromTemplate(AssetPathKubeFlannel, internal.KubeFlannelTemplate, noData),
+		mustCreateAssetFromTemplate(AssetPathKubeSystemSARoleBinding, internal.KubeSystemSARoleBindingTemplate, noData),
 	}
 	return assets
 }

--- a/pkg/asset/tls.go
+++ b/pkg/asset/tls.go
@@ -97,13 +97,20 @@ func newAPIKeyAndCert(caCert *x509.Certificate, caPrivKey *rsa.PrivateKey, altNa
 }
 
 func newKubeletKeyAndCert(caCert *x509.Certificate, caPrivKey *rsa.PrivateKey) (*rsa.PrivateKey, *x509.Certificate, error) {
+	// TLS organizations map to Kubernetes groups, and "system:masters"
+	// is a well-known Kubernetes group that gives a user admin power.
+	//
+	// For now, put the kubelets in this group. Later we can restrict
+	// their credentials, likely with the help of TLS bootstrapping.
+	const orgSystemMasters = "system:masters"
+
 	key, err := tlsutil.NewPrivateKey()
 	if err != nil {
 		return nil, nil, err
 	}
 	config := tlsutil.CertConfig{
 		CommonName:   "kubelet",
-		Organization: []string{"kube-node"},
+		Organization: []string{orgSystemMasters},
 	}
 	cert, err := tlsutil.NewSignedCertificate(config, key, caCert, caPrivKey)
 	if err != nil {

--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -93,6 +93,7 @@ func makeAPIServerFlags(config Config) ([]string, error) {
 		"--tls-private-key-file=" + filepath.Join(config.AssetDir, asset.AssetPathAPIServerKey),
 		"--tls-cert-file=" + filepath.Join(config.AssetDir, asset.AssetPathAPIServerCert),
 		"--client-ca-file=" + filepath.Join(config.AssetDir, asset.AssetPathCACert),
+		"--authorization-mode=RBAC",
 		"--etcd-servers=" + config.EtcdServer.String(),
 		"--service-cluster-ip-range=" + serviceCIDR,
 		"--service-account-key-file=" + filepath.Join(config.AssetDir, asset.AssetPathServiceAccountPubKey),

--- a/pkg/tlsutil/tlsutil.go
+++ b/pkg/tlsutil/tlsutil.go
@@ -111,7 +111,7 @@ func NewSignedCertificate(cfg CertConfig, key *rsa.PrivateKey, caCert *x509.Cert
 	certTmpl := x509.Certificate{
 		Subject: pkix.Name{
 			CommonName:   cfg.CommonName,
-			Organization: caCert.Subject.Organization,
+			Organization: cfg.Organization,
 		},
 		DNSNames:     cfg.AltNames.DNSNames,
 		IPAddresses:  cfg.AltNames.IPs,


### PR DESCRIPTION
RBAC changes pulled out of #261.

~~Still seeing errors bringing up the API server. Don't know what it's about~~

edit: didn't give my VMs enough disk :/

```
Feb 23 01:06:01 node1.example.com kubelet-wrapper[1178]: E0223 01:06:01.408544    1178 pod_workers.go:184] Error syncing pod c61279d9-f963-11e6-b0d5-525400a19cae, skipping: failed to "StartContainer" for "kube-apiserver" with CrashLoopBackOff: "Back-off 20s restarting failed container=kube-apiserver pod=kube-apiserver-0wr35_kube-system(c61279d9-f963-11e6-b0d5-525400a19cae)"
Feb 23 01:06:01 node1.example.com kubelet-wrapper[1178]: E0223 01:06:01.739433    1178 secret.go:197] Couldn't get secret kube-system/kube-apiserver
```