### PR TITLE
use a client cert for API server to kubelet communication

### DIFF
--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -22,6 +22,8 @@ coreos:
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --require-kubeconfig \
+          --client-ca-file=/etc/kubernetes/ca.crt \
+          --anonymous-auth=false \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --network-plugin=cni \
           --lock-file=/var/run/lock/kubelet.lock \

--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -52,6 +52,7 @@ function init_master_node() {
     chown -R core:core /home/core/assets
     mkdir -p /etc/kubernetes
     cp /home/core/assets/auth/kubeconfig /etc/kubernetes/
+    cp /home/core/assets/tls/ca.crt /etc/kubernetes/ca.crt
 
     # Start the kubelet
     systemctl enable kubelet; sudo systemctl start kubelet

--- a/hack/quickstart/init-worker.sh
+++ b/hack/quickstart/init-worker.sh
@@ -34,6 +34,9 @@ function init_worker_node() {
     # Setup kubeconfig
     mkdir -p /etc/kubernetes
     cp ${KUBECONFIG} /etc/kubernetes/kubeconfig
+    # Pulled out of the kubeconfig in extract_master_endpoint. Other installations should
+    # place the root CA here manually.
+    cp /home/core/ca.crt /etc/kubernetes/ca.crt
 
     sed "s/{{apiserver}}/${MASTER_PRIV}/" /home/core/kubelet.worker > /etc/systemd/system/kubelet.service
     rm /home/core/kubelet.worker

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -15,6 +15,8 @@ ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://${COREOS_PRIVATE_IPV4}:443 \
   --kubeconfig=/etc/kubernetes/kubeconfig \
+  --client-ca-file=/etc/kubernetes/ca.crt \
+  --anonymous-auth=false \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
   --network-plugin=cni \
   --lock-file=/var/run/lock/kubelet.lock \

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -13,6 +13,8 @@ ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://{{apiserver}}:443 \
   --kubeconfig=/etc/kubernetes/kubeconfig \
+  --client-ca-file=/etc/kubernetes/ca.crt \
+  --anonymous-auth=false \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
   --network-plugin=cni \
   --lock-file=/var/run/lock/kubelet.lock \

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -30,6 +30,8 @@ coreos:
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --require-kubeconfig \
+          --client-ca-file=/etc/kubernetes/ca.crt \
+          --anonymous-auth=false \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --network-plugin=cni \
           --lock-file=/var/run/lock/kubelet.lock \

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -167,6 +167,8 @@ spec:
         - --runtime-config=api/all=true
         - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
+        - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
+        - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --client-ca-file=/etc/kubernetes/secrets/ca.crt
         - --authorization-mode=RBAC
@@ -216,7 +218,7 @@ spec:
       hostNetwork: true
       containers:
       - name: checkpoint-installer
-        image: quay.io/coreos/pod-checkpointer:5b585a2d731173713fa6871c436f6c53fa17f754
+        image: quay.io/coreos/pod-checkpointer:417b8f7552ccf3db192ba1e5472e524848f0eb5f
         command:
         - /checkpoint-installer.sh
         volumeMounts:

--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -92,6 +92,8 @@ func makeAPIServerFlags(config Config) ([]string, error) {
 		"--allow-privileged=true",
 		"--tls-private-key-file=" + filepath.Join(config.AssetDir, asset.AssetPathAPIServerKey),
 		"--tls-cert-file=" + filepath.Join(config.AssetDir, asset.AssetPathAPIServerCert),
+		"--kubelet-client-key=" + filepath.Join(config.AssetDir, asset.AssetPathAPIServerKey),
+		"--kubelet-client-certificate=" + filepath.Join(config.AssetDir, asset.AssetPathAPIServerCert),
 		"--client-ca-file=" + filepath.Join(config.AssetDir, asset.AssetPathCACert),
 		"--authorization-mode=RBAC",
 		"--etcd-servers=" + config.EtcdServer.String(),


### PR DESCRIPTION
This PR turns on kubelet authentication[0], restricting access to the kubelet API running on port 10250. API servers deployed by bootkube now use a client cert to issue requests to this API (used for exec, logs, and port-forward functionality).

Because kubelets don't have a way to bootstrap a serving certificate with the correct SANs in many deployments (e.g. an autoscaling group), we'll continue to omit the API server CA check on the kubelet. We hope to remedy this later with TLS bootstrapping[1] once the kubelet can request a serving cert.

On the kubelet side, deployments should enable the following flags on the kubelet:

```bash
--client-ca-file=/etc/kubernetes/ca.crt # Placed in assets/tls/ca.crt by 'bootkube render'
--anonymous-auth=false
```

If these flags aren't enabled, the kubelet will continue to allow any request.

Since the checkpointer uses the kubelet API to get the current list of running pods, this PR does not turn on kubelet authorization because authorization requires an available API server. 

[0] https://kubernetes.io/docs/admin/kubelet-authentication-authorization/
[1] https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/

TODO:

- [x] Add flags to API server and kubelet.
- [ ] Update CI to use new kubelet flags.
- [x] Update checkpointer to use kubelet client certs to talk to the kubelet API. (#348)
- [x] Do a checkpointer release and update this PR to use it.
- [x] Add docs about on host requirements.

cc @aaronlevy @pbx0 