### PR TITLE
Update gce quickstart to use CLUSTER_PREFIX always

### DIFF
--- a/hack/quickstart/quickstart-gce.md
+++ b/hack/quickstart/quickstart-gce.md
@@ -27,7 +27,7 @@ $ gcloud compute firewall-rules create ${CLUSTER_PREFIX}-443 --target-tags=${CLU
 
 ### Bootstrap Master
 
-*Replace* `<node-ip>` with the EXTERNAL_IP from output of `gcloud compute instances list k8s-core1`.
+*Replace* `<node-ip>` with the EXTERNAL_IP from output of `gcloud compute instances list ${CLUSTER_PREFIX}-core1`.
 
 ```
 $ IDENT=~/.ssh/google_compute_engine ./init-master.sh <node-ip>


### PR DESCRIPTION
One of the example commands was using a hard-coded filter instead of `CLUSTER_PREFIX`