### PR TITLE
support self-hosted etcd in quickstart scripts

### DIFF
--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -13,8 +13,8 @@ ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
 ExecStartPre=/bin/mkdir -p /var/lib/cni
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=https://${COREOS_PRIVATE_IPV4}:443 \
   --kubeconfig=/etc/kubernetes/kubeconfig \
+  --require-kubeconfig \
   --client-ca-file=/etc/kubernetes/ca.crt \
   --anonymous-auth=false \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -11,8 +11,8 @@ ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
 ExecStartPre=/bin/mkdir -p /var/lib/cni
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=https://{{apiserver}}:443 \
   --kubeconfig=/etc/kubernetes/kubeconfig \
+  --require-kubeconfig \
   --client-ca-file=/etc/kubernetes/ca.crt \
   --anonymous-auth=false \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \

--- a/hack/tests/conformance-gce.sh
+++ b/hack/tests/conformance-gce.sh
@@ -31,8 +31,11 @@ BOOTKUBE_REPO=${BOOTKUBE_REPO:-}
 BOOTKUBE_VERSION=${BOOTKUBE_VERSION:-}
 COREOS_CHANNEL=${COREOS_CHANNEL:-'coreos-stable'}
 WORKER_COUNT=4
-GCE_PREFIX=${GCE_PREFIX:-'bootkube-ci'}
 SELF_HOST_ETCD=${SELF_HOST_ETCD:-false}
+
+GCE_PREFIX=${GCE_PREFIX:-'bootkube-ci'}
+GCE_SERVICE_ACCOUNT=${GCE_SERVICE_ACCOUNT:-'bootkube-ci'}
+GCE_PROJECT=${GCE_PROJECT:-coreos-gce-testing}
 
 function cleanup {
     gcloud compute instances delete --quiet --zone us-central1-a ${GCE_PREFIX}-m1 || true
@@ -46,8 +49,8 @@ function cleanup {
 function init {
     curl https://sdk.cloud.google.com | bash
     source ~/.bashrc
-    gcloud config set project coreos-gce-testing
-    gcloud auth activate-service-account ${GCE_PREFIX}@coreos-gce-testing.iam.gserviceaccount.com --key-file=/build/keyfile
+    gcloud config set project ${GCE_PROJECT}
+    gcloud auth activate-service-account ${GCE_SERVICE_ACCOUNT}@${GCE_PROJECT}.iam.gserviceaccount.com --key-file=/build/keyfile
     apt-get update && apt-get install -y jq
 
     ssh-keygen -t rsa -f /root/.ssh/id_rsa -N ""
@@ -113,7 +116,7 @@ else
     )
 
     #TODO(pb): See if there is a way to make the --inherit-env option replace
-    #passing all the variables manually.  
+    #passing all the variables manually. 
     sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.7.4 --exec /bin/bash -- -c \
-        "IN_CONTAINER=true BOOTKUBE_REPO=${BOOTKUBE_REPO} BOOTKUBE_VERSION=${BOOTKUBE_VERSION} COREOS_CHANNEL=${COREOS_CHANNEL} GCE_PREFIX=${GCE_PREFIX} SELF_HOST_ETCD=${SELF_HOST_ETCD} /build/bootkube/hack/tests/$(basename $0)"
+        "IN_CONTAINER=true BOOTKUBE_REPO=${BOOTKUBE_REPO} BOOTKUBE_VERSION=${BOOTKUBE_VERSION} COREOS_CHANNEL=${COREOS_CHANNEL} GCE_PREFIX=${GCE_PREFIX} GCE_SERVICE_ACCOUNT=${GCE_SERVICE_ACCOUNT} GCE_PROJECT=${GCE_PROJECT} SELF_HOST_ETCD=${SELF_HOST_ETCD} /build/bootkube/hack/tests/$(basename $0)"
 fi


### PR DESCRIPTION
Add support for self-hosted etcd within master-init script. Simplify service files and init-worker script a bit which makes them easier to configure and re-use by other tools. 

cc @aaronlevy 