### PR TITLE
Replace deprecated env vars passed to the kubelet-wrapper

### DIFF
--- a/Documentation/upgrading.md
+++ b/Documentation/upgrading.md
@@ -156,12 +156,12 @@ Now, all self-hosted Kubernetes components have been upgraded to a new version o
 
 The on-host kubelet is started by systemd, and is used to launch, and be replaced by, the self-hosted kubelet. While the on-host kubelet is short-lived, it should be kept up to date with the self hosted components.
 
-On each host running a kubelet, modify the kubelet systemd unit to reference a new `KUBELET_VERSION` (an example snippet is below)
+On each host running a kubelet, modify the kubelet systemd unit to reference a new `KUBELET_IMAGE_TAG` (an example snippet is below)
 
 `/etc/systemd/system/kubelet.service`
 
     [Service]
-    Environment=KUBELET_VERSION=v1.4.3_coreos.0
+    Environment=KUBELET_IMAGE_TAG=v1.4.3_coreos.0
 
 Reload systemd daemon and restart the kubelet unit:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,7 +8,7 @@
 ### Update hyperkube image
 
 - Update hyperkube image version in templates: `pkg/asset/internal/templates.go`
-- Update on-host kubelet versions (`KUBELET_VERSION`)
+- Update on-host kubelet versions (`KUBELET_IMAGE_TAG`)
     - hack/multi-node/user-data.sample
     - hack/single-node/user-data.sample
 
@@ -59,7 +59,7 @@ PUSH_IMAGE=true ./build/build-image.sh
 
 Note: the quickstart guides use the release images, so we should not update them until after building/pushing new release.
 
-Update on-host kubelet version (`KUBELET_VERSION`)
+Update on-host kubelet version (`KUBELET_IMAGE_TAG`)
 
  - hack/quickstart/kubelet.master
  - hack/quickstart/kubelet.worker

--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -8,9 +8,9 @@ coreos:
       content: |
         [Service]
         EnvironmentFile=/etc/environment
-        Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.5.3_coreos.0
-        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+        Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
+        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --mount volume=var-lib-cni,target=/var/lib/cni"
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -1,7 +1,7 @@
 [Service]
-Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-Environment=KUBELET_VERSION=v1.5.3_coreos.0
-Environment="RKT_OPTS=\
+Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
+Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/run/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
 --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -1,7 +1,7 @@
 [Service]
-Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-Environment=KUBELET_VERSION=v1.5.3_coreos.0
-Environment="RKT_OPTS=\
+Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
+Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/run/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
 --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -16,9 +16,9 @@ coreos:
       content: |
         [Service]
         EnvironmentFile=/etc/environment
-        Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.5.3_coreos.0
-        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+        Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
+        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --mount volume=var-lib-cni,target=/var/lib/cni"
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests


### PR DESCRIPTION
This fixes #207. 

The following environment variables used by kubelet-wrapper have been
deprecated:

* `KUBELET_VERSION` has been replaced with `KUBELET_IMAGE_TAG`
* `KUBELET_ACI` has replaced with `KUBELET_IMAGE_URL`
* `RKT_OPTS` has been replaces with `RKT_RUN_ARGS`

See https://github.com/coreos/coreos-overlay/blob/build-1220/app-admin/kubelet-wrapper/files/kubelet-wrapper#L29-L39.