### PR TITLE
SelfHostedEtcd: Add kenc as DS in master nodes

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -41,6 +41,7 @@ const (
 	AssetPathCheckpointer                = "manifests/pod-checkpoint-installer.yaml"
 	AssetPathEtcdOperator                = "manifests/etcd-operator.yaml"
 	AssetPathEtcdSvc                     = "manifests/etcd-service.yaml"
+	AssetPathKenc                        = "manifests/kenc.yaml"
 	AssetPathKubeSystemSARoleBinding     = "manifests/kube-system-rbac-role-binding.yaml"
 )
 

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -46,6 +46,7 @@ func newDynamicAssets(conf Config) Assets {
 		assets = append(assets,
 			mustCreateAssetFromTemplate(AssetPathEtcdOperator, internal.EtcdOperatorTemplate, conf),
 			mustCreateAssetFromTemplate(AssetPathEtcdSvc, internal.EtcdSvcTemplate, conf),
+			mustCreateAssetFromTemplate(AssetPathKenc, internal.KencTemplate, conf),
 		)
 	}
 	return assets


### PR DESCRIPTION
`kenc` is an iptables checkpoint tool.
With it, service IP connectivity on master nodes can endure reboot.