### PR TITLE
SelfHostedEtcd: update etcd-operator and kenc

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -220,7 +220,7 @@ spec:
         master: "true"
       hostNetwork: true
       containers:
-      - image: quay.io/coreos/kenc:82343328b867a762ffca07c2877f0079a99c8f1a
+      - image: quay.io/coreos/kenc:48b6feceeee56c657ea9263f47b6ea091e8d3035
         name: kenc
         securityContext:
           privileged: true
@@ -601,7 +601,7 @@ spec:
     spec:
       containers:
       - name: etcd-operator
-        image: quay.io/coreos/etcd-operator:v0.2.1
+        image: quay.io/coreos/etcd-operator:v0.2.3
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
kenc updates:
- atomically write iptables checkpoint file

etcd-operator updates:
- fix self hosted etcd reboot issues (relies on etcd pod not failing and endpoint not deleted)
- fix an issue that for-looping showing `etcd health probing failed for xxx: context deadline exceeded`

fix https://github.com/kubernetes-incubator/bootkube/issues/373

This would help us enable CI destruction test suite and pass them.

Note that this is not the ideal solution. We will need to do more testing as talked in https://github.com/kubernetes-incubator/bootkube/issues/379 . 