### PR TITLE
hack/quickstart: remove deprecated flag

### DIFF
--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -27,7 +27,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --minimum-container-ttl-duration=3m0s \
   --cluster_dns=10.3.0.10 \
   --cluster_domain=cluster.local \
-  --config=/etc/kubernetes/manifests
+  --pod-manifest-path=/etc/kubernetes/manifests
 
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
 Restart=always

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -24,7 +24,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --minimum-container-ttl-duration=3m0s \
   --cluster_dns=10.3.0.10 \
   --cluster_domain=cluster.local \
-  --config=/etc/kubernetes/manifests
+  --pod-manifest-path=/etc/kubernetes/manifests
 
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
 Restart=always


### PR DESCRIPTION
This was already done in the other setup methods, but never done for quickstart. v1.6.0 will hard fail if this flag isn't updated so might as well do it now.