### PR TITLE
Use `podAntiAffinity` to schedule control plane pods to different nodes.

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -282,9 +282,29 @@ metadata:
   labels:
     k8s-app: kube-controller-manager
 spec:
-  replicas: 2
+  replicas: 1
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/affinity: |
+          {
+            "podAntiAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "labelSelector": {
+                    "matchExpressions": [
+                      {
+                        "key": "k8s-app",
+                        "operator": "In",
+                        "values": ["kube-controller-manager"]
+                      }
+                    ]
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }
+              ]
+            }
+          }
       labels:
         k8s-app: kube-controller-manager
     spec:
@@ -338,9 +358,29 @@ metadata:
   labels:
     k8s-app: kube-scheduler
 spec:
-  replicas: 2
+  replicas: 1
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/affinity: |
+          {
+            "podAntiAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "labelSelector": {
+                    "matchExpressions": [
+                      {
+                        "key": "k8s-app",
+                        "operator": "In",
+                        "values": ["kube-scheduler"]
+                      }
+                    ]
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }
+              ]
+            }
+          }
       labels:
         k8s-app: kube-scheduler
     spec:


### PR DESCRIPTION
Without `podAntiAffinity`, the scheduler might schedule `kube-scheduler` and `kube-controller-manager` to the same node. When this node is down, we might lose all `kube-scheduler` or `kube-controller-manager` at once. The cluster will have problem recover from this failure.

With this patch, the scheduler will schedule control plane pods into different nodes making the cluster more reliable.