### PR TITLE
backports to release 0.3 branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ conformance-%: clean all
 # This will naively try and create a vendor dir from a k8s release
 # USE: make vendor VENDOR_VERSION=vX.Y.Z
 VENDOR_VERSION = v1.5.4+coreos.0
-ETCD_OPERATOR_VERSION = v0.2.1
+ETCD_OPERATOR_VERSION = v0.2.4
 vendor:
 	@echo "Creating k8s vendor for: $(VENDOR_VERSION)"
 	@rm -rf vendor

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -13,8 +13,8 @@ ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
 ExecStartPre=/bin/mkdir -p /var/lib/cni
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=https://${COREOS_PRIVATE_IPV4}:443 \
   --kubeconfig=/etc/kubernetes/kubeconfig \
+  --require-kubeconfig \
   --client-ca-file=/etc/kubernetes/ca.crt \
   --anonymous-auth=false \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -11,8 +11,8 @@ ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
 ExecStartPre=/bin/mkdir -p /var/lib/cni
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=https://{{apiserver}}:443 \
   --kubeconfig=/etc/kubernetes/kubeconfig \
+  --require-kubeconfig \
   --client-ca-file=/etc/kubernetes/ca.crt \
   --anonymous-auth=false \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -600,7 +600,7 @@ spec:
     spec:
       containers:
       - name: etcd-operator
-        image: quay.io/coreos/etcd-operator:v0.2.1
+        image: quay.io/coreos/etcd-operator:v0.2.4
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:

--- a/vendor/github.com/coreos/etcd-operator/pkg/spec/backup.go
+++ b/vendor/github.com/coreos/etcd-operator/pkg/spec/backup.go
@@ -14,7 +14,8 @@
 
 package spec
 
-// TODO: supports object store like s3
+import "time"
+
 type BackupStorageType string
 
 const (
@@ -68,11 +69,17 @@ type BackupServiceStatus struct {
 
 	// Backups is the totoal number of existing backups
 	Backups int `json:"backups"`
+
+	// BackupSize is the total size of existing backups in MB.
+	BackupSize float64 `json:"backupSize"`
 }
 
 type BackupStatus struct {
-	// Size is the size of the backup.
-	Size int64 `json:"size"`
+	// Creation time of the backup.
+	CreationTime time.Time `json:"creationTime"`
+
+	// Size is the size of the backup in MB.
+	Size float64 `json:"size"`
 
 	// Version is the version of the backup cluster.
 	Version string `json:"version"`

--- a/vendor/github.com/coreos/etcd-operator/pkg/spec/cluster_tls.go
+++ b/vendor/github.com/coreos/etcd-operator/pkg/spec/cluster_tls.go
@@ -1,0 +1,29 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+// TLSPolicy defines the TLS policy of an etcd cluster
+type TLSPolicy struct {
+	// StaticTLS enables user to generate static x509 certificates and keys,
+	// put them into Kubernetes secrets, and specify them into here.
+	Static *StaticTLS `json:"static"`
+}
+
+type StaticTLS struct {
+	// ServerSecretName contains peer-interface and client-interface server x509 key/cert, along with peer and client CA cert.
+	ServerSecretName string `json:"serverSecretName"`
+	// ClientSecretName contains etcd client key/cert, along with client CA cert.
+	ClientSecretName string `json:"clientSecretName"`
+}


### PR DESCRIPTION
Backport this to release 0.3 branch because tests need the require-kubeconfig flag. Also operator needs updating for tests as well

cc @aaronlevy 