### PR TITLE
hack/*, RELEASE.md: Use local static binary for quickstart and conformance test.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,6 +11,8 @@
 - Update on-host kubelet versions (`KUBELET_IMAGE_TAG`)
     - hack/multi-node/user-data.sample
     - hack/single-node/user-data.sample
+    - hack/quickstart/kubelet.master
+    - hack/quickstart/kubelet.worker
 
 ### Update conformance test k8s version
 
@@ -54,20 +56,6 @@ Or, manually:
 git checkout vX.Y.Z
 PUSH_IMAGE=true ./build/build-image.sh
 ```
-
-# Updating quickstart guides
-
-Note: the quickstart guides use the release images, so we should not update them until after building/pushing new release.
-
-Update on-host kubelet version (`KUBELET_IMAGE_TAG`)
-
- - hack/quickstart/kubelet.master
- - hack/quickstart/kubelet.worker
-
-Update the bootkube image version (to latest release)
-
-- hack/quickstart/init-master.sh (`BOOTKUBE_VERSION`)
-
 # Updating checkpointer
 
 This only needs to happen when changes have been made to the checkpointer code / container.

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -1,6 +1,6 @@
 [Service]
 Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-Environment=KUBELET_IMAGE_TAG=v1.5.6_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/run/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -1,6 +1,6 @@
 [Service]
 Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-Environment=KUBELET_IMAGE_TAG=v1.5.6_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/run/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \

--- a/hack/tests/conformance-gce.sh
+++ b/hack/tests/conformance-gce.sh
@@ -14,8 +14,6 @@ set -euo pipefail
 #  - $KEY_FILE:   path to GCE service account keyfile
 #
 # OPTIONAL ENV VARS:
-#  - $BOOTKUBE_REPO:    container repo to use to launch bootkube. Default to value in quickstart/init-master.sh
-#  - $BOOTKUBE_VERSION: container version to use to launch bootkube. Default to value in quickstart/init-master.sh
 #  - $COREOS_VERSION:   CoreOS image version.
 #
 # PROCESS:
@@ -27,8 +25,6 @@ set -euo pipefail
 #     - Use the quickstart init-worker.sh script to join node to kubernetes cluster
 #   - Run conformance tests against the launched cluster
 #
-BOOTKUBE_REPO=${BOOTKUBE_REPO:-}
-BOOTKUBE_VERSION=${BOOTKUBE_VERSION:-}
 COREOS_CHANNEL=${COREOS_CHANNEL:-'coreos-stable'}
 WORKER_COUNT=4
 SELF_HOST_ETCD=${SELF_HOST_ETCD:-false}
@@ -70,7 +66,7 @@ function add_master {
 
     MASTER_IP=$(gcloud compute instances list ${GCE_PREFIX}-m1 --format=json | jq --raw-output '.[].networkInterfaces[].accessConfigs[].natIP')
     cd /build/bootkube/hack/quickstart && SSH_OPTS="-o StrictHostKeyChecking=no" \
-        CLUSTER_DIR=/build/cluster BOOTKUBE_REPO=${BOOTKUBE_REPO} BOOTKUBE_VERSION=${BOOTKUBE_VERSION} SELF_HOST_ETCD=${SELF_HOST_ETCD} ./init-master.sh ${MASTER_IP}
+        CLUSTER_DIR=/build/cluster SELF_HOST_ETCD=${SELF_HOST_ETCD} ./init-master.sh ${MASTER_IP}
 }
 
 function add_workers {
@@ -120,5 +116,5 @@ else
     #TODO(pb): See if there is a way to make the --inherit-env option replace
     #passing all the variables manually. 
     sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.7.4 --exec /bin/bash -- -c \
-        "IN_CONTAINER=true BOOTKUBE_REPO=${BOOTKUBE_REPO} BOOTKUBE_VERSION=${BOOTKUBE_VERSION} COREOS_CHANNEL=${COREOS_CHANNEL} GCE_PREFIX=${GCE_PREFIX} GCE_SERVICE_ACCOUNT=${GCE_SERVICE_ACCOUNT} GCE_PROJECT=${GCE_PROJECT} SELF_HOST_ETCD=${SELF_HOST_ETCD} /build/bootkube/hack/tests/$(basename $0)"
+        "IN_CONTAINER=true COREOS_CHANNEL=${COREOS_CHANNEL} GCE_PREFIX=${GCE_PREFIX} GCE_SERVICE_ACCOUNT=${GCE_SERVICE_ACCOUNT} GCE_PROJECT=${GCE_PROJECT} SELF_HOST_ETCD=${SELF_HOST_ETCD} /build/bootkube/hack/tests/$(basename $0)"
 fi


### PR DESCRIPTION
With this PR, we don't have to update the quickstart scripts after a release is cut.

Also we are able to run conformance test for bootkube with corresponding kubelet version.