### PR TITLE
Use /etc/kubernetes/inactive-manifests instead of /src/kubernetes/manifests

### DIFF
--- a/cmd/checkpoint/README.md
+++ b/cmd/checkpoint/README.md
@@ -49,7 +49,7 @@ metadata:
 
 ### Asset Locations
 
-- Inactive checkpoint manifests: /srv/kubernetes/manifests
+- Inactive checkpoint manifests: /etc/kubernetes/inactive-manifests
 - Active checkpoint manifests: /etc/kubernetes/manifests
 - Checkpointed secrets: /etc/kubernetes/checkpoint-secrets
 - Config Maps: /etc/kubernetes/checkpoint-configmaps

--- a/cmd/checkpoint/main.go
+++ b/cmd/checkpoint/main.go
@@ -38,7 +38,7 @@ const (
 	kubeletAPIRunningPodsURL = "https://127.0.0.1:10250/runningpods/"
 
 	activeCheckpointPath    = "/etc/kubernetes/manifests"
-	inactiveCheckpointPath  = "/srv/kubernetes/manifests"
+	inactiveCheckpointPath  = "/etc/kubernetes/inactive-manifests"
 	checkpointSecretPath    = "/etc/kubernetes/checkpoint-secrets"
 	checkpointConfigMapPath = "/etc/kubernetes/checkpoint-configmaps"
 	kubeconfigPath          = "/etc/kubernetes/kubeconfig"

--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -16,7 +16,7 @@ coreos:
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
-        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -9,7 +9,7 @@ EnvironmentFile=/etc/environment
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
-ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests
 ExecStartPre=/bin/mkdir -p /var/lib/cni
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -16,7 +16,7 @@ coreos:
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
-        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \

--- a/image/checkpoint/checkpoint-pod.yaml
+++ b/image/checkpoint/checkpoint-pod.yaml
@@ -21,14 +21,9 @@ spec:
     volumeMounts:
     - mountPath: /etc/kubernetes
       name: etc-kubernetes
-    - mountPath: /srv/kubernetes
-      name: srv-kubernetes
   hostNetwork: true
   restartPolicy: Always
   volumes:
   - name: etc-kubernetes
     hostPath:
       path: /etc/kubernetes
-  - name: srv-kubernetes
-    hostPath:
-      path: /srv/kubernetes

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -239,7 +239,7 @@ spec:
       volumes:
       - name: checkpoint-dir
         hostPath:
-          path: /etc/kubernetes/checkpoint-iptables    
+          path: /etc/kubernetes/checkpoint-iptables
       - name: var-lock
         hostPath:
           path: /var/lock
@@ -287,8 +287,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: etc-kubernetes
-        - mountPath: /srv/kubernetes
-          name: srv-kubernetes
         - mountPath: /var/run
           name: var-run
       hostNetwork: true
@@ -297,9 +295,6 @@ spec:
       - name: etc-kubernetes
         hostPath:
           path: /etc/kubernetes
-      - name: srv-kubernetes
-        hostPath:
-          path: /srv/kubernetes
       - name: var-run
         hostPath:
           path: /var/run


### PR DESCRIPTION
Using `/srv/kubernetes` is less intuitive, everything else lives under `/etc/kubernetes`, and it's possible the two mounts could be different filesystems which defeats the purpose of using an atomic `mv` internally.

This patch moves "inactive" checkpointed manifests to `/etc/kubernetes/inactive-manifests`.