### PR TITLE
pkg/asset: Add critical pod annotations to control-plane

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -145,7 +145,11 @@ spec:
         component: kube-apiserver
       annotations:
         checkpointer.alpha.coreos.com/checkpoint: "true"
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
       nodeSelector:
         master: "true"
       hostNetwork: true
@@ -377,7 +381,12 @@ spec:
       labels:
         tier: control-plane
         component: kube-controller-manager
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -494,7 +503,12 @@ spec:
       labels:
         tier: control-plane
         component: kube-scheduler
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -574,6 +588,9 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
       hostNetwork: true
       containers:
       - name: kube-proxy


### PR DESCRIPTION
For more information: https://kubernetes.io/docs/concepts/cluster-administration/guaranteed-scheduling-critical-addon-pods/.

Since the hack setups (and I believe all cluster setups) only use a single master we could run the rescheduler, however for this PR I am not including it as we have concerns over the rescheduler not being leader elected, and potential issues with multi-master setups. See https://github.com/kubernetes/contrib/issues/2551.