### PR TITLE
hack,templates: rename `master` node label

### DIFF
--- a/Documentation/upgrading.md
+++ b/Documentation/upgrading.md
@@ -10,10 +10,10 @@ Let's upgrade a self-hosted Kubernetes v1.4.1 cluster to v1.4.3 as an example.
 Show the control plane daemonsets and deployments which will need to be updated.
 
     $ kubectl get daemonsets -n=kube-system
-    NAME             DESIRED   CURRENT   NODE-SELECTOR   AGE
-    kube-apiserver   1         1         master=true     5m
-    kube-proxy       3         3         <none>          5m
-    kubelet          3         3         <none>          5m
+    NAME             DESIRED   CURRENT   NODE-SELECTOR                    AGE
+    kube-apiserver   1         1         node-role.kubernetes.io/master   5m
+    kube-proxy       3         3         <none>                           5m
+    kubelet          3         3         <none>                           5m
 
     $ kubectl get deployments -n=kube-system
     NAME                      DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE

--- a/hack/multi-node/bootkube-up
+++ b/hack/multi-node/bootkube-up
@@ -22,7 +22,7 @@ if [ ! -d "cluster" ]; then
   ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.101:443 ${etcd_render_flags}
   cp user-data.sample cluster/user-data-worker
   cp user-data.sample cluster/user-data-controller
-  sed -i.bak -e '/--node-labels=master=true/d' cluster/user-data-worker
+  sed -i.bak -e '/--node-labels=node-role.kubernetes.io\/master/d' cluster/user-data-worker
 fi
 
 # Start the VM

--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -31,7 +31,7 @@ coreos:
           --pod-manifest-path=/etc/kubernetes/manifests \
           --allow-privileged \
           --hostname-override=${COREOS_PUBLIC_IPV4} \
-          --node-labels=master=true \
+          --node-labels=node-role.kubernetes.io/master \
           --cluster_dns=10.3.0.10 \
           --cluster_domain=cluster.local
 

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -23,7 +23,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --exit-on-lock-contention \
   --allow-privileged \
   --hostname-override=${COREOS_PRIVATE_IPV4} \
-  --node-labels=master=true \
+  --node-labels=node-role.kubernetes.io/master \
   --minimum-container-ttl-duration=3m0s \
   --cluster_dns=10.3.0.10 \
   --cluster_domain=cluster.local \

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -31,7 +31,7 @@ coreos:
           --allow-privileged \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --hostname-override=${COREOS_PUBLIC_IPV4} \
-          --node-labels=master=true \
+          --node-labels=node-role.kubernetes.io/master \
           --cluster_dns=10.3.0.10 \
           --cluster_domain=cluster.local
 

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -147,7 +147,7 @@ spec:
         checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:
       nodeSelector:
-        master: "true"
+        node-role.kubernetes.io/master: ""
       hostNetwork: true
       containers:
       - name: kube-apiserver
@@ -278,7 +278,7 @@ spec:
         checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:
       nodeSelector:
-        master: "true"
+        node-role.kubernetes.io/master: ""
       hostNetwork: true
       containers:
       - image: quay.io/coreos/kenc:48b6feceeee56c657ea9263f47b6ea091e8d3035
@@ -324,7 +324,7 @@ spec:
         checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:
       nodeSelector:
-        master: "true"
+        node-role.kubernetes.io/master: ""
       hostNetwork: true
       containers:
       - name: checkpoint
@@ -395,7 +395,7 @@ spec:
                   - kube-contoller-manager
               topologyKey: kubernetes.io/hostname
       nodeSelector:
-        master: "true"
+        node-role.kubernetes.io/master: ""
       containers:
       - name: kube-controller-manager
         image: quay.io/coreos/hyperkube:v1.6.1_coreos.0
@@ -512,7 +512,7 @@ spec:
                   - kube-scheduler
               topologyKey: kubernetes.io/hostname
       nodeSelector:
-        master: "true"
+        node-role.kubernetes.io/master: ""
       containers:
       - name: kube-scheduler
         image: quay.io/coreos/hyperkube:v1.6.1_coreos.0

--- a/pkg/util/etcdutil/migrate.go
+++ b/pkg/util/etcdutil/migrate.go
@@ -126,7 +126,7 @@ func createMigratedEtcdCluster(restclient restclient.Interface, host, podIP stri
     "version": "v3.1.0",
     "pod": {
       "nodeSelector": {
-        "master": "true"
+        "node-role.kubernetes.io/master": ""
       }
     },
     "selfHosted": {


### PR DESCRIPTION
Update the master node label from `master` to
`node-role.kubernetes.io/master` as documented in
https://github.com/kubernetes/kubernetes/pull/39112.

cc @aaronlevy @yifan-gu 