### PR TITLE
Change temporary secrets path to /etc/kubernetes/bootstrap-secrets.

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -49,7 +49,7 @@ const (
 	AssetPathBootstrapControllerManager  = "bootstrap-manifests/bootstrap-controller-manager.yaml"
 	AssetPathBootstrapScheduler          = "bootstrap-manifests/bootstrap-scheduler.yaml"
 	AssetPathBootstrapEtcd               = "bootstrap-manifests/bootstrap-etcd.yaml"
-	BootstrapSecretsDir                  = "/tmp/bootkube/secrets"
+	BootstrapSecretsDir                  = "/etc/kubernetes/bootstrap-secrets"
 )
 
 // AssetConfig holds all configuration needed when generating

--- a/pkg/bootkube/bootstrap.go
+++ b/pkg/bootkube/bootstrap.go
@@ -18,7 +18,7 @@ func CreateBootstrapControlPlane(assetDir string, podManifestPath string) error 
 	if err := os.RemoveAll(asset.BootstrapSecretsDir); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(asset.BootstrapSecretsDir, os.FileMode(0700)); err != nil {
+	if err := os.Mkdir(asset.BootstrapSecretsDir, os.FileMode(0700)); err != nil {
 		return err
 	}
 	secretsDir := filepath.Join(assetDir, asset.AssetPathSecrets)


### PR DESCRIPTION
This reduces the number of paths that users need to make available to
bootkube, especially if running in a container.

I think this is a good change because the user only needs to guarantee
read/write access to one path (/etc/kubernetes) rather than two.