### PR TITLE
templates: stop enabling alpha API groups

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -175,7 +175,6 @@ spec:
         - --insecure-port=8080
         - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
-        - --runtime-config=api/all=true
         - --secure-port=443
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --service-cluster-ip-range={{ .ServiceCIDR }}
@@ -235,7 +234,6 @@ spec:
     - --insecure-port=8080
     - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
-    - --runtime-config=api/all=true
     - --secure-port=443
     - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
     - --service-cluster-ip-range={{ .ServiceCIDR }}


### PR DESCRIPTION
We no longer use alpha API groups by default in bootkube, so we should
stop enabling them by default, allowing us to be confident that we do
not rely on alpha features.

cc @aaronlevy 