### PR TITLE
Patch etcd-operator as part of vendoring process

### DIFF
--- a/vendor/github.com/coreos/etcd-operator/pkg/spec/cluster.go
+++ b/vendor/github.com/coreos/etcd-operator/pkg/spec/cluster.go
@@ -21,8 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/client-go/pkg/api/meta/metatypes"
-	"k8s.io/client-go/pkg/api/unversioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
@@ -45,17 +44,17 @@ func TPRName() string {
 }
 
 type Cluster struct {
-	unversioned.TypeMeta `json:",inline"`
-	Metadata             v1.ObjectMeta `json:"metadata,omitempty"`
-	Spec                 ClusterSpec   `json:"spec"`
-	Status               ClusterStatus `json:"status"`
+	metav1.TypeMeta `json:",inline"`
+	Metadata        v1.ObjectMeta `json:"metadata,omitempty"`
+	Spec            ClusterSpec   `json:"spec"`
+	Status          ClusterStatus `json:"status"`
 }
 
-func (c *Cluster) AsOwner() metatypes.OwnerReference {
+func (c *Cluster) AsOwner() metav1.OwnerReference {
 	trueVar := true
 	// TODO: In 1.6 this is gonna be "k8s.io/kubernetes/pkg/apis/meta/v1"
-	// Both api.OwnerReference and metatypes.OwnerReference are combined into that.
-	return metatypes.OwnerReference{
+	// Both api.OwnerReference and metav1.OwnerReference are combined into that.
+	return metav1.OwnerReference{
 		APIVersion: c.APIVersion,
 		Kind:       c.Kind,
 		Name:       c.Metadata.Name,

--- a/vendor/github.com/coreos/etcd-operator/pkg/spec/etcd_cluster_list.go
+++ b/vendor/github.com/coreos/etcd-operator/pkg/spec/etcd_cluster_list.go
@@ -17,15 +17,15 @@ package spec
 import (
 	"encoding/json"
 
-	"k8s.io/client-go/pkg/api/unversioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ClusterList is a list of etcd clusters.
 type ClusterList struct {
-	unversioned.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
-	Metadata unversioned.ListMeta `json:"metadata,omitempty"`
+	Metadata metav1.ListMeta `json:"metadata,omitempty"`
 	// Items is a list of third party objects
 	Items []Cluster `json:"items"`
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/bootkube/issues/439

We should just apply the vendoring patch as part of the vendoring process itself. If it's done at compile time the working tree will report as dirty.