### PR TITLE
Remove deprecated --minimum-container-ttl-duration.

### DIFF
--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -24,7 +24,6 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --allow-privileged \
   --hostname-override=${COREOS_PRIVATE_IPV4} \
   --node-labels=node-role.kubernetes.io/master \
-  --minimum-container-ttl-duration=3m0s \
   --cluster_dns=10.3.0.10 \
   --cluster_domain=cluster.local \
   --pod-manifest-path=/etc/kubernetes/manifests

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -21,7 +21,6 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --exit-on-lock-contention \
   --allow-privileged \
   --hostname-override=${COREOS_PRIVATE_IPV4} \
-  --minimum-container-ttl-duration=3m0s \
   --cluster_dns=10.3.0.10 \
   --cluster_domain=cluster.local \
   --pod-manifest-path=/etc/kubernetes/manifests


### PR DESCRIPTION
This flag has been deprecated for a few releases. There are other flags
with reasonable defaults that supercede this behavior.

Fixes #404.