### PR TITLE
hack: fix taint value

### DIFF
--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -32,7 +32,7 @@ coreos:
           --allow-privileged \
           --hostname-override=${COREOS_PUBLIC_IPV4} \
           --node-labels=node-role.kubernetes.io/master \
-          --register-with-taints=node-role.kubernetes.io/master:NoSchedule \
+          --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
           --cluster_dns=10.3.0.10 \
           --cluster_domain=cluster.local
 

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -24,6 +24,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --allow-privileged \
   --hostname-override=${COREOS_PRIVATE_IPV4} \
   --node-labels=node-role.kubernetes.io/master \
+  --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
   --cluster_dns=10.3.0.10 \
   --cluster_domain=cluster.local \
   --pod-manifest-path=/etc/kubernetes/manifests


### PR DESCRIPTION
getting error
```
Error: invalid argument "node-role.kubernetes.io/master:NoSchedule" for --register-with-taints=node-role.kubernetes.io/master:NoSchedule: invalid taint spec: node-role.kubernetes.io/master:NoSchedule
```

I found that the taint was missing the taint value. It needed a `=` so that the value is set to empty string `""`.

Fixes @Quentin-M's issues in https://github.com/kubernetes-incubator/bootkube/pull/434.