### PR TITLE
hack: remove taints from master node

### DIFF
--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -32,7 +32,6 @@ coreos:
           --allow-privileged \
           --hostname-override=${COREOS_PUBLIC_IPV4} \
           --node-labels=node-role.kubernetes.io/master \
-          --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
           --cluster_dns=10.3.0.10 \
           --cluster_domain=cluster.local
 

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -24,7 +24,6 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --allow-privileged \
   --hostname-override=${COREOS_PRIVATE_IPV4} \
   --node-labels=node-role.kubernetes.io/master \
-  --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
   --cluster_dns=10.3.0.10 \
   --cluster_domain=cluster.local \
   --pod-manifest-path=/etc/kubernetes/manifests


### PR DESCRIPTION
Drop the taints on master nodes until fix for https://github.com/kubernetes-incubator/bootkube/issues/452 is merged.

/cc @xiang90 @hongchaodeng 