### PR TITLE
pkg/asset: bump flannel to v0.7.1

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -954,7 +954,7 @@ spec:
     spec:
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.7.0-amd64
+        image: quay.io/coreos/flannel:v0.7.1-amd64
         command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr", "--iface=$(POD_IP)"]
         securityContext:
           privileged: true


### PR DESCRIPTION
fixes https://github.com/kubernetes-incubator/bootkube/issues/454