### PR TITLE
Disable insecure apiserver access.

### DIFF
--- a/cmd/bootkube/start.go
+++ b/cmd/bootkube/start.go
@@ -47,7 +47,11 @@ func runCmdStart(cmd *cobra.Command, args []string) error {
 	util.InitLogs()
 	defer util.FlushLogs()
 
-	return bk.Run()
+	if err := bk.Run(); err != nil {
+		// Always report errors.
+		bootkube.UserOutput("Error: %v\n", err)
+	}
+	return nil
 }
 
 func validateStartOpts(cmd *cobra.Command, args []string) error {

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/kubernetes-incubator/bootkube/pkg/tlsutil"
@@ -60,31 +61,31 @@ const (
 // AssetConfig holds all configuration needed when generating
 // the default set of assets.
 type Config struct {
-	EtcdCACert          *x509.Certificate
-	EtcdClientCert      *x509.Certificate
-	EtcdClientKey       *rsa.PrivateKey
-	EtcdServers         []*url.URL
-	EtcdUseTLS          bool
-	APIServers          []*url.URL
-	CACert              *x509.Certificate
-	CAPrivKey           *rsa.PrivateKey
-	AltNames            *tlsutil.AltNames
-	PodCIDR             *net.IPNet
-	ServiceCIDR         *net.IPNet
-	APIServiceIP        net.IP
-	DNSServiceIP        net.IP
-	EtcdServiceIP       net.IP
-	SelfHostKubelet     bool
-	SelfHostedEtcd      bool
-	CloudProvider       string
-	BootstrapSecretsDir string
+	EtcdCACert             *x509.Certificate
+	EtcdClientCert         *x509.Certificate
+	EtcdClientKey          *rsa.PrivateKey
+	EtcdServers            []*url.URL
+	EtcdUseTLS             bool
+	APIServers             []*url.URL
+	CACert                 *x509.Certificate
+	CAPrivKey              *rsa.PrivateKey
+	AltNames               *tlsutil.AltNames
+	PodCIDR                *net.IPNet
+	ServiceCIDR            *net.IPNet
+	APIServiceIP           net.IP
+	DNSServiceIP           net.IP
+	EtcdServiceIP          net.IP
+	SelfHostKubelet        bool
+	SelfHostedEtcd         bool
+	CloudProvider          string
+	BootstrapSecretsSubdir string
 }
 
 // NewDefaultAssets returns a list of default assets, optionally
 // configured via a user provided AssetConfig. Default assets include
 // TLS assets (certs, keys and secrets), and k8s component manifests.
 func NewDefaultAssets(conf Config) (Assets, error) {
-	conf.BootstrapSecretsDir = BootstrapSecretsDir
+	conf.BootstrapSecretsSubdir = path.Base(BootstrapSecretsDir)
 
 	as := newStaticAssets()
 	as = append(as, newDynamicAssets(conf)...)

--- a/pkg/bootkube/parse.go
+++ b/pkg/bootkube/parse.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/kubernetes-incubator/bootkube/pkg/asset"
-	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // detectEtcdIP deserializes the etcd-service ClusterIP.

--- a/pkg/bootkube/status.go
+++ b/pkg/bootkube/status.go
@@ -12,11 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
-	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/v1"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
 
 const (
@@ -39,14 +38,18 @@ func WaitUntilPodsRunning(pods []string, timeout time.Duration) error {
 }
 
 type statusController struct {
-	client        clientset.Interface
+	client        kubernetes.Interface
 	podStore      cache.Store
 	watchPods     []string
 	lastPodPhases map[string]v1.PodPhase
 }
 
 func NewStatusController(pods []string) (*statusController, error) {
-	client, err := clientset.NewForConfig(&restclient.Config{Host: insecureAPIAddr})
+	config, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This disables the insecure apiserver port for both the bootstrap
and self-hosted control planes. In so doing I migrated all of bootkube
to use the kubeconfig rather than a static local port.

This assumes that the temporary control plane is also addressable
at the same IP as the the final control plane. If this is a faulty
assumption then this part likely won't work.

While I was at it I changed some dependencies to point at client-go
to help us move off of vendoring all of kubernetes in the future.

Fixes #324.