### PR TITLE
pkg/asset/internal: Add --cloud-provider to bootstrap manifests

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -255,6 +255,7 @@ spec:
     - --secure-port=443
     - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
     - --service-cluster-ip-range={{ .ServiceCIDR }}
+    - --cloud-provider={{ .CloudProvider }}
     - --storage-backend=etcd3
     - --tls-ca-file=/etc/kubernetes/secrets/ca.crt
     - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
@@ -488,6 +489,7 @@ spec:
     - controller-manager
     - --allocate-node-cidrs=true
     - --cluster-cidr={{ .PodCIDR }}
+    - --cloud-provider={{ .CloudProvider }}
     - --configure-cloud-routes=false
     - --kubeconfig=/etc/kubernetes/kubeconfig
     - --leader-elect=true


### PR DESCRIPTION
~This was a solution to #463, not necessarily the right solution. I'm not familiar with the original reasons we set `configure-cloud-routes=true` to false (upstream default is true) or its impact on other providers.~

* Add --cloud-provider to bootstrap apiserver and controller-manager (missing)
~* Set --configure-cloud-routes true. Upstream description: "Should CIDRs allocated by allocate-node-cidrs be configured on the cloud provider. (default true)"~