### PR TITLE
Fix up some logging configuration.

### DIFF
--- a/cmd/bootkube/main.go
+++ b/cmd/bootkube/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/kubernetes-incubator/bootkube/pkg/util"
 	"github.com/kubernetes-incubator/bootkube/pkg/version"
 )
 
@@ -28,6 +30,10 @@ var (
 )
 
 func main() {
+	flag.Parse()
+	util.InitLogs()
+	defer util.FlushLogs()
+
 	cmdRoot.AddCommand(cmdVersion)
 	if err := cmdRoot.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/bootkube/start.go
+++ b/cmd/bootkube/start.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"errors"
-	"flag"
 
 	"github.com/spf13/cobra"
 
 	"github.com/kubernetes-incubator/bootkube/pkg/bootkube"
-	"github.com/kubernetes-incubator/bootkube/pkg/util"
 )
 
 var (
@@ -37,15 +35,9 @@ func runCmdStart(cmd *cobra.Command, args []string) error {
 		AssetDir:        startOpts.assetDir,
 		PodManifestPath: startOpts.podManifestPath,
 	})
-
 	if err != nil {
 		return err
 	}
-
-	// set in util init() func, but lets not depend on that
-	flag.Set("logtostderr", "true")
-	util.InitLogs()
-	defer util.FlushLogs()
 
 	err = bk.Run()
 	if err != nil {


### PR DESCRIPTION
- Use the same logging config for all bootkube commands.
- Make sure flag.Parse() is called, otherwise glog complains.
  I checked and cobra does not call flag.Parse().