### PR TITLE
Change temporary etcd port to 4001.

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -248,7 +248,7 @@ spec:
     - --etcd-certfile=/etc/kubernetes/secrets/etcd-client.crt
     - --etcd-keyfile=/etc/kubernetes/secrets/etcd-client.key
 {{- end }}
-    - --etcd-servers={{ range $i, $e := .EtcdServers }}{{ if $i }},{{end}}{{ $e }}{{end}}{{ if .SelfHostedEtcd }},http://127.0.0.1:12379{{end}}
+    - --etcd-servers={{ range $i, $e := .EtcdServers }}{{ if $i }},{{end}}{{ $e }}{{end}}{{ if .SelfHostedEtcd }},http://127.0.0.1:4001{{end}}
     - --insecure-port=0
     - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
@@ -912,9 +912,9 @@ spec:
     command:
     - /usr/local/bin/etcd
     - --name=boot-etcd
-    - --listen-client-urls=http://0.0.0.0:12379
+    - --listen-client-urls=http://0.0.0.0:4001
     - --listen-peer-urls=http://0.0.0.0:12380
-    - --advertise-client-urls=http://$(MY_POD_IP):12379
+    - --advertise-client-urls=http://$(MY_POD_IP):4001
     - --initial-advertise-peer-urls=http://$(MY_POD_IP):12380
     - --initial-cluster=boot-etcd=http://$(MY_POD_IP):12380
     - --initial-cluster-token=bootkube

--- a/pkg/util/etcdutil/migrate.go
+++ b/pkg/util/etcdutil/migrate.go
@@ -140,7 +140,7 @@ func createMigratedEtcdCluster(restclient restclient.Interface, podIP string) er
       ]
     },
     "selfHosted": {
-      "bootMemberClientEndpoint": "http://%s:12379"
+      "bootMemberClientEndpoint": "http://%s:4001"
     }
   }
 }`, spec.TPRGroup, spec.TPRVersion, strings.Title(spec.TPRKind), etcdClusterName, podIP))


### PR DESCRIPTION
This is an actual (though deprecated) etcd port, as opposed
to a completely random one. Some docs recommend using this
port for migrating from http to https, so it feels slightly
more natural to use it.