### PR TITLE
checkpoint: Fix garbage collection bug.

### DIFF
--- a/cmd/checkpoint/main.go
+++ b/cmd/checkpoint/main.go
@@ -217,7 +217,7 @@ func process(localRunningPods, localParentPods, apiParentPods, activeCheckpoints
 	// We can only make some GC decisions if we've successfully contacted an apiserver.
 	// When apiParentPods == nil, that means we were not able to get an updated list of pods.
 	removeMap := make(map[string]struct{})
-	if apiParentPods != nil {
+	if len(apiParentPods) != 0 {
 
 		// Scan for inacive checkpoints we should GC
 		for id := range inactiveCheckpoints {


### PR DESCRIPTION
The apiParentPods is always non-nil, so we should test the length
instead of the nil pointer. Besides, testing the length will work
for nil pointer as well.