### PR TITLE
pkg/assets/internal: Remove duplicated apiVersion

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -22,7 +22,6 @@ contexts:
 
 	KubeSystemSARoleBindingTemplate = []byte(`apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: system:default-sa
 subjects:


### PR DESCRIPTION
Harmless, but apiVersion is included twice in the ClusterRoleBinding. I noticed while doing some diffs with other renderings.