### PR TITLE
terraform: Add terraform module for bootkube render

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfvars
+*.tfstate*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,53 @@
+# Terraform
+
+This Terraform module generates bootkube assets, just like using the bootkube binary to run `bootkube render`. It aims to provide the same variables, defaults, features, and generated output that the command line tool does.
+
+Terraform-based clusters can generate bootkube assets as part of `terraform apply`.
+
+## TODO
+
+Note, this module does not have feature parity with `bootkube render` yet.
+
+* Experimental manifests
+* etcd TLS
+* Self-hosted etcd
+
+## Usage
+
+Use the terraform module within your terraform configs. Check `variables.tf` for required and optional input variables and `terraform.tfvars.example` for examples.
+
+```hcl
+module "bootkube" {
+  source = "git://https://github.com/coreos/bootkube.git//terraform"
+
+  cluster_name = "example"
+  api_servers = ["node1.example.com"]
+  etcd_servers = ["http://127.0.0.1:2379"]
+  asset_dir = "/home/core/clusters/mycluster"
+}
+```
+
+Alternately, copy `terraform.tfvars.example` to `terraform.tfvars` and run terraform commands directly from this module directory.
+
+Render bootkube assets.
+
+```sh
+terraform get
+terraform plan
+terraform apply
+```
+
+### Comparison
+
+Render bootkube assets directly with bootkube v0.4.2.
+
+```sh
+bootkube version
+bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --etcd-servers=http://127.0.0.1:2379
+```
+
+Compare assets. The only diffs you should see are TLS credentials.
+
+```sh
+diff -rw assets /home/core/cluster/mycluster
+```

--- a/terraform/assets.tf
+++ b/terraform/assets.tf
@@ -1,0 +1,72 @@
+# Self-hosted Kubernetes bootstrap manifests
+resource "template_dir" "bootstrap-manifests" {
+  source_dir      = "${path.module}/resources/bootstrap-manifests"
+  destination_dir = "${var.asset_dir}/bootstrap-manifests"
+
+  vars {
+    hyperkube_image = "${var.container_images["hyperkube"]}"
+    etcd_servers    = "${join(",", var.etcd_servers)}"
+
+    cloud_provider = "${var.cloud_provider}"
+    pod_cidr       = "${var.pod_cidr}"
+    service_cidr   = "${var.service_cidr}"
+  }
+}
+
+# Self-hosted Kubernetes manifests
+resource "template_dir" "manifests" {
+  source_dir      = "${path.module}/resources/manifests"
+  destination_dir = "${var.asset_dir}/manifests"
+
+  vars {
+    hyperkube_image = "${var.container_images["hyperkube"]}"
+    etcd_servers    = "${join(",", var.etcd_servers)}"
+
+    cloud_provider = "${var.cloud_provider}"
+    pod_cidr       = "${var.pod_cidr}"
+    service_cidr   = "${var.service_cidr}"
+
+    kube_dns_service_ip = "${var.kube_dns_service_ip}"
+
+    ca_cert            = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
+    apiserver_key      = "${base64encode(tls_private_key.apiserver.private_key_pem)}"
+    apiserver_cert     = "${base64encode(tls_locally_signed_cert.apiserver.cert_pem)}"
+    serviceaccount_pub = "${base64encode(tls_private_key.service-account.public_key_pem)}"
+    serviceaccount_key = "${base64encode(tls_private_key.service-account.private_key_pem)}"
+  }
+}
+
+# Generated kubeconfig (auth/kubeconfig)
+data "template_file" "kubeconfig" {
+  template = "${file("${path.module}/resources/kubeconfig")}"
+
+  vars {
+    ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
+    kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
+    kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
+    server       = "${format("https://%s:443", element(var.api_servers, 0))}"
+  }
+}
+
+resource "local_file" "kubeconfig" {
+  content  = "${data.template_file.kubeconfig.rendered}"
+  filename = "${var.asset_dir}/auth/kubeconfig"
+}
+
+# Generated kubeconfig (auth/kubeconfig)
+data "template_file" "user-kubeconfig" {
+  template = "${file("${path.module}/resources/user-kubeconfig")}"
+
+  vars {
+    name         = "${var.cluster_name}"
+    ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
+    kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
+    kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
+    server       = "${format("https://%s:443", element(var.api_servers, 0))}"
+  }
+}
+
+resource "local_file" "user-kubeconfig" {
+  content  = "${data.template_file.user-kubeconfig.rendered}"
+  filename = "${var.asset_dir}/auth/${var.cluster_name}-config"
+}

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,35 @@
+output "id" {
+  value = "${sha1("${template_dir.bootstrap-manifests.id} ${local_file.kubeconfig.id}")}"
+}
+
+output "content_hash" {
+  value = "${sha1("${template_dir.bootstrap-manifests.id} ${template_dir.manifests.id}")}"
+}
+
+output "kubeconfig" {
+  value = "${data.template_file.kubeconfig.rendered}"
+}
+
+output "user-kubeconfig" {
+  value = "${local_file.user-kubeconfig.filename}"
+}
+
+# Some platforms may need to reconstruct the kubeconfig directly in user-data.
+# That can't be done with the way template_file interpolates multi-line
+# contents so the raw components of the kubeconfig may be needed.
+
+output "ca_cert" {
+  value = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
+}
+
+output "kubelet_cert" {
+  value = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
+}
+
+output "kubelet_key" {
+  value = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
+}
+
+output "server" {
+  value = "${format("https://%s:443", element(var.api_servers, 0))}"
+}

--- a/terraform/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/terraform/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bootstrap-kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-apiserver
+    image: ${hyperkube_image}
+    command:
+    - /usr/bin/flock
+    - --exclusive
+    - --timeout=30
+    - /var/lock/api-server.lock
+    - /hyperkube
+    - apiserver
+    - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
+    - --advertise-address=$(POD_IP)
+    - --allow-privileged=true
+    - --authorization-mode=RBAC
+    - --bind-address=0.0.0.0
+    - --client-ca-file=/etc/kubernetes/secrets/ca.crt
+    - --etcd-servers=${etcd_servers}
+    - --insecure-port=0
+    - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
+    - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
+    - --secure-port=443
+    - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
+    - --service-cluster-ip-range=${service_cidr}
+    - --cloud-provider=${cloud_provider}
+    - --storage-backend=etcd3
+    - --tls-ca-file=/etc/kubernetes/secrets/ca.crt
+    - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
+    - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
+    env:
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    volumeMounts:
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-host
+      readOnly: true
+    - mountPath: /etc/kubernetes/secrets
+      name: secrets
+      readOnly: true
+    - mountPath: /var/lock
+      name: var-lock
+      readOnly: false
+  hostNetwork: true
+  volumes:
+  - name: secrets
+    hostPath:
+      path: /etc/kubernetes/bootstrap-secrets
+  - name: ssl-certs-host
+    hostPath:
+      path: /usr/share/ca-certificates
+  - name: var-lock
+    hostPath:
+      path: /var/lock

--- a/terraform/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
+++ b/terraform/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bootstrap-kube-controller-manager
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-controller-manager
+    image: ${hyperkube_image}
+    command:
+    - ./hyperkube
+    - controller-manager
+    - --allocate-node-cidrs=true
+    - --cluster-cidr=${pod_cidr}
+    - --cloud-provider=${cloud_provider}
+    - --configure-cloud-routes=false
+    - --kubeconfig=/etc/kubernetes/kubeconfig
+    - --leader-elect=true
+    - --root-ca-file=/etc/kubernetes/bootstrap-secrets/ca.crt
+    - --service-account-private-key-file=/etc/kubernetes/bootstrap-secrets/service-account.key
+    volumeMounts:
+    - name: kubernetes
+      mountPath: /etc/kubernetes
+      readOnly: true
+    - name: ssl-host
+      mountPath: /etc/ssl/certs
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - name: kubernetes
+    hostPath:
+      path: /etc/kubernetes
+  - name: ssl-host
+    hostPath:
+      path: /usr/share/ca-certificates

--- a/terraform/resources/bootstrap-manifests/bootstrap-scheduler.yaml
+++ b/terraform/resources/bootstrap-manifests/bootstrap-scheduler.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bootstrap-kube-scheduler
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-scheduler
+    image: ${hyperkube_image}
+    command:
+    - ./hyperkube
+    - scheduler
+    - --kubeconfig=/etc/kubernetes/kubeconfig
+    - --leader-elect=true
+    volumeMounts:
+    - name: kubernetes
+      mountPath: /etc/kubernetes
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - name: kubernetes
+    hostPath:
+      path: /etc/kubernetes

--- a/terraform/resources/kubeconfig
+++ b/terraform/resources/kubeconfig
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: ${server}
+    certificate-authority-data: ${ca_cert}
+users:
+- name: kubelet
+  user:
+    client-certificate-data: ${kubelet_cert}
+    client-key-data: ${kubelet_key}
+contexts:
+- context:
+    cluster: local
+    user: kubelet

--- a/terraform/resources/manifests/kube-apiserver-secret.yaml
+++ b/terraform/resources/manifests/kube-apiserver-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+type: Opaque
+data:
+  apiserver.key: ${apiserver_key}
+  apiserver.crt: ${apiserver_cert}
+  service-account.pub: ${serviceaccount_pub}
+  ca.crt: ${ca_cert}

--- a/terraform/resources/manifests/kube-apiserver.yaml
+++ b/terraform/resources/manifests/kube-apiserver.yaml
@@ -1,0 +1,81 @@
+apiVersion: "extensions/v1beta1"
+kind: DaemonSet
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    component: kube-apiserver
+spec:
+  template:
+    metadata:
+      labels:
+        tier: control-plane
+        component: kube-apiserver
+      annotations:
+        checkpointer.alpha.coreos.com/checkpoint: "true"
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      containers:
+      - name: kube-apiserver
+        image: ${hyperkube_image}
+        command:
+        - /usr/bin/flock
+        - --exclusive
+        - --timeout=30
+        - /var/lock/api-server.lock
+        - /hyperkube
+        - apiserver
+        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
+        - --advertise-address=$(POD_IP)
+        - --allow-privileged=true
+        - --anonymous-auth=false
+        - --authorization-mode=RBAC
+        - --bind-address=0.0.0.0
+        - --client-ca-file=/etc/kubernetes/secrets/ca.crt
+        - --cloud-provider=${cloud_provider}
+        - --etcd-servers=${etcd_servers}
+        - --insecure-port=0
+        - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
+        - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
+        - --secure-port=443
+        - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
+        - --service-cluster-ip-range=${service_cidr}
+        - --storage-backend=etcd3
+        - --tls-ca-file=/etc/kubernetes/secrets/ca.crt
+        - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
+        - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: ssl-certs-host
+          readOnly: true
+        - mountPath: /etc/kubernetes/secrets
+          name: secrets
+          readOnly: true
+        - mountPath: /var/lock
+          name: var-lock
+          readOnly: false
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      volumes:
+      - name: ssl-certs-host
+        hostPath:
+          path: /usr/share/ca-certificates
+      - name: secrets
+        secret:
+          secretName: kube-apiserver
+      - name: var-lock
+        hostPath:
+          path: /var/lock

--- a/terraform/resources/manifests/kube-controller-manager-disruption.yaml
+++ b/terraform/resources/manifests/kube-controller-manager-disruption.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      tier: control-plane
+      component: kube-controller-manager

--- a/terraform/resources/manifests/kube-controller-manager-secret.yaml
+++ b/terraform/resources/manifests/kube-controller-manager-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+type: Opaque
+data:
+  service-account.key: ${serviceaccount_key}
+  ca.crt: ${ca_cert}

--- a/terraform/resources/manifests/kube-controller-manager.yaml
+++ b/terraform/resources/manifests/kube-controller-manager.yaml
@@ -1,0 +1,76 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    component: kube-controller-manager
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        tier: control-plane
+        component: kube-controller-manager
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: tier
+                  operator: In
+                  values:
+                  - control-plane
+                - key: component
+                  operator: In
+                  values:
+                  - kube-contoller-manager
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: kube-controller-manager
+        image: ${hyperkube_image}
+        command:
+        - ./hyperkube
+        - controller-manager
+        - --allocate-node-cidrs=true
+        - --cloud-provider=${cloud_provider}
+        - --cluster-cidr=${pod_cidr}
+        - --configure-cloud-routes=false
+        - --leader-elect=true
+        - --root-ca-file=/etc/kubernetes/secrets/ca.crt
+        - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10252  # Note: Using default port. Update if --port option is set differently.
+          initialDelaySeconds: 15
+          timeoutSeconds: 15
+        volumeMounts:
+        - name: secrets
+          mountPath: /etc/kubernetes/secrets
+          readOnly: true
+        - name: ssl-host
+          mountPath: /etc/ssl/certs
+          readOnly: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      volumes:
+      - name: secrets
+        secret:
+          secretName: kube-controller-manager
+      - name: ssl-host
+        hostPath:
+          path: /usr/share/ca-certificates
+      dnsPolicy: Default # Don't use cluster DNS.

--- a/terraform/resources/manifests/kube-dns-deployment.yaml
+++ b/terraform/resources/manifests/kube-dns-deployment.yaml
@@ -1,0 +1,155 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+spec:
+  # replicas: not specified here:
+  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+  # 2. Default is 1.
+  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  strategy:
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      containers:
+      - name: kubedns
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1
+        resources:
+          # TODO: Set memory limits when we've profiled the container for large
+          # clusters, then set request = limit to keep this container in
+          # guaranteed class. Currently, this container falls into the
+          # "burstable" category so the kubelet doesn't backoff from restarting it.
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        livenessProbe:
+          httpGet:
+            path: /healthcheck/kubedns
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 8081
+            scheme: HTTP
+          # we poll on pod startup for the Kubernetes master service and
+          # only setup the /readiness HTTP server once that's available.
+          initialDelaySeconds: 3
+          timeoutSeconds: 5
+        args:
+        - --domain=cluster.local.
+        - --dns-port=10053
+        - --config-dir=/kube-dns-config
+        - --v=2
+        env:
+        - name: PROMETHEUS_PORT
+          value: "10055"
+        ports:
+        - containerPort: 10053
+          name: dns-local
+          protocol: UDP
+        - containerPort: 10053
+          name: dns-tcp-local
+          protocol: TCP
+        - containerPort: 10055
+          name: metrics
+          protocol: TCP
+        volumeMounts:
+        - name: kube-dns-config
+          mountPath: /kube-dns-config
+      - name: dnsmasq
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1
+        livenessProbe:
+          httpGet:
+            path: /healthcheck/dnsmasq
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        args:
+        - -v=2
+        - -logtostderr
+        - -configDir=/etc/k8s/dns/dnsmasq-nanny
+        - -restartDnsmasq=true
+        - --
+        - -k
+        - --cache-size=1000
+        - --log-facility=-
+        - --server=/cluster.local/127.0.0.1#10053
+        - --server=/in-addr.arpa/127.0.0.1#10053
+        - --server=/ip6.arpa/127.0.0.1#10053
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
+        resources:
+          requests:
+            cpu: 150m
+            memory: 20Mi
+        volumeMounts:
+        - name: kube-dns-config
+          mountPath: /etc/k8s/dns/dnsmasq-nanny
+      - name: sidecar
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        args:
+        - --v=2
+        - --logtostderr
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,A
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,A
+        ports:
+        - containerPort: 10054
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+      dnsPolicy: Default  # Don't use cluster DNS.
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      volumes:
+      - name: kube-dns-config
+        configMap:
+          name: kube-dns
+          optional: true

--- a/terraform/resources/manifests/kube-dns-svc.yaml
+++ b/terraform/resources/manifests/kube-dns-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "KubeDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: ${kube_dns_service_ip}
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP

--- a/terraform/resources/manifests/kube-flannel-cfg.yaml
+++ b/terraform/resources/manifests/kube-flannel-cfg.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "type": "flannel",
+      "delegate": {
+        "isDefaultGateway": true
+      }
+    }
+  net-conf.json: |
+    {
+      "Network": "${pod_cidr}",
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }

--- a/terraform/resources/manifests/kube-flannel.yaml
+++ b/terraform/resources/manifests/kube-flannel.yaml
@@ -1,0 +1,64 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-flannel
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+    spec:
+      containers:
+      - name: kube-flannel
+        image: quay.io/coreos/flannel:v0.7.1-amd64
+        command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr", "--iface=$(POD_IP)"]
+        securityContext:
+          privileged: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        volumeMounts:
+        - name: run
+          mountPath: /run
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      - name: install-cni
+        image: busybox
+        command: [ "/bin/sh", "-c", "set -e -x; TMP=/etc/cni/net.d/.tmp-flannel-cfg; cp /etc/kube-flannel/cni-conf.json $TMP; mv $TMP /etc/cni/net.d/10-flannel.conf; while :; do sleep 3600; done" ]
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      volumes:
+        - name: run
+          hostPath:
+            path: /run
+        - name: cni
+          hostPath:
+            path: /etc/kubernetes/cni/net.d
+        - name: flannel-cfg
+          configMap:
+            name: kube-flannel-cfg

--- a/terraform/resources/manifests/kube-proxy.yaml
+++ b/terraform/resources/manifests/kube-proxy.yaml
@@ -1,0 +1,55 @@
+apiVersion: "extensions/v1beta1"
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+  labels:
+    tier: node
+    component: kube-proxy
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        component: kube-proxy
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      containers:
+      - name: kube-proxy
+        image: ${hyperkube_image}
+        command:
+        - /hyperkube
+        - proxy
+        - --cluster-cidr=${pod_cidr}
+        - --hostname-override=$(NODE_NAME)
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        - --proxy-mode=iptables
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: ssl-certs-host
+          readOnly: true
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+          readOnly: true
+      hostNetwork: true
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      volumes:
+      - hostPath:
+          path: /usr/share/ca-certificates
+        name: ssl-certs-host
+      - name: etc-kubernetes
+        hostPath:
+          path: /etc/kubernetes

--- a/terraform/resources/manifests/kube-scheduler-disruption.yaml
+++ b/terraform/resources/manifests/kube-scheduler-disruption.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      tier: control-plane
+      component: kube-scheduler

--- a/terraform/resources/manifests/kube-scheduler.yaml
+++ b/terraform/resources/manifests/kube-scheduler.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    component: kube-scheduler
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        tier: control-plane
+        component: kube-scheduler
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: tier
+                  operator: In
+                  values:
+                  - control-plane
+                - key: component
+                  operator: In
+                  values:
+                  - kube-scheduler
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: kube-scheduler
+        image: ${hyperkube_image}
+        command:
+        - ./hyperkube
+        - scheduler
+        - --leader-elect=true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10251  # Note: Using default port. Update if --port option is set differently.
+          initialDelaySeconds: 15
+          timeoutSeconds: 15
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule

--- a/terraform/resources/manifests/kube-system-rbac-role-binding.yaml
+++ b/terraform/resources/manifests/kube-system-rbac-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: system:default-sa
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/terraform/resources/manifests/pod-checkpointer.yaml
+++ b/terraform/resources/manifests/pod-checkpointer.yaml
@@ -1,0 +1,58 @@
+apiVersion: "extensions/v1beta1"
+kind: DaemonSet
+metadata:
+  name: pod-checkpointer
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    component: pod-checkpointer
+spec:
+  template:
+    metadata:
+      labels:
+        tier: control-plane
+        component: pod-checkpointer
+      annotations:
+        checkpointer.alpha.coreos.com/checkpoint: "true"
+    spec:
+      containers:
+      - name: checkpoint
+        image: quay.io/coreos/pod-checkpointer:2cad4cac4186611a79de1969e3ea4924f02f459e
+        command:
+        - /checkpoint
+        - --v=4
+        - --lock-file=/var/run/lock/pod-checkpointer.lock
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        imagePullPolicy: Always
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: etc-kubernetes
+        - mountPath: /var/run
+          name: var-run
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      restartPolicy: Always
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      volumes:
+      - name: etc-kubernetes
+        hostPath:
+          path: /etc/kubernetes
+      - name: var-run
+        hostPath:
+          path: /var/run

--- a/terraform/resources/user-kubeconfig
+++ b/terraform/resources/user-kubeconfig
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: ${name}-cluster
+  cluster:
+    server: ${server}
+    certificate-authority-data: ${ca_cert}
+users:
+- name: ${name}-user
+  user:
+    client-certificate-data: ${kubelet_cert}
+    client-key-data: ${kubelet_key}
+contexts:
+- name: ${name}-context
+  context:
+    cluster: ${name}-cluster
+    user: ${name}-user

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,4 @@
+cluster_name = "example"
+api_servers = ["node1.example.com"]
+etcd_servers = ["http://127.0.0.1:2379"]
+asset_dir = "/home/core/clusters/mycluster"

--- a/terraform/tls.tf
+++ b/terraform/tls.tf
@@ -1,0 +1,165 @@
+# NOTE: Across this module, the following syntax is used at various places:
+#   `"${var.ca_certificate == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key}"`
+#
+# Due to https://github.com/hashicorp/hil/issues/50, both sides of conditions
+# are evaluated, until one of them is discarded. Unfortunately, the
+# `{tls_private_key/tls_self_signed_cert}.kube-ca` resources are created
+# conditionally and might not be present - in which case an error is
+# generated. Because a `count` is used on these ressources, the resources can be
+# referenced as lists with the `.*` notation, and arrays are allowed to be
+# empty. The `join()` interpolation function is then used to cast them back to
+# a string. Since `count` can only be 0 or 1, the returned value is either empty
+# (and discarded anyways) or the desired value.
+
+# Kubernetes CA (tls/{ca.crt,ca.key})
+resource "tls_private_key" "kube-ca" {
+  count = "${var.ca_certificate == "" ? 1 : 0}"
+
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+resource "tls_self_signed_cert" "kube-ca" {
+  count = "${var.ca_certificate == "" ? 1 : 0}"
+
+  key_algorithm   = "${tls_private_key.kube-ca.algorithm}"
+  private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
+
+  subject {
+    common_name  = "kube-ca"
+    organization = "bootkube"
+  }
+
+  is_ca_certificate     = true
+  validity_period_hours = 8760
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "cert_signing",
+  ]
+}
+
+resource "local_file" "kube-ca-key" {
+  content  = "${var.ca_certificate == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key}"
+  filename = "${var.asset_dir}/tls/ca.key"
+}
+
+resource "local_file" "kube-ca-crt" {
+  content  = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate}"
+  filename = "${var.asset_dir}/tls/ca.crt"
+}
+
+# Kubernetes API Server (tls/{apiserver.key,apiserver.crt})
+resource "tls_private_key" "apiserver" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+resource "tls_cert_request" "apiserver" {
+  key_algorithm   = "${tls_private_key.apiserver.algorithm}"
+  private_key_pem = "${tls_private_key.apiserver.private_key_pem}"
+
+  subject {
+    common_name  = "kube-apiserver"
+    organization = "kube-master"
+  }
+
+  dns_names = [
+    "${var.api_servers}",
+    "kubernetes",
+    "kubernetes.default",
+    "kubernetes.default.svc",
+    "kubernetes.default.svc.cluster.local",
+  ]
+
+  ip_addresses = [
+    "${var.kube_apiserver_service_ip}",
+  ]
+}
+
+resource "tls_locally_signed_cert" "apiserver" {
+  cert_request_pem = "${tls_cert_request.apiserver.cert_request_pem}"
+
+  ca_key_algorithm   = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.key_algorithm) : var.ca_key_alg}"
+  ca_private_key_pem = "${var.ca_certificate == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key}"
+  ca_cert_pem        = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem): var.ca_certificate}"
+
+  validity_period_hours = 8760
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+    "client_auth",
+  ]
+}
+
+resource "local_file" "apiserver-key" {
+  content  = "${tls_private_key.apiserver.private_key_pem}"
+  filename = "${var.asset_dir}/tls/apiserver.key"
+}
+
+resource "local_file" "apiserver-crt" {
+  content  = "${tls_locally_signed_cert.apiserver.cert_pem}"
+  filename = "${var.asset_dir}/tls/apiserver.crt"
+}
+
+# Kubernete's Service Account (tls/{service-account.key,service-account.pub})
+resource "tls_private_key" "service-account" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+resource "local_file" "service-account-key" {
+  content  = "${tls_private_key.service-account.private_key_pem}"
+  filename = "${var.asset_dir}/tls/service-account.key"
+}
+
+resource "local_file" "service-account-crt" {
+  content  = "${tls_private_key.service-account.public_key_pem}"
+  filename = "${var.asset_dir}/tls/service-account.pub"
+}
+
+# Kubelet
+resource "tls_private_key" "kubelet" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+resource "tls_cert_request" "kubelet" {
+  key_algorithm   = "${tls_private_key.kubelet.algorithm}"
+  private_key_pem = "${tls_private_key.kubelet.private_key_pem}"
+
+  subject {
+    common_name  = "kubelet"
+    organization = "system:masters"
+  }
+}
+
+resource "tls_locally_signed_cert" "kubelet" {
+  cert_request_pem = "${tls_cert_request.kubelet.cert_request_pem}"
+
+  ca_key_algorithm   = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.key_algorithm) : var.ca_key_alg}"
+  ca_private_key_pem = "${var.ca_certificate == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key}"
+  ca_cert_pem        = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate}"
+
+  validity_period_hours = 8760
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+    "client_auth",
+  ]
+}
+
+resource "local_file" "kubelet-key" {
+  content  = "${tls_private_key.kubelet.private_key_pem}"
+  filename = "${var.asset_dir}/tls/kubelet.key"
+}
+
+resource "local_file" "kubelet-crt" {
+  content  = "${tls_locally_signed_cert.kubelet.cert_pem}"
+  filename = "${var.asset_dir}/tls/kubelet.crt"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,77 @@
+variable "cluster_name" {
+  description = "Cluster name"
+  type        = "string"
+}
+
+variable "api_servers" {
+  description = "URL used to reach kube-apiserver"
+  type        = "list"
+}
+
+variable "etcd_servers" {
+  description = "List of etcd server URLs including protocol, host, and port"
+  type        = "list"
+}
+
+variable "asset_dir" {
+  description = "Output path where generated assets should be placed (contains secrets)"
+  type        = "string"
+}
+
+variable "cloud_provider" {
+  description = "The provider for cloud services (empty string for no provider)"
+  type        = "string"
+  default     = ""
+}
+
+variable "pod_cidr" {
+  description = "CIDR IP range to assign Kubernetes pods"
+  type        = "string"
+  default     = "10.2.0.0/16"
+}
+
+variable "service_cidr" {
+  description = "CIDR IP range to assign Kubernetes services"
+  type        = "string"
+  default     = "10.3.0.0/24"
+}
+
+variable "container_images" {
+  description = "Container images to use"
+  type        = "map"
+
+  // Only template images which are used more than once
+  default = {
+    hyperkube = "quay.io/coreos/hyperkube:v1.6.2_coreos.0"
+  }
+}
+
+variable "kube_apiserver_service_ip" {
+  description = "Kubernetes service IP for kube-apiserver (must be within service_cidr)"
+  type        = "string"
+  default     = "10.3.0.1"
+}
+
+variable "kube_dns_service_ip" {
+  description = "Kubernetes service IP for kube-dns (must be within server_cidr)"
+  type        = "string"
+  default     = "10.3.0.10"
+}
+
+variable "ca_certificate" {
+  description = "Existing PEM-encoded CA certificate (generated if blank)"
+  type        = "string"
+  default     = ""
+}
+
+variable "ca_key_alg" {
+  description = "Algorithm used to generate ca_key (required if ca_cert is specified)"
+  type        = "string"
+  default     = "RSA"
+}
+
+variable "ca_private_key" {
+  description = "Existing Certificate Authority private key (required if ca_certificate is set)"
+  type        = "string"
+  default     = ""
+}


### PR DESCRIPTION
This terraform module generates bootkube assets which aim to provide the same variables, defaults, features, and generated output that the command line `bootkube render` does. In practical terms, terraform users can use the module via

```
terraform apply
```

to do the equivalent of:

```
bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --etcd-servers=http://127.0.0.1:2379
```

### Why

Supporting a module like allows vanilla bootkube clusters to be automated and tested with `terraform apply`. It unlocks generating assets as part of the apply (as opposed to installing bootkube locally) and using those assets in post-processing (such as copying the assets to a controller).

It will be directly useful for `bootkube` GCE/AWS testing and `matchbox` bare-metal examples.

### TODO

Note, this module does not yet have feature parity with the bootkube binary.

* Experimental manifests
* etcd TLS
* Self-hosted etcd