### PR TITLE
hack/terraform-quickstart: initial commit

### DIFF
--- a/hack/terraform-quickstart/README.md
+++ b/hack/terraform-quickstart/README.md
@@ -1,0 +1,20 @@
+## Terraform-quickstart
+This directory provides a basic way to use terraform to setup compute resources on AWS. It was written with testing in mind.
+
+Prerequisites:
+ - terraform 
+ - bootkube binary built from the repo root
+
+To start a cluster first fill out the terraform.tfvars.example with the needed secrets and rename it to terraform.tfvars. Then:
+
+```
+terraform plan
+terraform apply
+./start-cluster.sh
+```
+
+To destroy a cluster:
+
+```
+terraform destroy
+```

--- a/hack/terraform-quickstart/main.tf
+++ b/hack/terraform-quickstart/main.tf
@@ -1,0 +1,50 @@
+provider "aws" {
+  access_key = "${var.access_key_id}"
+  secret_key = "${var.access_key}"
+  region     = "${var.region}"
+}
+
+resource "aws_instance" "bootstrap_node" {
+  ami           = "${data.aws_ami.coreos_ami.image_id}"
+  instance_type = "m3.medium"
+  key_name      = "${var.ssh_key}"
+
+  tags {
+    Name = "${var.instance_tags}"
+  }
+}
+
+resource "aws_instance" "worker_node" {
+  ami           = "${data.aws_ami.coreos_ami.image_id}"
+  instance_type = "m3.medium"
+  key_name      = "${var.ssh_key}"
+  count         = "${var.num_workers}"
+
+  tags {
+    Name = "${var.instance_tags}"
+  }
+}
+
+data "aws_ami" "coreos_ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["CoreOS-stable-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "owner-id"
+    values = ["595879546273"]
+  }
+}

--- a/hack/terraform-quickstart/outputs.tf
+++ b/hack/terraform-quickstart/outputs.tf
@@ -1,0 +1,11 @@
+output "bootstrap_node_ip" {
+  value = "${aws_instance.bootstrap_node.public_ip}"
+}
+
+output "worker_ips" {
+  value = ["${aws_instance.worker_node.*.public_ip}"]
+}
+
+output "self_host_etcd" {
+  value = "${var.self_host_etcd}"
+}

--- a/hack/terraform-quickstart/start-cluster.sh
+++ b/hack/terraform-quickstart/start-cluster.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+export BOOTSTRAP_IP=`terraform output bootstrap_node_ip`
+export WORKER_IPS=`terraform output -json worker_ips | jq -r '.value[]'`
+export SELF_HOST_ETCD=`terraform output self_host_etcd`
+export SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+
+cd ../quickstart
+./init-master.sh $BOOTSTRAP_IP
+
+for IP in $WORKER_IPS
+do
+  ./init-worker.sh $IP cluster/auth/kubeconfig
+done

--- a/hack/terraform-quickstart/terraform.tfvars.example
+++ b/hack/terraform-quickstart/terraform.tfvars.example
@@ -1,0 +1,5 @@
+access_key_id = ""
+access_key = ""
+instance_tags = "bootkube_example_terraform"
+ssh_key = ""
+

--- a/hack/terraform-quickstart/variables.tf
+++ b/hack/terraform-quickstart/variables.tf
@@ -1,0 +1,34 @@
+variable "access_key_id" {
+  type = "string"
+}
+
+variable "access_key" {
+  type = "string"
+}
+
+variable "ssh_key" {
+  description = "aws ssh key"
+  type        = "string"
+}
+
+variable "instance_tags" {
+  description = "Name all instances behind a single tag based on who/what is running terraform"
+  type        = "string"
+}
+
+variable "self_host_etcd" {
+  type    = "string"
+  default = "true"
+}
+
+variable "num_workers" {
+  description = "number of worker nodes"
+  type        = "string"
+  default     = "1"
+}
+
+variable "region" {
+  description = "aws region"
+  type        = "string"
+  default     = "us-east-1"
+}


### PR DESCRIPTION
This adds a basic way to use terraform to setup AWS compute along with the
quickstart scripts to initiate a cluster. This is designed for forming
the basis for test setup.