### PR TITLE
Preliminary recovery command for bootkube.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ bootkube start --asset-dir=my-cluster
 
 ### Recover a downed cluster
 
-In the case of a partial or total control plane outage (i.e. due to lost master nodes) an experimental `recover` command can extract and write manifests from a backup location. These manifests can then be used by the `start` to reboot the cluster. Currently recovery from a running etcd cluster is the only supported method.
+In the case of a partial or total control plane outage (i.e. due to lost master nodes) an experimental `recover` command can extract and write manifests from a backup location. These manifests can then be used by the `start` command to reboot the cluster. Currently recovery from an external running etcd cluster is the only supported method.
 
 To see available options, run:
 
@@ -72,7 +72,7 @@ Example:
 bootkube recover --asset-dir=recovered --etcd-servers=http://127.0.0.1:2379 --kubeconfig=/etc/kubernetes/kubeconfig
 ```
 
-For a complete recovery example please see the [hack/multi-node/bootkube-recover](hack/multi-node/bootkube-recover) script.
+For a complete recovery example please see the [hack/multi-node/bootkube-test-recovery](hack/multi-node/bootkube-test-recovery) script.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ If you are interested in the design and details [see the Kubernetes self-hosted 
 
 ## Usage
 
-Bootkube has two main commands: `render` and `start`
+Bootkube has two main commands: `render` and `start`.
+
+There is a third, experimental command `recover` which can help reboot a downed cluster (see below).
 
 ### Render assets
 
@@ -53,6 +55,24 @@ Example:
 ```
 bootkube start --asset-dir=my-cluster
 ```
+
+### Recover a downed cluster
+
+In the case of a partial or total control plane outage (i.e. due to lost master nodes) an experimental `recover` command can extract and write manifests from a backup location. These manifests can then be used by the `start` to reboot the cluster. Currently recovery from a running etcd cluster is the only supported method.
+
+To see available options, run:
+
+```
+bootkube recover --help
+```
+
+Example:
+
+```
+bootkube recover --asset-dir=recovered --etcd-servers=http://127.0.0.1:2379 --kubeconfig=/etc/kubernetes/kubeconfig
+```
+
+For a complete recovery example please see the [hack/multi-node/bootkube-recover](hack/multi-node/bootkube-recover) script.
 
 ## Building
 

--- a/cmd/bootkube/recover.go
+++ b/cmd/bootkube/recover.go
@@ -11,8 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/etcd/clientv3"
 	"github.com/kubernetes-incubator/bootkube/pkg/recovery"
+
+	"github.com/coreos/etcd/clientv3"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +44,7 @@ func init() {
 	cmdRecover.Flags().StringVar(&recoverOpts.etcdCAPath, "etcd-ca-path", "", "Path to an existing PEM encoded CA that will be used for TLS-enabled communication between the apiserver and etcd. Must be used in conjunction with --etcd-certificate-path and --etcd-private-key-path, and must have etcd configured to use TLS with matching secrets.")
 	cmdRecover.Flags().StringVar(&recoverOpts.etcdCertificatePath, "etcd-certificate-path", "", "Path to an existing certificate that will be used for TLS-enabled communication between the apiserver and etcd. Must be used in conjunction with --etcd-ca-path and --etcd-private-key-path, and must have etcd configured to use TLS with matching secrets.")
 	cmdRecover.Flags().StringVar(&recoverOpts.etcdPrivateKeyPath, "etcd-private-key-path", "", "Path to an existing private key that will be used for TLS-enabled communication between the apiserver and etcd. Must be used in conjunction with --etcd-ca-path and --etcd-certificate-path, and must have etcd configured to use TLS with matching secrets.")
-	cmdRecover.Flags().StringVar(&recoverOpts.etcdServers, "etcd-servers", "", "List of etcd servers URLs including host:port, comma separated. Cannot be specified with --etcd-data-dir.")
+	cmdRecover.Flags().StringVar(&recoverOpts.etcdServers, "etcd-servers", "", "List of etcd servers URLs including host:port, comma separated.")
 	cmdRecover.Flags().StringVar(&recoverOpts.etcdPrefix, "etcd-prefix", "/registry", "Path prefix to Kubernetes cluster data in etcd.")
 	cmdRecover.Flags().StringVar(&recoverOpts.kubeConfigPath, "kubeconfig", "", "Path to kubeconfig for communicating with the cluster.")
 }
@@ -67,16 +68,16 @@ func runCmdRecover(cmd *cobra.Command, args []string) error {
 
 func validateRecoverOpts(cmd *cobra.Command, args []string) error {
 	if recoverOpts.assetDir == "" {
-		return errors.New("Missing required flag: --asset-dir")
+		return errors.New("missing required flag: --asset-dir")
 	}
 	if (recoverOpts.etcdCAPath != "" || recoverOpts.etcdCertificatePath != "" || recoverOpts.etcdPrivateKeyPath != "") && (recoverOpts.etcdCAPath == "" || recoverOpts.etcdCertificatePath == "" || recoverOpts.etcdPrivateKeyPath == "") {
-		return errors.New("You must specify either all or none of --etcd-ca-path, --etcd-certificate-path, and --etcd-private-key-path")
+		return errors.New("you must specify either all or none of --etcd-ca-path, --etcd-certificate-path, and --etcd-private-key-path")
 	}
 	if recoverOpts.etcdPrefix == "" {
-		return errors.New("Missing required flag: --etcd-prefix")
+		return errors.New("missing required flag: --etcd-prefix")
 	}
 	if recoverOpts.kubeConfigPath == "" {
-		return errors.New("Missing required flag: --kubeconfig")
+		return errors.New("missing required flag: --kubeconfig")
 	}
 	return nil
 }

--- a/cmd/bootkube/recover.go
+++ b/cmd/bootkube/recover.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/kubernetes-incubator/bootkube/pkg/recovery"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdRecover = &cobra.Command{
+		Use:          "recover",
+		Short:        "Recover a control plane from state stored in etcd.",
+		Long:         "",
+		PreRunE:      validateRecoverOpts,
+		RunE:         runCmdRecover,
+		SilenceUsage: true,
+	}
+
+	recoverOpts struct {
+		assetDir            string
+		etcdCAPath          string
+		etcdCertificatePath string
+		etcdPrivateKeyPath  string
+		etcdServers         string
+		etcdPrefix          string
+		kubeConfigPath      string
+	}
+)
+
+func init() {
+	cmdRoot.AddCommand(cmdRecover)
+	cmdRecover.Flags().StringVar(&recoverOpts.assetDir, "asset-dir", "", "Output path for writing recovered cluster assets.")
+	cmdRecover.Flags().StringVar(&recoverOpts.etcdCAPath, "etcd-ca-path", "", "Path to an existing PEM encoded CA that will be used for TLS-enabled communication between the apiserver and etcd. Must be used in conjunction with --etcd-certificate-path and --etcd-private-key-path, and must have etcd configured to use TLS with matching secrets.")
+	cmdRecover.Flags().StringVar(&recoverOpts.etcdCertificatePath, "etcd-certificate-path", "", "Path to an existing certificate that will be used for TLS-enabled communication between the apiserver and etcd. Must be used in conjunction with --etcd-ca-path and --etcd-private-key-path, and must have etcd configured to use TLS with matching secrets.")
+	cmdRecover.Flags().StringVar(&recoverOpts.etcdPrivateKeyPath, "etcd-private-key-path", "", "Path to an existing private key that will be used for TLS-enabled communication between the apiserver and etcd. Must be used in conjunction with --etcd-ca-path and --etcd-certificate-path, and must have etcd configured to use TLS with matching secrets.")
+	cmdRecover.Flags().StringVar(&recoverOpts.etcdServers, "etcd-servers", "", "List of etcd servers URLs including host:port, comma separated. Cannot be specified with --etcd-data-dir.")
+	cmdRecover.Flags().StringVar(&recoverOpts.etcdPrefix, "etcd-prefix", "/registry", "Path prefix to Kubernetes cluster data in etcd.")
+	cmdRecover.Flags().StringVar(&recoverOpts.kubeConfigPath, "kubeconfig", "", "Path to kubeconfig for communicating with the cluster.")
+}
+
+func runCmdRecover(cmd *cobra.Command, args []string) error {
+	var err error
+	recoverOpts.kubeConfigPath, err = filepath.Abs(recoverOpts.kubeConfigPath)
+	if err != nil {
+		return err
+	}
+	etcdClient, err := createEtcdClient()
+	if err != nil {
+		return err
+	}
+	as, err := recovery.Recover(context.Background(), recovery.NewEtcdBackend(etcdClient, recoverOpts.etcdPrefix), recoverOpts.kubeConfigPath)
+	if err != nil {
+		return err
+	}
+	return as.WriteFiles(recoverOpts.assetDir)
+}
+
+func validateRecoverOpts(cmd *cobra.Command, args []string) error {
+	if recoverOpts.assetDir == "" {
+		return errors.New("Missing required flag: --asset-dir")
+	}
+	if (recoverOpts.etcdCAPath != "" || recoverOpts.etcdCertificatePath != "" || recoverOpts.etcdPrivateKeyPath != "") && (recoverOpts.etcdCAPath == "" || recoverOpts.etcdCertificatePath == "" || recoverOpts.etcdPrivateKeyPath == "") {
+		return errors.New("You must specify either all or none of --etcd-ca-path, --etcd-certificate-path, and --etcd-private-key-path")
+	}
+	if recoverOpts.etcdPrefix == "" {
+		return errors.New("Missing required flag: --etcd-prefix")
+	}
+	if recoverOpts.kubeConfigPath == "" {
+		return errors.New("Missing required flag: --kubeconfig")
+	}
+	return nil
+}
+
+func createEtcdClient() (*clientv3.Client, error) {
+	cfg := clientv3.Config{
+		Endpoints:   strings.Split(recoverOpts.etcdServers, ","),
+		DialTimeout: 5 * time.Second,
+	}
+	if recoverOpts.etcdCAPath != "" {
+		clientCert, err := tls.LoadX509KeyPair(recoverOpts.etcdCertificatePath, recoverOpts.etcdPrivateKeyPath)
+		if err != nil {
+			return nil, err
+		}
+		roots := x509.NewCertPool()
+		etcdCA, err := ioutil.ReadFile(recoverOpts.etcdCAPath)
+		if err != nil {
+			return nil, err
+		}
+		if ok := roots.AppendCertsFromPEM(etcdCA); !ok {
+			return nil, fmt.Errorf("error processing --etcd-ca-file %s", recoverOpts.etcdCAPath)
+		}
+		cfg.TLS = &tls.Config{
+			Certificates: []tls.Certificate{clientCert},
+			RootCAs:      roots,
+		}
+	}
+	return clientv3.New(cfg)
+}

--- a/hack/multi-node/bootkube-recover
+++ b/hack/multi-node/bootkube-recover
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GLOG_v=${GLOG_v:-1}
+HOST=${HOST:-c1}
+SELF_HOST_ETCD=${SELF_HOST_ETCD:-false}
+
+if [ ${SELF_HOST_ETCD} = "true" ]; then
+  echo "ERROR: bootkube-recover does not currently support self-hosted etcd."
+  exit 1
+fi
+
+if [ ! -d "cluster" ]; then
+  echo "Need some cluster assets to perform recovery; try running bootkube-up."
+fi
+
+echo
+echo "Destroying and re-creating the master node..."
+echo
+
+vagrant destroy -f $HOST
+vagrant up $HOST
+
+echo
+echo "As you can see, the cluster is now dead:"
+echo
+
+set -x
+! kubectl --kubeconfig=cluster/auth/kubeconfig get nodes
+{ set +x; } 2>/dev/null
+
+echo
+echo "Recovering the control plane from etcd..."
+echo
+
+scp -q -F ssh_config ../../_output/bin/linux/bootkube cluster/auth/kubeconfig cluster/tls/etcd-* core@$HOST:/home/core
+ssh -q -F ssh_config core@$HOST "GLOG_v=${GLOG_v} /home/core/bootkube recover \
+  --asset-dir=/home/core/recovered \
+  --etcd-ca-path=/home/core/etcd-ca.crt \
+  --etcd-certificate-path=/home/core/etcd-client.crt \
+  --etcd-private-key-path=/home/core/etcd-client.key \
+  --etcd-servers=https://172.17.4.51:2379 \
+  --kubeconfig=/home/core/kubeconfig 2>> /home/core/recovery.log"
+
+echo
+echo "Running bootkube start..."
+echo
+
+ssh -q -F ssh_config core@$HOST "sudo GLOG_v=${GLOG_v} /home/core/bootkube start --asset-dir=/home/core/recovered 2>> /home/core/recovery.log"
+
+echo
+echo "The cluster should now be recovered. You should be able to access the cluster again using:"
+echo "kubectl --kubeconfig=cluster/auth/kubeconfig get nodes"
+echo

--- a/hack/multi-node/bootkube-test-recovery
+++ b/hack/multi-node/bootkube-test-recovery
@@ -5,13 +5,13 @@ GLOG_v=${GLOG_v:-1}
 HOST=${HOST:-c1}
 SELF_HOST_ETCD=${SELF_HOST_ETCD:-false}
 
-if [ ${SELF_HOST_ETCD} = "true" ]; then
-  echo "ERROR: bootkube-recover does not currently support self-hosted etcd."
-  exit 1
-fi
-
 if [ ! -d "cluster" ]; then
   echo "Need some cluster assets to perform recovery; try running bootkube-up."
+fi
+
+if [ -f cluster/bootstrap-manifests/bootstrap-etcd.yaml ]; then
+  echo "ERROR: $(basename $0) does not currently support self-hosted etcd."
+  exit 1
 fi
 
 echo

--- a/pkg/bootkube/bootstrap.go
+++ b/pkg/bootkube/bootstrap.go
@@ -5,68 +5,62 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kubernetes-incubator/bootkube/pkg/asset"
 )
 
-// CreateBootstrapControlPlane seeds static manifests to the kubelet to launch the bootstrap control
-// plane.
-func CreateBootstrapControlPlane(assetDir string, podManifestPath string) error {
-	UserOutput("Running temporary bootstrap control plane...\n")
+type bootstrapControlPlane struct {
+	assetDir        string
+	podManifestPath string
+	ownedManifests  []string
+}
 
+// NewBootstrapControlPlane constructs a new bootstrap control plane object.
+func NewBootstrapControlPlane(assetDir, podManifestPath string) *bootstrapControlPlane {
+	return &bootstrapControlPlane{
+		assetDir:        assetDir,
+		podManifestPath: podManifestPath,
+	}
+}
+
+// Start seeds static manifests to the kubelet to launch the bootstrap control plane.
+// Users should always ensure that Cleanup() is called even in the case of errors.
+func (b *bootstrapControlPlane) Start() error {
+	UserOutput("Starting temporary bootstrap control plane...\n")
 	// Make secrets temporarily available to bootstrap cluster.
 	if err := os.RemoveAll(asset.BootstrapSecretsDir); err != nil {
 		return err
 	}
-	if err := os.Mkdir(asset.BootstrapSecretsDir, os.FileMode(0700)); err != nil {
+	secretsDir := filepath.Join(b.assetDir, asset.AssetPathSecrets)
+	if _, err := copyDirectory(secretsDir, asset.BootstrapSecretsDir, true /* overwrite */); err != nil {
 		return err
 	}
-	secretsDir := filepath.Join(assetDir, asset.AssetPathSecrets)
-	secrets, err := ioutil.ReadDir(secretsDir)
-	if err != nil {
-		return err
-	}
-	for _, secret := range secrets {
-		if err := copyFile(filepath.Join(secretsDir, secret.Name()), filepath.Join(asset.BootstrapSecretsDir, secret.Name()), true); err != nil {
-			return err
-		}
-	}
-
 	// Copy the static manifests to the kubelet's pod manifest path.
-	manifestsDir := filepath.Join(assetDir, asset.AssetPathBootstrapManifests)
-	manifests, err := ioutil.ReadDir(manifestsDir)
-	if err != nil {
-		return err
-	}
-	for _, manifest := range manifests {
-		if err := copyFile(filepath.Join(manifestsDir, manifest.Name()), filepath.Join(podManifestPath, manifest.Name()), false); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	manifestsDir := filepath.Join(b.assetDir, asset.AssetPathBootstrapManifests)
+	ownedManifests, err := copyDirectory(manifestsDir, b.podManifestPath, false /* overwrite */)
+	b.ownedManifests = ownedManifests // always copy in case of partial failure.
+	return err
 }
 
-// CleanupBootstrapControlPlane brings down the bootstrap control plane and cleans up the temporary
+// Teardown brings down the bootstrap control plane and cleans up the temporary manifests and
 // secrets. This function is idempotent.
-func CleanupBootstrapControlPlane(assetDir string, podManifestPath string) error {
-	UserOutput("Cleaning up temporary bootstrap control plane...\n")
-
+func (b *bootstrapControlPlane) Teardown() error {
+	UserOutput("Tearing down temporary bootstrap control plane...\n")
 	if err := os.RemoveAll(asset.BootstrapSecretsDir); err != nil {
 		return err
 	}
-	manifests, err := ioutil.ReadDir(filepath.Join(assetDir, asset.AssetPathBootstrapManifests))
-	if err != nil {
-		return err
-	}
-	for _, manifest := range manifests {
-		if err := os.Remove(filepath.Join(podManifestPath, manifest.Name())); err != nil && !os.IsNotExist(err) {
+	for _, manifest := range b.ownedManifests {
+		if err := os.Remove(manifest); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 	}
+	b.ownedManifests = nil
 	return nil
 }
 
+// copyFile copies a single file from src to dst. Returns an error if overwrite is true and dst
+// exists, or if any I/O error occurs during copying.
 func copyFile(src, dst string, overwrite bool) error {
 	if !overwrite {
 		fi, err := os.Stat(dst)
@@ -82,4 +76,28 @@ func copyFile(src, dst string, overwrite bool) error {
 		return err
 	}
 	return ioutil.WriteFile(dst, data, os.FileMode(0600))
+}
+
+// copyDirectory copies srcDir to dstDir recursively. It returns the paths of files (not
+// directories) that were copied.
+func copyDirectory(srcDir, dstDir string, overwrite bool) ([]string, error) {
+	var copied []string
+	return copied, filepath.Walk(srcDir, func(src string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		dst := filepath.Join(dstDir, strings.TrimPrefix(src, srcDir))
+		if info.IsDir() {
+			err = os.Mkdir(dst, os.FileMode(0700))
+			if os.IsExist(err) {
+				err = nil
+			}
+			return err
+		}
+		if err := copyFile(src, dst, overwrite); err != nil {
+			return err
+		}
+		copied = append(copied, dst)
+		return nil
+	})
 }

--- a/pkg/bootkube/create.go
+++ b/pkg/bootkube/create.go
@@ -2,6 +2,7 @@ package bootkube
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -19,6 +20,11 @@ import (
 )
 
 func CreateAssets(manifestDir string, timeout time.Duration) error {
+	if _, err := os.Stat(manifestDir); os.IsNotExist(err) {
+		UserOutput(fmt.Sprintf("WARNING: %v does not exist, not creating any self-hosted assets.\n", manifestDir))
+		return nil
+	}
+
 	upFn := func() (bool, error) {
 		if err := apiTest(); err != nil {
 			glog.Warningf("Unable to determine api-server readiness: %v", err)

--- a/pkg/recovery/etcd.go
+++ b/pkg/recovery/etcd.go
@@ -51,23 +51,10 @@ func (s *etcdBackend) read(ctx context.Context) (*controlPlane, error) {
 		yamlName:    "deployment",
 		obj:         &cp.deployments,
 	}, {
-		etcdKeyName: "poddisruptionbudgets",
-		yamlName:    "pod-disruption-budget",
-		obj:         &cp.podDisruptionBudgets,
-	}, {
 		etcdKeyName: "secrets",
 		yamlName:    "secret",
 		obj:         &cp.secrets,
-	}, {
-		etcdKeyName: "services/specs",
-		yamlName:    "service",
-		obj:         &cp.services,
-	}, {
-		etcdKeyName: "serviceaccounts",
-		yamlName:    "service-account",
-		obj:         &cp.serviceAccounts,
-	},
-	} {
+	}} {
 		if err := s.list(ctx, r.etcdKeyName, r.obj); err != nil {
 			return nil, err
 		}

--- a/pkg/recovery/etcd.go
+++ b/pkg/recovery/etcd.go
@@ -1,0 +1,147 @@
+// The etcd backend fetches control plane objects directly from etcd. This is adapted heavily from
+// kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go.
+
+package recovery
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"reflect"
+	"strings"
+
+	"github.com/coreos/etcd/clientv3"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/pkg/api"
+)
+
+// EtcdBackend is a backend that extracts a controlPlane from an etcd instance.
+type EtcdBackend struct {
+	client     *clientv3.Client
+	decoder    runtime.Decoder
+	pathPrefix string
+}
+
+// NewEtcdBackend constructs a new EtcdBackend for the given client and pathPrefix.
+func NewEtcdBackend(client *clientv3.Client, pathPrefix string) Backend {
+	return &EtcdBackend{
+		client:     client,
+		decoder:    api.Codecs.UniversalDecoder(),
+		pathPrefix: pathPrefix,
+	}
+}
+
+// read implements Backend.read().
+func (s *EtcdBackend) read(ctx context.Context) (*controlPlane, error) {
+	cp := &controlPlane{}
+	for _, r := range []struct {
+		etcdName string
+		yamlName string
+		obj      runtime.Object
+	}{{
+		etcdName: "configmaps",
+		yamlName: "config-map",
+		obj:      &cp.configMaps,
+	}, {
+		etcdName: "daemonsets",
+		yamlName: "daemonset",
+		obj:      &cp.daemonSets,
+	}, {
+		etcdName: "deployments",
+		yamlName: "deployment",
+		obj:      &cp.deployments,
+	}, {
+		etcdName: "poddisruptionbudgets",
+		yamlName: "pod-disruption-budget",
+		obj:      &cp.podDisruptionBudgets,
+	}, {
+		etcdName: "secrets",
+		yamlName: "secret",
+		obj:      &cp.secrets,
+	}, {
+		etcdName: "services/specs",
+		yamlName: "service",
+		obj:      &cp.services,
+	}, {
+		etcdName: "serviceaccounts",
+		yamlName: "service-account",
+		obj:      &cp.serviceAccounts,
+	},
+	} {
+		if err := s.list(ctx, r.etcdName, r.obj); err != nil {
+			return nil, err
+		}
+	}
+	return cp, nil
+}
+
+// get fetches a single runtime.Object with key `key` from etcd.
+func (s *EtcdBackend) get(ctx context.Context, key string, out runtime.Object, ignoreNotFound bool) error {
+	key = path.Join(s.pathPrefix, key, api.NamespaceSystem)
+	getResp, err := s.client.KV.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	if len(getResp.Kvs) == 0 {
+		if ignoreNotFound {
+			return runtime.SetZeroValue(out)
+		}
+		return fmt.Errorf("key not found: %s", key)
+	}
+	kv := getResp.Kvs[0]
+	return decode(s.decoder, kv.Value, out)
+}
+
+// list fetches a list runtime.Object from etcd located at key prefix `key`.
+func (s *EtcdBackend) list(ctx context.Context, key string, listObj runtime.Object) error {
+	listPtr, err := meta.GetItemsPtr(listObj)
+	if err != nil {
+		return err
+	}
+	key = path.Join(s.pathPrefix, key, api.NamespaceSystem)
+	if !strings.HasSuffix(key, "/") {
+		key += "/"
+	}
+	getResp, err := s.client.KV.Get(ctx, key, clientv3.WithPrefix())
+	if err != nil {
+		return err
+	}
+
+	elems := make([][]byte, len(getResp.Kvs))
+	for i, kv := range getResp.Kvs {
+		elems[i] = kv.Value
+	}
+	return decodeList(elems, listPtr, s.decoder)
+}
+
+// decode decodes value of bytes into object.
+func decode(decoder runtime.Decoder, value []byte, objPtr runtime.Object) error {
+	if _, err := conversion.EnforcePtr(objPtr); err != nil {
+		return fmt.Errorf("objPtr must be pointer, got: %T", objPtr)
+	}
+	_, _, err := decoder.Decode(value, nil, objPtr)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// decodeList decodes a list of values into a list of objects.
+func decodeList(elems [][]byte, listPtr interface{}, decoder runtime.Decoder) error {
+	v, err := conversion.EnforcePtr(listPtr)
+	if err != nil || v.Kind() != reflect.Slice {
+		return fmt.Errorf("listPtr must be pointer to slice, got: %T", listPtr)
+	}
+	for _, elem := range elems {
+		obj, _, err := decoder.Decode(elem, nil, reflect.New(v.Type().Elem()).Interface().(runtime.Object))
+		if err != nil {
+			return err
+		}
+		v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))
+	}
+	return nil
+}

--- a/pkg/recovery/recover.go
+++ b/pkg/recovery/recover.go
@@ -1,0 +1,332 @@
+// Package recovery provides tooling to help with control plane disaster recovery. Recover() uses a
+// Backend to extract the control plane from a store, such as etcd, and use those to write assets
+// that can be used by `bootkube start` to reboot the control plane.
+//
+// The recovery tool assumes that the component names for the control plane elements are the same as
+// what is output by `bootkube render`. The `bootkube start` command also makes this assumption.
+// It also assumes that kubeconfig on the kubelet is located at /etc/kubernetes/kubeconfig, though
+// that can be changed in the bootstrap manifests that are rendered.
+package recovery
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"reflect"
+	"strings"
+
+	"github.com/ghodss/yaml"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	policyv1beta1 "k8s.io/client-go/pkg/apis/policy/v1beta1"
+
+	"github.com/kubernetes-incubator/bootkube/pkg/asset"
+)
+
+const (
+	kubeletKubeConfigPath = "/etc/kubernetes/kubeconfig"
+)
+
+var (
+	// bootstrapComponents contains the names of the components that we will extract to construct the
+	// temporary bootstrap control plane.
+	bootstrapComponents = map[string]bool{
+		"kube-apiserver":          true,
+		"kube-controller-manager": true,
+		"kube-scheduler":          true,
+		"pod-checkpointer":        true,
+	}
+	// kubeConfigComponents contains the names of the bootstrap pods that need to add a --kubeconfig
+	// flag to run in non-self-hosted mode.
+	kubeConfigComponents = map[string]bool{
+		"kube-controller-manager": true,
+		"kube-scheduler":          true,
+	}
+	// typeMetas contains a mapping from API object types to the TypeMeta struct that should be
+	// populated for them when they are serialized.
+	typeMetas    = make(map[reflect.Type]metav1.TypeMeta)
+	metaAccessor = meta.NewAccessor()
+)
+
+func init() {
+	addTypeMeta := func(obj runtime.Object, gv schema.GroupVersion) {
+		t := reflect.TypeOf(obj)
+		typeMetas[t] = metav1.TypeMeta{
+			APIVersion: gv.String(),
+			Kind:       t.Elem().Name(),
+		}
+	}
+	addTypeMeta(&v1.ConfigMap{}, v1.SchemeGroupVersion)
+	addTypeMeta(&v1beta1.DaemonSet{}, v1beta1.SchemeGroupVersion)
+	addTypeMeta(&v1beta1.Deployment{}, v1beta1.SchemeGroupVersion)
+	addTypeMeta(&policyv1beta1.PodDisruptionBudget{}, policyv1beta1.SchemeGroupVersion)
+	addTypeMeta(&v1.Pod{}, v1.SchemeGroupVersion)
+	addTypeMeta(&v1.Secret{}, v1.SchemeGroupVersion)
+	addTypeMeta(&v1.Service{}, v1.SchemeGroupVersion)
+	addTypeMeta(&v1.ServiceAccount{}, v1.SchemeGroupVersion)
+}
+
+// Backend defines an interface for any backend that can populate a controlPlane struct.
+type Backend interface {
+	read(context.Context) (*controlPlane, error)
+}
+
+// controlPlane holds the control plane objects that are recovered from a backend.
+type controlPlane struct {
+	configMaps           v1.ConfigMapList
+	daemonSets           v1beta1.DaemonSetList
+	deployments          v1beta1.DeploymentList
+	podDisruptionBudgets policyv1beta1.PodDisruptionBudgetList
+	secrets              v1.SecretList
+	services             v1.ServiceList
+	serviceAccounts      v1.ServiceAccountList
+}
+
+// Recover recovers a control plane using the provided backend and kubeConfigPath, returning assets
+// for the existing control plane and a bootstrap control plane that can be used with `bootkube
+// start` to re-bootstrap the control plane.
+func Recover(ctx context.Context, backend Backend, kubeConfigPath string) (asset.Assets, error) {
+	cp, err := backend.read(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	as, err := cp.renderSelfHosted()
+	if err != nil {
+		return nil, err
+	}
+
+	bs, err := cp.renderBootstrap(kubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	as = append(as, bs...)
+
+	ks, err := renderKubeConfig(kubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	as = append(as, ks...)
+
+	return as, nil
+}
+
+// renderSelfHosted returns assets for the self-hosted control plane objects. These are output
+// without modification from what the backend recovered.
+func (cp *controlPlane) renderSelfHosted() (asset.Assets, error) {
+	var as asset.Assets
+	if objAs, err := serializeListObjToYAML(&cp.configMaps); err != nil {
+		return nil, err
+	} else {
+		as = append(as, objAs...)
+	}
+	if objAs, err := serializeListObjToYAML(&cp.daemonSets); err != nil {
+		return nil, err
+	} else {
+		as = append(as, objAs...)
+	}
+	if objAs, err := serializeListObjToYAML(&cp.deployments); err != nil {
+		return nil, err
+	} else {
+		as = append(as, objAs...)
+	}
+	if objAs, err := serializeListObjToYAML(&cp.podDisruptionBudgets); err != nil {
+		return nil, err
+	} else {
+		as = append(as, objAs...)
+	}
+	if objAs, err := serializeListObjToYAML(&cp.secrets); err != nil {
+		return nil, err
+	} else {
+		as = append(as, objAs...)
+	}
+	if objAs, err := serializeListObjToYAML(&cp.services); err != nil {
+		return nil, err
+	} else {
+		as = append(as, objAs...)
+	}
+	if objAs, err := serializeListObjToYAML(&cp.serviceAccounts); err != nil {
+		return nil, err
+	} else {
+		as = append(as, objAs...)
+	}
+	return as, nil
+}
+
+// renderBootstrap returns assets for a bootstrap control plane that can be used with `bootkube
+// start` to re-bootstrap a control plane. These assets are derived from the self-hosted control
+// plane that was recovered by the backend, but modified for direct injection into a kubelet.
+func (cp *controlPlane) renderBootstrap(kubeConfigPath string) (asset.Assets, error) {
+	// Extract pod specs from daemonsets and deployments.
+	var pods []*v1.Pod
+	for _, ds := range cp.daemonSets.Items {
+		if componentName := ds.Labels["component"]; bootstrapComponents[componentName] {
+			pod := &v1.Pod{Spec: ds.Spec.Template.Spec}
+			if err := setBootstrapPodMetadata(pod, ds.ObjectMeta); err != nil {
+				return nil, err
+			}
+			pods = append(pods, pod)
+		}
+	}
+	for _, ds := range cp.deployments.Items {
+		if componentName := ds.Labels["component"]; bootstrapComponents[componentName] {
+			pod := &v1.Pod{Spec: ds.Spec.Template.Spec}
+			if err := setBootstrapPodMetadata(pod, ds.ObjectMeta); err != nil {
+				return nil, err
+			}
+			pods = append(pods, pod)
+		}
+	}
+
+	// Fix up the pods.
+	var as asset.Assets
+	requiredSecrets := make(map[string]bool)
+	for _, pod := range pods {
+		// Change secret volumes to point to file mounts.
+		for i := range pod.Spec.Volumes {
+			vol := &pod.Spec.Volumes[i]
+			if vol.Secret != nil {
+				requiredSecrets[vol.Secret.SecretName] = true
+				secretPath := path.Join(asset.BootstrapSecretsDir, vol.Secret.SecretName)
+				vol.HostPath = &v1.HostPathVolumeSource{Path: secretPath}
+				vol.Secret = nil
+			}
+		}
+
+		// Make sure the kubeconfig is in the commandline.
+		for i, _ := range pod.Spec.Containers {
+			cn := &pod.Spec.Containers[i]
+			// Assumes the bootkube naming convention is used. Could also just make sure the image uses hyperkube.
+			if kubeConfigComponents[cn.Name] {
+				cn.Command = append(cn.Command, "--kubeconfig=/kubeconfig/kubeconfig")
+				cn.VolumeMounts = append(cn.VolumeMounts, v1.VolumeMount{
+					MountPath: "/kubeconfig",
+					Name:      "kubeconfig",
+					ReadOnly:  true,
+				})
+			}
+		}
+
+		// Add a mount for the kubeconfig.
+		pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+			VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: kubeletKubeConfigPath}},
+			Name:         "kubeconfig",
+		})
+
+		// Output the pod definition.
+		a, err := serializeYAML(path.Join(asset.AssetPathBootstrapManifests, pod.Name+".yaml"), pod)
+		if err != nil {
+			return nil, err
+		}
+		as = append(as, a)
+	}
+
+	// Output all the required secrets.
+	for _, secret := range cp.secrets.Items {
+		if requiredSecrets[secret.Name] {
+			for key, data := range secret.Data {
+				as = append(as, asset.Asset{
+					Name: path.Join(asset.AssetPathSecrets, secret.Name, key),
+					Data: data,
+				})
+			}
+			delete(requiredSecrets, secret.Name)
+		}
+	}
+
+	if len(requiredSecrets) > 0 {
+		var missingSecrets []string
+		for secret := range requiredSecrets {
+			missingSecrets = append(missingSecrets, secret)
+		}
+		return nil, fmt.Errorf("failed to extract some required bootstrap secrets: %v", missingSecrets)
+	}
+
+	return as, nil
+}
+
+// renderKubeConfig outputs kubeconfig assets to ensure that the kubeconfig will be rendered to the
+// assetDir for use by `bootkube start`.
+func renderKubeConfig(kubeConfigPath string) (asset.Assets, error) {
+	kubeConfig, err := ioutil.ReadFile(kubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return []asset.Asset{{
+		Name: asset.AssetPathKubeConfig, // used by `bootkube start`.
+		Data: kubeConfig,
+	}}, nil
+}
+
+// setTypeMeta sets the TypeMeta for a runtime.Object.
+// TODO(diegs): find the apimachinery code that does this, and use that instead.
+func setTypeMeta(obj runtime.Object) error {
+	typeMeta, ok := typeMetas[reflect.TypeOf(obj)]
+	if !ok {
+		return fmt.Errorf("don't know about type: %T", obj)
+	}
+	metaAccessor.SetAPIVersion(obj, typeMeta.APIVersion)
+	metaAccessor.SetKind(obj, typeMeta.Kind)
+	return nil
+}
+
+// setBootstrapPodMetadata creates valid metadata for a bootstrap pod. Currently it sets the
+// TypeMeta and Name, Namespace, and Annotations on the ObjectMeta.
+func setBootstrapPodMetadata(pod *v1.Pod, parent metav1.ObjectMeta) error {
+	if err := setTypeMeta(pod); err != nil {
+		return err
+	}
+	pod.ObjectMeta = metav1.ObjectMeta{
+		Annotations: parent.Annotations,
+		Name:        "bootstrap-" + parent.Name,
+		Namespace:   parent.Namespace,
+	}
+	return nil
+}
+
+// serializeListObjToYAML takes a runtime.Object of type 'list', fixes up the metadata of each
+// element, and serializes them to YAML assets using the naming convention `name-kind.yaml`.
+func serializeListObjToYAML(outerObj runtime.Object) (asset.Assets, error) {
+	objList, err := meta.ExtractList(outerObj)
+	if err != nil {
+		return nil, err
+	}
+	var as asset.Assets
+	for _, obj := range objList {
+		if err := setTypeMeta(obj); err != nil {
+			return nil, err
+		}
+		name, err := metaAccessor.Name(obj)
+		if err != nil {
+			return nil, err
+		}
+		kind, err := metaAccessor.Kind(obj)
+		if err != nil {
+			return nil, err
+		}
+		a, err := serializeYAML(path.Join(asset.AssetPathManifests, name+"-"+strings.ToLower(kind)+".yaml"), obj)
+		if err != nil {
+			return nil, err
+		}
+		as = append(as, a)
+	}
+	return as, nil
+}
+
+// serializeYAML serializes a runtime.Object into a YAML asset.
+func serializeYAML(assetName string, obj runtime.Object) (asset.Asset, error) {
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return asset.Asset{}, err
+	}
+	return asset.Asset{
+		Name: assetName,
+		Data: data,
+	}, nil
+}

--- a/pkg/recovery/recover_test.go
+++ b/pkg/recovery/recover_test.go
@@ -1,0 +1,343 @@
+package recovery
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+
+	"github.com/kubernetes-incubator/bootkube/pkg/asset"
+)
+
+var (
+	secretData = []byte("this is very secret")
+
+	cp = &controlPlane{
+		configMaps: v1.ConfigMapList{},
+		daemonSets: v1beta1.DaemonSetList{
+			Items: []v1beta1.DaemonSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver",
+					Namespace: "kube-system",
+					Labels: map[string]string{
+						"tier":    "control-plane",
+						"k8s-app": "kube-apiserver",
+					},
+				},
+				Spec: v1beta1.DaemonSetSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:    "kube-apiserver",
+								Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+								Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
+								VolumeMounts: []v1.VolumeMount{{
+									Name:      "ssl-certs-host",
+									MountPath: "/etc/ssl/certs",
+									ReadOnly:  true,
+								}, {
+									Name:      "secrets",
+									MountPath: "/etc/kubernetes/secrets",
+									ReadOnly:  true,
+								}},
+							}},
+							Volumes: []v1.Volume{{
+								Name:         "ssl-certs-host",
+								VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/usr/share/ca-certificates"}},
+							}, {
+								Name:         "secrets",
+								VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "kube-apiserver"}},
+							}},
+						},
+					},
+				},
+			}},
+		},
+		deployments: v1beta1.DeploymentList{
+			Items: []v1beta1.Deployment{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-scheduler",
+					Namespace: "kube-system",
+					Labels: map[string]string{
+						"tier":    "control-plane",
+						"k8s-app": "kube-scheduler",
+					},
+				},
+				Spec: v1beta1.DeploymentSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:    "kube-scheduler",
+								Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+								Command: []string{"/hyperkube", "scheduler"},
+							}},
+						},
+					},
+				},
+			}},
+		},
+		secrets: v1.SecretList{
+			Items: []v1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver",
+					Namespace: "kube-system",
+				},
+				Data: map[string][]byte{"apiserver.crt": secretData},
+			}},
+		},
+	}
+)
+
+func TestExtractBootstrapPods(t *testing.T) {
+	got, err := extractBootstrapPods(cp.daemonSets.Items, cp.deployments.Items)
+	want := []v1.Pod{{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bootstrap-kube-apiserver",
+			Namespace: "kube-system",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:    "kube-apiserver",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
+				VolumeMounts: []v1.VolumeMount{{
+					Name:      "ssl-certs-host",
+					MountPath: "/etc/ssl/certs",
+					ReadOnly:  true,
+				}, {
+					Name:      "secrets",
+					MountPath: "/etc/kubernetes/secrets",
+					ReadOnly:  true,
+				}},
+			}},
+			Volumes: []v1.Volume{{
+				Name:         "ssl-certs-host",
+				VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/usr/share/ca-certificates"}},
+			}, {
+				Name:         "secrets",
+				VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "kube-apiserver"}},
+			}},
+		},
+	}, {
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bootstrap-kube-scheduler",
+			Namespace: "kube-system",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:    "kube-scheduler",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Command: []string{"/hyperkube", "scheduler"},
+			}},
+		},
+	}}
+	if err != nil {
+		t.Errorf("extractBootstrapPods(%v, %v) = %v, want: %v", cp.daemonSets.Items, cp.deployments.Items, err, nil)
+	} else if !reflect.DeepEqual(got, want) {
+		t.Errorf("extractBootstrapPods(%v, %v) = %v, want: %v", cp.daemonSets.Items, cp.deployments.Items, got, want)
+	}
+}
+
+func TestFixUpBootstrapPods(t *testing.T) {
+	pods := []v1.Pod{{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bootstrap-kube-apiserver",
+			Namespace: "kube-system",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:    "kube-apiserver",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
+				VolumeMounts: []v1.VolumeMount{{
+					Name:      "ssl-certs-host",
+					MountPath: "/etc/ssl/certs",
+					ReadOnly:  true,
+				}, {
+					Name:      "secrets",
+					MountPath: "/etc/kubernetes/secrets",
+					ReadOnly:  true,
+				}},
+			}},
+			Volumes: []v1.Volume{{
+				Name:         "ssl-certs-host",
+				VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/usr/share/ca-certificates"}},
+			}, {
+				Name:         "secrets",
+				VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "kube-apiserver"}},
+			}},
+		},
+	}, {
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bootstrap-kube-scheduler",
+			Namespace: "kube-system",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:    "kube-scheduler",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Command: []string{"/hyperkube", "scheduler"},
+			}},
+		},
+	}}
+	wantPods := []v1.Pod{{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bootstrap-kube-apiserver",
+			Namespace: "kube-system",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:    "kube-apiserver",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
+				VolumeMounts: []v1.VolumeMount{{
+					Name:      "ssl-certs-host",
+					MountPath: "/etc/ssl/certs",
+					ReadOnly:  true,
+				}, {
+					Name:      "secrets",
+					MountPath: "/etc/kubernetes/secrets",
+					ReadOnly:  true,
+				}},
+			}},
+			Volumes: []v1.Volume{{
+				Name:         "ssl-certs-host",
+				VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/usr/share/ca-certificates"}},
+			}, {
+				Name:         "secrets",
+				VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/kubernetes/bootstrap-secrets/kube-apiserver"}},
+			}, {
+				Name:         "kubeconfig",
+				VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/kubernetes/kubeconfig"}},
+			}},
+		},
+	}, {
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bootstrap-kube-scheduler",
+			Namespace: "kube-system",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:    "kube-scheduler",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Command: []string{"/hyperkube", "scheduler", "--kubeconfig=/kubeconfig/kubeconfig"},
+				VolumeMounts: []v1.VolumeMount{{
+					Name:      "kubeconfig",
+					MountPath: "/kubeconfig",
+					ReadOnly:  true,
+				}},
+			}},
+			Volumes: []v1.Volume{{
+				Name:         "kubeconfig",
+				VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/kubernetes/kubeconfig"}},
+			}},
+		},
+	}}
+	wantSecrets := map[string]struct{}{"kube-apiserver": {}}
+	gotSecrets, err := fixUpBootstrapPods(pods)
+	if err != nil || !reflect.DeepEqual(gotSecrets, wantSecrets) {
+		t.Errorf("fixUpBootstrapPods(%v) = %v, %v, want: %v, %v", pods, gotSecrets, err, wantSecrets, nil)
+	} else if !reflect.DeepEqual(pods, wantPods) {
+		t.Errorf("fixUpBootstrapPods(%v) = %v, want: %v", pods, pods, wantPods)
+	}
+}
+
+func TestOutputBootstrapSecrets(t *testing.T) {
+	requiredSecrets := map[string]struct{}{"kube-apiserver": {}}
+	want := asset.Assets{{
+		Name: "tls/kube-apiserver/apiserver.crt",
+		Data: secretData,
+	}}
+	if got, err := outputBootstrapSecrets(cp.secrets.Items, requiredSecrets); err != nil {
+		t.Errorf("outputBootstrapSecrets(%v, %v) = %v, want: nil", cp.secrets.Items, requiredSecrets, err)
+	} else if !reflect.DeepEqual(got, want) {
+		t.Errorf("outputBootstrapSecrets(%v, %v) = %v, want: %v", cp.secrets.Items, requiredSecrets, got, want)
+	}
+}
+
+func TestOutputBootstrapSecretsMissing(t *testing.T) {
+	requiredSecrets := map[string]struct{}{"missing-secret": {}}
+	if as, err := outputBootstrapSecrets(cp.secrets.Items, requiredSecrets); err == nil {
+		t.Errorf("outputBootstrapSecrets(%v, %v) = %v, %v, want: nil, non-nil", cp.secrets.Items, requiredSecrets, as, err)
+	}
+}
+
+func TestIsBootstrapApp(t *testing.T) {
+	for app := range bootstrapK8sApps {
+		labels := map[string]string{
+			"tier":      "control-plane",
+			k8sAppLabel: app,
+		}
+		if !isBootstrapApp(labels) {
+			t.Errorf("isBootstrapApp(%v) = false, want: true", labels)
+		}
+		labels = map[string]string{
+			"tier":            "control-plane",
+			componentAppLabel: app,
+		}
+		if !isBootstrapApp(labels) {
+			t.Errorf("isBootstrapApp(%v) = false, want: true", labels)
+		}
+	}
+}
+
+func TestIsNotBootstrapApp(t *testing.T) {
+	for _, labels := range []map[string]string{{
+		"tier":      "control-plane",
+		k8sAppLabel: "wrong-app",
+	}, {
+		"tier":        "control-plane",
+		"wrong-label": "kube-apiserver",
+	}} {
+		if isBootstrapApp(labels) {
+			t.Errorf("isBootstrapApp(%v) = true, want: false", labels)
+		}
+	}
+}
+
+func TestSetTypeMeta(t *testing.T) {
+	for _, obj := range []runtime.Object{
+		&v1.ConfigMap{},
+		&v1beta1.DaemonSet{},
+		&v1beta1.Deployment{},
+		&v1.Pod{},
+		&v1.Secret{},
+	} {
+		if err := setTypeMeta(obj); err != nil {
+			t.Errorf("setTypeMeta(%v) = %v, want: nil", obj, err)
+		}
+		if apiVersion, err := metaAccessor.APIVersion(obj); apiVersion == "" || err != nil {
+			t.Errorf("APIVersion(%v) = %v, %v, want: <non-empty>, nil", obj, apiVersion, err)
+		}
+		if kind, err := metaAccessor.Kind(obj); kind == "" || err != nil {
+			t.Errorf("Kind(%v) = %v, %v, want: <non-empty>, nil", obj, kind, err)
+		}
+	}
+}

--- a/pkg/recovery/util.go
+++ b/pkg/recovery/util.go
@@ -1,0 +1,37 @@
+package recovery
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// decode decodes value of bytes into object.
+func decode(decoder runtime.Decoder, value []byte, objPtr runtime.Object) error {
+	if _, err := conversion.EnforcePtr(objPtr); err != nil {
+		return fmt.Errorf("objPtr must be pointer, got: %T", objPtr)
+	}
+	_, _, err := decoder.Decode(value, nil, objPtr)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// decodeList decodes a list of values into a list of objects.
+func decodeList(elems [][]byte, listPtr interface{}, decoder runtime.Decoder) error {
+	v, err := conversion.EnforcePtr(listPtr)
+	if err != nil || v.Kind() != reflect.Slice {
+		return fmt.Errorf("listPtr must be pointer to slice, got: %T", listPtr)
+	}
+	for _, elem := range elems {
+		obj, _, err := decoder.Decode(elem, nil, reflect.New(v.Type().Elem()).Interface().(runtime.Object))
+		if err != nil {
+			return err
+		}
+		v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))
+	}
+	return nil
+}


### PR DESCRIPTION
The new `bootkube recover` command provides a framework for reading
control plane manifests out of a storage backend, serializing them to
disk, and constructing pod manifests for the bootstrap components that
are usable with `bootkube start` to re-bootstrap the control plane.

The command initially provides and etcdclient backend for use with a
running etcd cluster. In the future we can add support other methods,
such as an etcd backup directory or a running apiserver.

There is also documentation and an example script in hack/multi-node
that deletes a master node, recovers the assets from etcd, and then
re-bootstraps the control plane.

This is a first step in addressing the issues described in #432.