### PR TITLE
templates: update etcd-operator to v0.2.6

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -865,7 +865,7 @@ spec:
     spec:
       containers:
       - name: etcd-operator
-        image: quay.io/coreos/etcd-operator:v0.2.5
+        image: quay.io/coreos/etcd-operator:v0.2.6
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
There is a change for self hosted etcd pods that make it more resilient
on anti-affinity guarantee. It doesn't break existing cluster, but have
stronger guarantee.