### PR TITLE
e2e: start of test framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ release: \
 check:
 	@find . -name vendor -prune -o -name '*.go' -exec gofmt -s -d {} +
 	@go vet $(shell go list ./... | grep -v '/vendor/')
-	@go test -v $(shell go list ./... | grep -v '/vendor/')
+	@go test -v $(shell go list ./... | grep -v '/vendor/\|/e2e')
 
 install: _output/bin/$(LOCAL_OS)/bootkube
 	cp $< $(GOPATH_BIN)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,22 @@
+## Bootkube E2E Testing
+
+This is the beginnings of E2E testing for the bootkube repo using the standard go testing harness. The framework package handles any inputs into the tests and expects that kubernetes cluster is already running. It is also a place to put common test code and patterns particularly around destructive testing interfaces that have yet to be created.
+
+To run the tests once you have a kubeconfig to a running cluster just execute:
+`go test -v --nodes=<number of nodes> --kubeconfig=<filepath> ./e2e/`
+
+The number of nodes is required so that the framework can block on all nodes being registered.
+
+## Writing tests
+
+You can write tests more or less as you normally would in go except that at the beginning of every test one must call `framework.NewCluster()` to get access to the k8s client and any additional interfaces useful for testing. See `example_test.go` to get started
+
+## Roadmap
+
+The framework will need to be expanded to handle destructive testing such that all current tests in the pluton can be ported over.
+
+## Requirements
+
+Tests can't rely on network access to the cluster except via the kubernetes api.
+
+

--- a/e2e/example_test.go
+++ b/e2e/example_test.go
@@ -1,0 +1,21 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/kubernetes-incubator/bootkube/e2e/framework"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExample(t *testing.T) {
+	c := framework.NewCluster()
+
+	podlist, err := c.Client.CoreV1().Pods("kube-system").List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	for _, pod := range podlist.Items {
+		t.Logf(pod.ObjectMeta.Name)
+	}
+}

--- a/e2e/framework/cluster.go
+++ b/e2e/framework/cluster.go
@@ -1,0 +1,71 @@
+package framework
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Cluster represents an interface to test bootkube based kubernetes clusters.
+// The simplest way to write tests against it is to just write go tests that call
+// out to NewCluster at the beginning of each test. External tooling should first
+// provision the kubernetes cluster and output a kubeconfig.
+type Cluster struct {
+	Client kubernetes.Clientset
+
+	expectedNodes int
+}
+
+func NewCluster() *Cluster {
+	// uses the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	c := &Cluster{
+		Client:        *clientset,
+		expectedNodes: *expectedNodes,
+	}
+
+	return c
+}
+
+// Ready blocks until a Cluster is considered available. The current
+// implementation checks that the expected number of nodes are registered.
+func (c *Cluster) Ready() error {
+	f := func() error {
+		list, err := c.Client.CoreV1().Nodes().List(metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		if len(list.Items) != c.expectedNodes {
+			return fmt.Errorf("cluster is not ready, expected %v nodes got %v", c.expectedNodes, len(list.Items))
+		}
+
+		for _, node := range list.Items {
+			if node.Status.Phase != v1.NodeRunning {
+				return fmt.Errorf("One or more nodes not in the ready state: %v", node.Status.Phase)
+			}
+		}
+
+		return nil
+	}
+
+	if err := Retry(12, 10*time.Second, f); err != nil {
+		return err
+	}
+	return nil
+}

--- a/e2e/framework/setup.go
+++ b/e2e/framework/setup.go
@@ -1,0 +1,20 @@
+package framework
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+var (
+	kubeconfig    = flag.String("kubeconfig", "../hack/quickstart/cluster/auth/kubeconfig", "absolute path to the kubeconfig file")
+	expectedNodes = flag.Int("nodes", 0, "the number of nodes to expect")
+)
+
+func init() {
+	flag.Parse()
+	if *expectedNodes == 0 {
+		fmt.Println("Please set --nodes flag with the number of nodes in the running cluster")
+		os.Exit(1)
+	}
+}

--- a/e2e/framework/util.go
+++ b/e2e/framework/util.go
@@ -1,0 +1,20 @@
+package framework
+
+import "time"
+
+func Retry(attempts int, delay time.Duration, f func() error) error {
+	var err error
+
+	for i := 0; i < attempts; i++ {
+		err = f()
+		if err == nil {
+			break
+		}
+
+		if i < attempts-1 {
+			time.Sleep(delay)
+		}
+	}
+
+	return err
+}


### PR DESCRIPTION
This commit forms the basis for moving tests in-repo, using the go test framework and a kubeconfig. Next steps would be moving over pluton tests, though much of the destructive abilities of those tests still need implementations through the k8s api. Longer-term this functionality may be implemented through some type of daemon-set. For now we can hack together what we need to reboot nodes and the like.

Looking for feedback on the basis of this before I get too far into porting tests.

cc @aaronlevy @derekparker @yifan-gu @diegs 