### PR TITLE
pkg/bootkube: increase count when api object already exists

### DIFF
--- a/pkg/bootkube/create.go
+++ b/pkg/bootkube/create.go
@@ -109,6 +109,7 @@ func createAssets(manifestDir string) error {
 		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object)
 		if err != nil {
 			if apierrors.IsAlreadyExists(err) {
+				count++
 				return nil
 			}
 			return cmdutil.AddSourceToErr("creating", info.Source, err)


### PR DESCRIPTION
If we do not increase this count, we will hit the error returns at line 132 in the same file.

Found when trying out recovery from a self hosted etcd cluster.

/cc @yifan-gu @aaronlevy 