### PR TITLE
templates: etcd operator should select master nodes

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -875,6 +875,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists


### PR DESCRIPTION
All system components are sitting on master nodes.
However, etcd operator was somehow dismissed for that.