### PR TITLE
e2e: Add simple cluster type to make tests migration easier.

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/crypto/ssh"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"

--- a/e2e/ssh_client.go
+++ b/e2e/ssh_client.go
@@ -19,13 +19,13 @@ type SSHClient struct {
 }
 
 func InitSSHClient(keypath string) {
-	sshClient = NewSSHClientOrDie(keypath)
+	sshClient = newSSHClientOrDie(keypath)
 }
 
-// NewSSHClientOrDie tries to create an ssh client.
+// newSSHClientOrDie tries to create an ssh client.
 // If $SSH_AUTH_SOCK is set, the use the ssh agent to create the client,
 // otherwise read the private key directly.
-func NewSSHClientOrDie(keypath string) *SSHClient {
+func newSSHClientOrDie(keypath string) *SSHClient {
 	var authMethod ssh.AuthMethod
 
 	sock := os.Getenv("SSH_AUTH_SOCK")


### PR DESCRIPTION
Calling GetCluster() in each test can returns a Cluster type that
stores the list of master and worker nodes, which provide SSH() and
Reboot() interfaces.