### PR TITLE
Calico policy support

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -52,9 +52,11 @@ var (
 		selfHostKubelet     bool
 		cloudProvider       string
 		selfHostedEtcd      bool
+		calicoNetworkPolicy bool
 	}
 
 	imageVersions = asset.DefaultImages
+	cniRelease    = asset.DefaultCNIRelease
 )
 
 func init() {
@@ -73,6 +75,7 @@ func init() {
 	cmdRender.Flags().BoolVar(&renderOpts.selfHostKubelet, "experimental-self-hosted-kubelet", false, "(Experimental) Create a self-hosted kubelet daemonset.")
 	cmdRender.Flags().StringVar(&renderOpts.cloudProvider, "cloud-provider", "", "The provider for cloud services.  Empty string for no provider")
 	cmdRender.Flags().BoolVar(&renderOpts.selfHostedEtcd, "experimental-self-hosted-etcd", false, "(Experimental) Create self-hosted etcd assets.")
+	cmdRender.Flags().BoolVar(&renderOpts.calicoNetworkPolicy, "experimental-calico-network-policy", false, "(Experimental) Add network policy support by calico.")
 }
 
 func runCmdRender(cmd *cobra.Command, args []string) error {
@@ -222,25 +225,27 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 	}
 
 	return &asset.Config{
-		EtcdCACert:        etcdCACert,
-		EtcdClientCert:    etcdClientCert,
-		EtcdClientKey:     etcdClientKey,
-		EtcdServers:       etcdServers,
-		EtcdUseTLS:        etcdUseTLS,
-		CACert:            caCert,
-		CAPrivKey:         caPrivKey,
-		APIServers:        apiServers,
-		AltNames:          altNames,
-		PodCIDR:           podNet,
-		ServiceCIDR:       serviceNet,
-		APIServiceIP:      apiServiceIP,
-		BootEtcdServiceIP: bootEtcdServiceIP,
-		DNSServiceIP:      dnsServiceIP,
-		EtcdServiceIP:     etcdServiceIP,
-		SelfHostKubelet:   renderOpts.selfHostKubelet,
-		CloudProvider:     renderOpts.cloudProvider,
-		SelfHostedEtcd:    renderOpts.selfHostedEtcd,
-		Images:            imageVersions,
+		EtcdCACert:          etcdCACert,
+		EtcdClientCert:      etcdClientCert,
+		EtcdClientKey:       etcdClientKey,
+		EtcdServers:         etcdServers,
+		EtcdUseTLS:          etcdUseTLS,
+		CACert:              caCert,
+		CAPrivKey:           caPrivKey,
+		APIServers:          apiServers,
+		AltNames:            altNames,
+		PodCIDR:             podNet,
+		ServiceCIDR:         serviceNet,
+		APIServiceIP:        apiServiceIP,
+		BootEtcdServiceIP:   bootEtcdServiceIP,
+		DNSServiceIP:        dnsServiceIP,
+		EtcdServiceIP:       etcdServiceIP,
+		SelfHostKubelet:     renderOpts.selfHostKubelet,
+		CloudProvider:       renderOpts.cloudProvider,
+		SelfHostedEtcd:      renderOpts.selfHostedEtcd,
+		CalicoNetworkPolicy: renderOpts.calicoNetworkPolicy,
+		Images:              imageVersions,
+		CNIRelease:          cniRelease,
 	}, nil
 }
 

--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -56,7 +56,6 @@ var (
 	}
 
 	imageVersions = asset.DefaultImages
-	cniRelease    = asset.DefaultCNIRelease
 )
 
 func init() {
@@ -245,7 +244,6 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 		SelfHostedEtcd:      renderOpts.selfHostedEtcd,
 		CalicoNetworkPolicy: renderOpts.calicoNetworkPolicy,
 		Images:              imageVersions,
-		CNIRelease:          cniRelease,
 	}, nil
 }
 

--- a/e2e/network_test.go
+++ b/e2e/network_test.go
@@ -1,0 +1,295 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+func TestNetwork(t *testing.T) {
+	//
+	// 1. create nginx service
+	di, _, err := api.Codecs.UniversalDecoder().Decode(nginxDepNT, nil, &v1beta1.Deployment{})
+	if err != nil {
+		t.Fatalf("unable to decode deployment manifest: %v", err)
+	}
+
+	d, ok := di.(*v1beta1.Deployment)
+	if !ok {
+		t.Fatalf("expected manifest to decode into *api.deployment, got %T", di)
+	}
+	_, err = client.ExtensionsV1beta1().Deployments(namespace).Create(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deleteDeployment := func() {
+		delPropPolicy := metav1.DeletePropagationForeground
+		client.ExtensionsV1beta1().Deployments(namespace).Delete("nginx-deployment-nt", &metav1.DeleteOptions{
+			PropagationPolicy: &delPropPolicy,
+		})
+	}
+	defer deleteDeployment()
+
+	if err := retry(10, time.Second*10, getNginxPod); err != nil {
+		t.Fatalf("timed out waiting for nginx pod: %v", err)
+	}
+
+	si, _, err := api.Codecs.UniversalDecoder().Decode(nginxSVCNT, nil, &v1.Service{})
+	if err != nil {
+		t.Fatalf("unable to decode service manifest: %v", err)
+	}
+	s, ok := si.(*v1.Service)
+	if !ok {
+		t.Fatalf("expected manifest to decode into *api.service, got %T", si)
+	}
+	_, err = client.CoreV1().Services(namespace).Create(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.CoreV1().Services(namespace).Delete("nginx-service-nt", &metav1.DeleteOptions{})
+
+	//
+	// 2. create a wget pod that hits the nginx service
+	testPodName := fmt.Sprintf("%s-%s", "wget-pod-nt", utilrand.String(5))
+	wgetPodNT.ObjectMeta.Name = testPodName
+	_, err = client.CoreV1().Pods(namespace).Create(wgetPodNT)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := retry(10, time.Second*10, getPod(testPodName)); err != nil {
+		t.Fatalf(fmt.Sprintf("timed out waiting for wget pod to succeed: %v", err))
+	}
+
+	t.Run("DefaultDeny", HelperDefaultDeny)
+
+	resetNetworkPolicy := func() {
+		n, err := client.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("unable to retrieve namespace %v", err)
+		}
+
+		n.ObjectMeta.Annotations = map[string]string{}
+		n.ObjectMeta.Annotations["net.beta.kubernetes.io/network-policy"] = defaultAllowNetworkPolicy
+		_, err = client.CoreV1().Namespaces().Update(n)
+		if err != nil {
+			t.Fatalf("unable to reset namespace network policy%v", err)
+		}
+	}
+	defer resetNetworkPolicy()
+
+	t.Run("NetworkPolicy", HelperPolicy)
+}
+
+func HelperDefaultDeny(t *testing.T) {
+	//
+	// 3. set DefaultDeny policy
+	var n *v1.Namespace
+	n, err := client.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unable to retrieve namespace %v", err)
+	}
+
+	n.ObjectMeta.Annotations = map[string]string{}
+	n.ObjectMeta.Annotations["net.beta.kubernetes.io/network-policy"] = defaultDenyNetworkPolicy
+	_, err = client.CoreV1().Namespaces().Update(n)
+	if err != nil {
+		t.Fatalf("unable to set namespace network policy defaultdeny%v", err)
+	}
+
+	//
+	// 4. create a wget pod that fails to hit nginx service
+	testPodName := fmt.Sprintf("%s-%s", "wget-pod-nt", utilrand.String(5))
+	wgetPodNT.ObjectMeta.Name = testPodName
+	_, err = client.CoreV1().Pods(namespace).Create(wgetPodNT)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := retry(10, time.Second*10, getFailedPod(testPodName)); err != nil {
+		t.Fatalf(fmt.Sprintf("timed out waiting for wget pod to fail: %v", err))
+	}
+}
+
+func HelperPolicy(t *testing.T) {
+	//
+	// 5. create NetworkPolicy that allows `allow=access`
+	npi, _, err := api.Codecs.UniversalDecoder().Decode(netPolicy, nil, &v1beta1.NetworkPolicy{})
+	if err != nil {
+		t.Fatalf("unable to decode network policy manifest: %v", err)
+	}
+
+	np, ok := npi.(*v1beta1.NetworkPolicy)
+	if !ok {
+		t.Fatalf("expected manifest to decode into *api.networkpolicy, got %T", npi)
+	}
+
+	httpRestClient := client.ExtensionsV1beta1().RESTClient()
+	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s",
+		strings.ToLower("extensions"),
+		strings.ToLower("v1beta1"),
+		strings.ToLower(namespace),
+		strings.ToLower("NetworkPolicies"))
+
+	result := httpRestClient.Post().RequestURI(uri).Body(np).Do()
+	if result.Error() != nil {
+		t.Fatal(result.Error())
+	}
+	defer func() {
+		uri = fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s",
+			strings.ToLower("extensions"),
+			strings.ToLower("v1beta1"),
+			strings.ToLower(namespace),
+			strings.ToLower("NetworkPolicies"),
+			strings.ToLower(np.ObjectMeta.Name))
+
+		result = httpRestClient.Delete().RequestURI(uri).Do()
+		if result.Error() != nil {
+			t.Fatal(result.Error())
+		}
+
+	}()
+
+	//
+	// 6. create a wget pod with label `allow=access` that hits the nginx service
+	testPodName := fmt.Sprintf("%s-%s", "wget-pod-nt", utilrand.String(5))
+	wgetPodNT.ObjectMeta.Name = testPodName
+	wgetPodNT.ObjectMeta.Labels = map[string]string{}
+	wgetPodNT.ObjectMeta.Labels["allow"] = "access"
+	_, err = client.CoreV1().Pods(namespace).Create(wgetPodNT)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := retry(10, time.Second*10, getPod(testPodName)); err != nil {
+		t.Fatalf(fmt.Sprintf("timed out waiting for wget pod to succeed: %v", err))
+	}
+
+	//
+	// 7. create a wget pod with label `allow=cant-access` that fails to the nginx service
+	testPodName = fmt.Sprintf("%s-%s", "wget-pod-nt", utilrand.String(5))
+	wgetPodNT.ObjectMeta.Name = testPodName
+	wgetPodNT.ObjectMeta.Labels["allow"] = "cant-access"
+	_, err = client.CoreV1().Pods(namespace).Create(wgetPodNT)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := retry(10, time.Second*10, getFailedPod(testPodName)); err != nil {
+		t.Fatalf(fmt.Sprintf("timed out waiting for wget pod to fail: %v", err))
+	}
+}
+
+func getNginxPod() error {
+	l, err := client.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: "app=nginx"})
+	if err != nil || len(l.Items) == 0 {
+		return fmt.Errorf("couldn't list pods: %v", err)
+	}
+
+	// take the first pod
+	p := &l.Items[0]
+
+	if p.Status.Phase != v1.PodRunning {
+		return fmt.Errorf("pod not yet running: %v", p.Status.Phase)
+	}
+	return nil
+}
+
+func getPod(name string) func() error {
+	return func() error {
+		p, err := client.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("couldn't get pod: %v", err)
+		}
+		if p.Status.Phase != v1.PodSucceeded {
+			return fmt.Errorf("pod did not succeed: %v", p.Status.Phase)
+		}
+		return nil
+	}
+}
+
+func getFailedPod(name string) func() error {
+	return func() error {
+		p, err := client.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("couldn't get pod: %v", err)
+		}
+		if p.Status.Phase != v1.PodFailed {
+			return fmt.Errorf("pod did not fail: %v", p.Status.Phase)
+		}
+		return nil
+	}
+}
+
+var nginxDepNT = []byte(`apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-deployment-nt
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.8
+        ports:
+        - containerPort: 80
+`)
+
+var wgetPodNT = &v1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: namespace,
+	},
+	Spec: v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:    "wget-container",
+				Image:   "busybox:1.26",
+				Command: []string{"wget", "--timeout", "5", "nginx-service-nt"},
+			},
+		},
+		RestartPolicy: v1.RestartPolicyNever,
+	},
+}
+
+var nginxSVCNT = []byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service-nt
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+`)
+
+var defaultDenyNetworkPolicy = `{"ingress":{"isolation":"DefaultDeny"}}`
+var defaultAllowNetworkPolicy = `{"ingress":{"isolation":""}}`
+
+var netPolicy = []byte(`kind: NetworkPolicy                                                      
+apiVersion: extensions/v1beta1
+metadata:
+  name: access-nginx
+spec:
+  podSelector:
+    matchLabels:
+      app: nginx
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            allow: access
+`)

--- a/hack/multi-node/bootkube-up
+++ b/hack/multi-node/bootkube-up
@@ -18,9 +18,17 @@ else
     etcd_render_flags="--etcd-servers=https://172.17.4.51:2379"
 fi
 
+CALICO_NETWORK_POLICY=${CALICO_NETWORK_POLICY:-false}
+if [ ${CALICO_NETWORK_POLICY} = "true" ]; then
+    echo "WARNING: THIS IS EXPERIMENTAL SUPPORT FOR NETWORK POLICY"
+    cnp_render_flags="--experimental-calico-network-policy"
+else
+    cnp_render_flags=""
+fi
+
 # Render assets
 if [ ! -d "cluster" ]; then
-  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.101:443 ${etcd_render_flags} --experimental-calico-network-policy
+  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.101:443 ${etcd_render_flags} ${cnp_render_flags}
   cp user-data.sample cluster/user-data-worker
   cp user-data.sample cluster/user-data-controller
   sed -i.bak -e '/node-role.kubernetes.io\/master/d' cluster/user-data-worker

--- a/hack/multi-node/bootkube-up
+++ b/hack/multi-node/bootkube-up
@@ -20,7 +20,7 @@ fi
 
 # Render assets
 if [ ! -d "cluster" ]; then
-  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.101:443 ${etcd_render_flags}
+  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.101:443 ${etcd_render_flags} --experimental-calico-network-policy
   cp user-data.sample cluster/user-data-worker
   cp user-data.sample cluster/user-data-controller
   sed -i.bak -e '/node-role.kubernetes.io\/master/d' cluster/user-data-worker

--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -12,7 +12,10 @@ coreos:
         Environment=KUBELET_IMAGE_TAG=v1.6.4_coreos.0
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
-          --mount volume=var-lib-cni,target=/var/lib/cni"
+          --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
+          --mount volume=var-lib-cni,target=/var/lib/cni \
+          --mount volume=opt-cni-bin,target=/opt/cni/bin"
+        ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets

--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -57,7 +57,7 @@ function init_master_node() {
     fi
 
     # Render cluster assets
-    /home/${REMOTE_USER}/bootkube render --asset-dir=/home/${REMOTE_USER}/assets ${etcd_render_flags} \
+    /home/${REMOTE_USER}/bootkube render --asset-dir=/home/${REMOTE_USER}/assets ${etcd_render_flags} --experimental-calico-network-policy \
       --api-servers=https://${COREOS_PUBLIC_IPV4}:443,https://${COREOS_PRIVATE_IPV4}:443
 
     # Move the local kubeconfig into expected location

--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -8,6 +8,7 @@ CLUSTER_DIR=${CLUSTER_DIR:-cluster}
 IDENT=${IDENT:-${HOME}/.ssh/id_rsa}
 SSH_OPTS=${SSH_OPTS:-}
 SELF_HOST_ETCD=${SELF_HOST_ETCD:-false}
+CALICO_NETWORK_POLICY=${CALICO_NETWORK_POLICY:-false}
 CLOUD_PROVIDER=${CLOUD_PROVIDER:-}
 
 function usage() {
@@ -56,8 +57,15 @@ function init_master_node() {
         etcd_render_flags="--etcd-servers=https://${COREOS_PRIVATE_IPV4}:2379"
     fi
 
+    if [ "$CALICO_NETWORK_POLICY" = true ]; then
+        echo "WARNING: THIS IS EXPERIMENTAL SUPPORT FOR NETWORK POLICY"
+        cnp_render_flags="--experimental-calico-network-policy"
+    else
+        cnp_render_flags=""
+    fi
+
     # Render cluster assets
-    /home/${REMOTE_USER}/bootkube render --asset-dir=/home/${REMOTE_USER}/assets ${etcd_render_flags} --experimental-calico-network-policy \
+    /home/${REMOTE_USER}/bootkube render --asset-dir=/home/${REMOTE_USER}/assets ${etcd_render_flags} ${cnp_render_flags} \
       --api-servers=https://${COREOS_PUBLIC_IPV4}:443,https://${COREOS_PRIVATE_IPV4}:443
 
     # Move the local kubeconfig into expected location
@@ -101,7 +109,7 @@ if [ "${REMOTE_HOST}" != "local" ]; then
 
     # Copy self to remote host so script can be executed in "local" mode
     scp -i ${IDENT} -P ${REMOTE_PORT} ${SSH_OPTS} ${BASH_SOURCE[0]} ${REMOTE_USER}@${REMOTE_HOST}:/home/${REMOTE_USER}/init-master.sh
-    ssh -i ${IDENT} -p ${REMOTE_PORT} ${SSH_OPTS} ${REMOTE_USER}@${REMOTE_HOST} "sudo REMOTE_USER=${REMOTE_USER} CLOUD_PROVIDER=${CLOUD_PROVIDER} SELF_HOST_ETCD=${SELF_HOST_ETCD} /home/${REMOTE_USER}/init-master.sh local"
+    ssh -i ${IDENT} -p ${REMOTE_PORT} ${SSH_OPTS} ${REMOTE_USER}@${REMOTE_HOST} "sudo REMOTE_USER=${REMOTE_USER} CLOUD_PROVIDER=${CLOUD_PROVIDER} SELF_HOST_ETCD=${SELF_HOST_ETCD} CALICO_NETWORK_POLICY=${CALICO_NETWORK_POLICY} /home/${REMOTE_USER}/init-master.sh local"
 
     # Copy assets from remote host to a local directory. These can be used to launch additional nodes & contain TLS assets
     mkdir ${CLUSTER_DIR}

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -4,9 +4,11 @@ Environment=KUBELET_IMAGE_TAG=v1.6.4_coreos.0
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/cache/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
+--volume opt-cni-bin,kind=host,source=/opt/cni/bin --mount volume=opt-cni-bin,target=/opt/cni/bin \
 --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/bin/mkdir -p /opt/cni/bin
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -4,9 +4,11 @@ Environment=KUBELET_IMAGE_TAG=v1.6.4_coreos.0
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/cache/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
+--volume opt-cni-bin,kind=host,source=/opt/cni/bin --mount volume=opt-cni-bin,target=/opt/cni/bin \
 --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/bin/mkdir -p /opt/cni/bin
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
 ExecStartPre=/bin/mkdir -p /var/lib/cni
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid

--- a/hack/single-node/bootkube-up
+++ b/hack/single-node/bootkube-up
@@ -19,7 +19,7 @@ fi
 
 # Render assets
 if [ ! -d "cluster" ]; then
-  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.100:443 ${etcd_render_flags}
+  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.100:443 ${etcd_render_flags} --experimental-calico-network-policy
   cp user-data.sample cluster/user-data
 	if [ ${SELF_HOST_ETCD} = "false" ]; then
 		cat user-data-etcd.sample >> cluster/user-data

--- a/hack/single-node/bootkube-up
+++ b/hack/single-node/bootkube-up
@@ -17,9 +17,17 @@ else
     etcd_render_flags=""
 fi
 
+CALICO_NETWORK_POLICY=${CALICO_NETWORK_POLICY:-false}
+if [ ${CALICO_NETWORK_POLICY} = "true" ]; then
+    echo "WARNING: THIS IS EXPERIMENTAL SUPPORT FOR NETWORK POLICY"
+    cnp_render_flags="--experimental-calico-network-policy"
+else
+    cnp_render_flags=""
+fi
+
 # Render assets
 if [ ! -d "cluster" ]; then
-  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.100:443 ${etcd_render_flags} --experimental-calico-network-policy
+  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.100:443 ${etcd_render_flags} ${cnp_render_flags}
   cp user-data.sample cluster/user-data
 	if [ ${SELF_HOST_ETCD} = "false" ]; then
 		cat user-data-etcd.sample >> cluster/user-data

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -12,7 +12,10 @@ coreos:
         Environment=KUBELET_IMAGE_TAG=v1.6.4_coreos.0
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
-          --mount volume=var-lib-cni,target=/var/lib/cni"
+          --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
+          --mount volume=var-lib-cni,target=/var/lib/cni \
+          --mount volume=opt-cni-bin,target=/opt/cni/bin"
+        ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets

--- a/hack/terraform-quickstart/outputs.tf
+++ b/hack/terraform-quickstart/outputs.tf
@@ -13,3 +13,7 @@ output "master_ips" {
 output "self_host_etcd" {
   value = "${var.self_host_etcd}"
 }
+
+output "calico_network_policy" {
+  value = "${var.calico_network_policy}"
+}

--- a/hack/terraform-quickstart/start-cluster.sh
+++ b/hack/terraform-quickstart/start-cluster.sh
@@ -5,6 +5,7 @@ export BOOTSTRAP_IP=`terraform output bootstrap_node_ip`
 export WORKER_IPS=`terraform output -json worker_ips | jq -r '.value[]'`
 export MASTER_IPS=`terraform output -json master_ips | jq -r '.value[]'`
 export SELF_HOST_ETCD=`terraform output self_host_etcd`
+export CALICO_NETWORK_POLICY=`terraform output calico_network_policy`
 export SSH_OPTS=${SSH_OPTS:-}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 export CLOUD_PROVIDER=${CLOUD_PROVIDER:-aws}
 

--- a/hack/terraform-quickstart/variables.tf
+++ b/hack/terraform-quickstart/variables.tf
@@ -27,6 +27,11 @@ variable "self_host_etcd" {
   default = "true"
 }
 
+variable "calico_network_policy" {
+  type    = "string"
+  default = "true"
+}
+
 variable "num_workers" {
   description = "number of worker nodes"
   type        = "string"

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -44,6 +44,11 @@ const (
 	AssetPathProxy                          = "manifests/kube-proxy.yaml"
 	AssetPathKubeFlannel                    = "manifests/kube-flannel.yaml"
 	AssetPathKubeFlannelCfg                 = "manifests/kube-flannel-cfg.yaml"
+	AssetPathKubeCalico                     = "manifests/kube-calico.yaml"
+	AssetPathKubeCalicoCfg                  = "manifests/kube-calico-cfg.yaml"
+	AssetPathKubeCalcioSA                   = "manifests/kube-calico-sa.yaml"
+	AssetPathKubeCalcioRole                 = "manifests/kube-calico-role.yaml"
+	AssetPathKubeCalcioRoleBinding          = "manifests/kube-calico-role-binding.yaml"
 	AssetPathAPIServerSecret                = "manifests/kube-apiserver-secret.yaml"
 	AssetPathAPIServer                      = "manifests/kube-apiserver.yaml"
 	AssetPathControllerManager              = "manifests/kube-controller-manager.yaml"
@@ -96,17 +101,21 @@ type Config struct {
 	EtcdServiceName        string
 	SelfHostKubelet        bool
 	SelfHostedEtcd         bool
+	CalicoNetworkPolicy    bool
 	CloudProvider          string
 	BootstrapSecretsSubdir string
 	Images                 ImageVersions
+	CNIRelease             string
 }
 
 // ImageVersions holds all the images (and their versions) that are rendered into the templates.
 type ImageVersions struct {
-	Busybox         string
+	Alpine          string
 	Etcd            string
 	EtcdOperator    string
 	Flannel         string
+	Calico          string
+	CalicoCNI       string
 	Hyperkube       string
 	Kenc            string
 	KubeDNS         string

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -105,15 +105,14 @@ type Config struct {
 	CloudProvider          string
 	BootstrapSecretsSubdir string
 	Images                 ImageVersions
-	CNIRelease             string
 }
 
 // ImageVersions holds all the images (and their versions) that are rendered into the templates.
 type ImageVersions struct {
-	Alpine          string
 	Etcd            string
 	EtcdOperator    string
 	Flannel         string
+	FlannelCNI      string
 	Calico          string
 	CalicoCNI       string
 	Hyperkube       string

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -5,8 +5,9 @@ var DefaultImages = ImageVersions{
 	Etcd:            "quay.io/coreos/etcd:v3.1.8",
 	EtcdOperator:    "quay.io/coreos/etcd-operator:v0.3.2",
 	Flannel:         "quay.io/coreos/flannel:v0.7.1-amd64",
-	Calico:          "quay.io/calico/node:v1.2.1",
-	CalicoCNI:       "quay.io/calico/cni:v1.8.3",
+	FlannelCNI:      "quay.io/coreos/flannel-cni:0.1.0",
+	Calico:          "quay.io/calico/node:v1.3.0",
+	CalicoCNI:       "quay.io/calico/cni:v1.9.1-4-g23fcd5f",
 	Hyperkube:       "quay.io/coreos/hyperkube:v1.6.4_coreos.0",
 	Kenc:            "quay.io/coreos/kenc:8f6e2e885f790030fbbb0496ea2a2d8830e58b8f",
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1",
@@ -14,6 +15,3 @@ var DefaultImages = ImageVersions{
 	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1",
 	PodCheckpointer: "quay.io/coreos/pod-checkpointer:4e7a7dab10bc4d895b66c21656291c6e0b017248",
 }
-
-// DefaultCNIRelease is the default version of cni release
-var DefaultCNIRelease = "0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff"

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -2,10 +2,11 @@ package asset
 
 // DefaultImages are the defualt images bootkube components use.
 var DefaultImages = ImageVersions{
-	Busybox:         "busybox",
 	Etcd:            "quay.io/coreos/etcd:v3.1.8",
 	EtcdOperator:    "quay.io/coreos/etcd-operator:v0.3.2",
 	Flannel:         "quay.io/coreos/flannel:v0.7.1-amd64",
+	Calico:          "quay.io/calico/node:v1.2.1",
+	CalicoCNI:       "quay.io/calico/cni:v1.8.3",
 	Hyperkube:       "quay.io/coreos/hyperkube:v1.6.4_coreos.0",
 	Kenc:            "quay.io/coreos/kenc:8f6e2e885f790030fbbb0496ea2a2d8830e58b8f",
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1",
@@ -13,3 +14,6 @@ var DefaultImages = ImageVersions{
 	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1",
 	PodCheckpointer: "quay.io/coreos/pod-checkpointer:4e7a7dab10bc4d895b66c21656291c6e0b017248",
 }
+
+// DefaultCNIRelease is the default version of cni release
+var DefaultCNIRelease = "0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff"

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -1091,13 +1091,38 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       - name: install-cni
-        image: {{ .Images.Busybox }}
-        command: [ "/bin/sh", "-c", "set -e -x; TMP=/etc/cni/net.d/.tmp-flannel-cfg; cp /etc/kube-flannel/cni-conf.json ${TMP}; mv ${TMP} /etc/cni/net.d/10-flannel.conf; while :; do sleep 3600; done" ]
+        image: {{ .Images.Alpine }}
+        command: 
+          - '/bin/sh'
+          - '-c'
+          - >
+            set -e -x;
+            ARCH=${ARCH:-amd64};
+            CNI_RELEASE=${CNI_RELEASE:-{{ .CNIRelease }}};
+            TMP=/etc/cni/net.d/.tmp-flannel-cfg;
+            cp /etc/kube-flannel/cni-conf.json ${TMP};
+            mv ${TMP} /etc/cni/net.d/10-flannel.conf;
+
+            apk add --update ca-certificates openssl && update-ca-certificates;
+            OPT_CNI=/opt/cni;
+            mkdir -p ${OPT_CNI};
+            wget -qO- https://storage.googleapis.com/kubernetes-release/network-plugins/cni-${ARCH}-${CNI_RELEASE}.tar.gz | tar -xz -C ${OPT_CNI};
+
+            if [ -w "/host/opt/cni/bin/" ]; then
+              cp /opt/cni/bin/* /host/opt/cni/bin/;
+              echo "Wrote CNI binaries to /host/opt/cni/bin/";
+            fi;
+
+            while :; do sleep 3600; done;
         volumeMounts:
         - name: cni
           mountPath: /etc/cni/net.d
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
+        - name: host-cni-bin
+          mountPath: /host/opt/cni/bin/
+        - name: ssl-certs
+          mountPath: /etc/ssl/certs
       hostNetwork: true
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -1113,10 +1138,236 @@ spec:
         - name: flannel-cfg
           configMap:
             name: kube-flannel-cfg
+        - name: host-cni-bin
+          hostPath:
+            path: /opt/cni/bin
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
     type: RollingUpdate
+`)
+
+var KubeCalicoCfgTemplate = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-calico-cfg
+  namespace: kube-system
+data:
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "cniVersion": "0.1.0",
+        "type": "calico",
+        "log_level": "debug",
+        "datastore_type": "kubernetes",
+        "nodename": "__KUBERNETES_NODE_NAME__",
+        "ipam": {
+            "type": "host-local",
+            "subnet": "usePodCidr"
+        },
+        "policy": {
+            "type": "k8s",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        }
+    }
+`)
+
+var KubeCalicoTemplate = []byte(`apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-calico
+  namespace: kube-system
+  labels:
+    k8s-app: kube-calico
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-calico
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-calico
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      serviceAccountName: kube-calico
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      containers:
+        - name: kube-calico
+          image: {{ .Images.Calico }}
+          env:
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
+            - name: CALICO_NETWORKING_BACKEND
+              value: "none"
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: CALICO_IPV4POOL_CIDR
+              value: "{{ .PodCIDR }}"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        - name: install-cni
+          image: {{ .Images.CalicoCNI }}
+          command: ["/install-cni.sh"]
+          env:
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: kube-calico-cfg
+                  key: cni_network_config
+            - name: CNI_NET_DIR
+              value: "/etc/kubernetes/cni/net.d"
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/kubernetes/cni/net.d
+  `)
+
+var KubeCalicoServiceAccountTemplate = []byte(`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-calico
+  namespace: kube-system
+  `)
+
+var KubeCalicoRoleTemplate = []byte(`apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-calico
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - thirdpartyresources
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["projectcalico.org"]
+    resources:
+      - globalconfigs
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups: ["projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  `)
+
+var KubeCalicoRoleBindingTemplate = []byte(`apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-calico
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-calico
+subjects:
+- kind: ServiceAccount
+  name: kube-calico
+  namespace: kube-system
 `)
 
 // vim: set expandtab:tabstop=2

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -1217,9 +1217,6 @@ spec:
             requests:
               cpu: 250m
           volumeMounts:
-            - mountPath: /lib/modules
-              name: lib-modules
-              readOnly: true
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
@@ -1246,9 +1243,6 @@ spec:
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
       volumes:
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
         - name: var-run-calico
           hostPath:
             path: /var/run/calico

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -35,7 +35,6 @@ func newStaticAssets(imageVersions ImageVersions) Assets {
 		MustCreateAssetFromTemplate(AssetPathControllerManagerDisruption, internal.ControllerManagerDisruptionTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathKubeDNSDeployment, internal.DNSDeploymentTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathCheckpointer, internal.CheckpointerTemplate, conf),
-		MustCreateAssetFromTemplate(AssetPathKubeFlannel, internal.KubeFlannelTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathKubeSystemSARoleBinding, internal.KubeSystemSARoleBindingTemplate, conf),
 	}
 	return assets
@@ -47,6 +46,7 @@ func newDynamicAssets(conf Config) Assets {
 		MustCreateAssetFromTemplate(AssetPathAPIServer, internal.APIServerTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathProxy, internal.ProxyTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathKubeFlannelCfg, internal.KubeFlannelCfgTemplate, conf),
+		MustCreateAssetFromTemplate(AssetPathKubeFlannel, internal.KubeFlannelTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathKubeDNSSvc, internal.DNSSvcTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathBootstrapAPIServer, internal.BootstrapAPIServerTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathBootstrapControllerManager, internal.BootstrapControllerManagerTemplate, conf),
@@ -64,6 +64,14 @@ func newDynamicAssets(conf Config) Assets {
 			MustCreateAssetFromTemplate(AssetPathBootstrapEtcd, internal.BootstrapEtcdTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathBootstrapEtcdService, internal.BootstrapEtcdSvcTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathMigrateEtcdCluster, internal.EtcdTPRTemplate, conf))
+	}
+	if conf.CalicoNetworkPolicy {
+		assets = append(assets,
+			MustCreateAssetFromTemplate(AssetPathKubeCalicoCfg, internal.KubeCalicoCfgTemplate, conf),
+			MustCreateAssetFromTemplate(AssetPathKubeCalcioRole, internal.KubeCalicoRoleTemplate, conf),
+			MustCreateAssetFromTemplate(AssetPathKubeCalcioRoleBinding, internal.KubeCalicoRoleBindingTemplate, conf),
+			MustCreateAssetFromTemplate(AssetPathKubeCalcioSA, internal.KubeCalicoServiceAccountTemplate, conf),
+			MustCreateAssetFromTemplate(AssetPathKubeCalico, internal.KubeCalicoTemplate, conf))
 	}
 	return assets
 }


### PR DESCRIPTION
#513 
Notes:
- Uses Calico's Kubernetes Datastore  [`installation`](http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/) to provide policy only support

Needs to be discussed:
hyperkube image already ships with cni binaries in `/opt/cni/bin` and kube-calico DaemonSet also installs its cni binaries in `/opt/cni/bin`.

So there would be chances of version mismatch as kubelet doesn't mount this directory from host. To prevent this I have mounted an empty `/opt/cni/bin` from the host to the kubelet.
