### PR TITLE
WIP: Make control plane run as non-root.

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -59,7 +59,7 @@ var (
 		Etcd:            "quay.io/coreos/etcd:v3.1.6",
 		EtcdOperator:    "quay.io/coreos/etcd-operator:v0.3.0",
 		Flannel:         "quay.io/coreos/flannel:v0.7.1-amd64",
-		Hyperkube:       "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+		Hyperkube:       "quay.io/coreos/hyperkube:v1.6.2_coreos.1",
 		Kenc:            "quay.io/coreos/kenc:48b6feceeee56c657ea9263f47b6ea091e8d3035",
 		KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1",
 		KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1",

--- a/cmd/checkpoint/main.go
+++ b/cmd/checkpoint/main.go
@@ -331,9 +331,9 @@ func createCheckpointsForValidParents(client kubernetes.Interface, pods map[stri
 		//
 		// We do not use the `localPodRunning` state, because while the runtime may think the pod/containers are running -
 		// they may actually be in a failing state - and we've not successfully sent that podStatus to any api-server.
-		if !isRunning(pod) {
-			continue
-		}
+		// if !isRunning(pod) {
+		// 	continue
+		// }
 		id := PodFullName(pod)
 
 		cp, err := copyPod(pod)

--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -9,7 +9,7 @@ coreos:
         [Service]
         EnvironmentFile=/etc/environment
         Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-        Environment=KUBELET_IMAGE_TAG=v1.6.2_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.6.2_coreos.1
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --mount volume=var-lib-cni,target=/var/lib/cni"

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -1,6 +1,6 @@
 [Service]
 Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-Environment=KUBELET_IMAGE_TAG=v1.6.2_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.6.2_coreos.1
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/run/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -1,6 +1,6 @@
 [Service]
 Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-Environment=KUBELET_IMAGE_TAG=v1.6.2_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.6.2_coreos.1
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/run/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -9,7 +9,7 @@ coreos:
         [Service]
         EnvironmentFile=/etc/environment
         Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-        Environment=KUBELET_IMAGE_TAG=v1.6.2_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.6.2_coreos.1
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --mount volume=var-lib-cni,target=/var/lib/cni"

--- a/hack/tests/conformance-test.sh
+++ b/hack/tests/conformance-test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CONFORMANCE_REPO=${CONFORMANCE_REPO:-github.com/coreos/kubernetes}
-CONFORMANCE_VERSION=${CONFORMANCE_VERSION:-v1.6.2+coreos.0}
+CONFORMANCE_VERSION=${CONFORMANCE_VERSION:-v1.6.2+coreos.1}
 
 usage() {
     echo "USAGE:"

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -1,8 +1,7 @@
 // Package internal holds asset templates used by bootkube.
 package internal
 
-var (
-	KubeConfigTemplate = []byte(`apiVersion: v1
+var KubeConfigTemplate = []byte(`apiVersion: v1
 kind: Config
 clusters:
 - name: local
@@ -20,7 +19,7 @@ contexts:
     user: kubelet
 `)
 
-	KubeSystemSARoleBindingTemplate = []byte(`apiVersion: rbac.authorization.k8s.io/v1alpha1
+var KubeSystemSARoleBindingTemplate = []byte(`apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRoleBinding
 metadata:
   name: system:default-sa
@@ -34,7 +33,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 `)
 
-	KubeletTemplate = []byte(`apiVersion: extensions/v1beta1
+var KubeletTemplate = []byte(`apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kubelet
@@ -132,7 +131,7 @@ spec:
           path: /
 `)
 
-	APIServerTemplate = []byte(`apiVersion: "extensions/v1beta1"
+var APIServerTemplate = []byte(`apiVersion: "extensions/v1beta1"
 kind: DaemonSet
 metadata:
   name: kube-apiserver
@@ -154,11 +153,7 @@ spec:
       - name: kube-apiserver
         image: {{ .Images.Hyperkube }}
         command:
-        - /usr/bin/flock
-        - --exclusive
-        - --timeout=30
-        - /var/lock/api-server.lock
-        - /hyperkube
+        - ./hyperkube
         - apiserver
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
         - --advertise-address=$(POD_IP)
@@ -189,6 +184,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65534
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: ssl-certs-host
@@ -220,7 +218,7 @@ spec:
           path: /var/lock
 `)
 
-	BootstrapAPIServerTemplate = []byte(`apiVersion: v1
+var BootstrapAPIServerTemplate = []byte(`apiVersion: v1
 kind: Pod
 metadata:
   name: bootstrap-kube-apiserver
@@ -230,11 +228,7 @@ spec:
   - name: kube-apiserver
     image: {{ .Images.Hyperkube }}
     command:
-    - /usr/bin/flock
-    - --exclusive
-    - --timeout=30
-    - /var/lock/api-server.lock
-    - /hyperkube
+    - ./hyperkube
     - apiserver
     - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
     - --advertise-address=$(POD_IP)
@@ -287,7 +281,7 @@ spec:
       path: /var/lock
 `)
 
-	KencTemplate = []byte(`apiVersion: "extensions/v1beta1"
+var KencTemplate = []byte(`apiVersion: "extensions/v1beta1"
 kind: DaemonSet
 metadata:
   name: kube-etcd-network-checkpointer
@@ -337,7 +331,7 @@ spec:
           path: /var/lock
 `)
 
-	CheckpointerTemplate = []byte(`apiVersion: "extensions/v1beta1"
+var CheckpointerTemplate = []byte(`apiVersion: "extensions/v1beta1"
 kind: DaemonSet
 metadata:
   name: pod-checkpointer
@@ -396,7 +390,8 @@ spec:
         hostPath:
           path: /var/run
 `)
-	ControllerManagerTemplate = []byte(`apiVersion: extensions/v1beta1
+
+var ControllerManagerTemplate = []byte(`apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kube-controller-manager
@@ -458,6 +453,9 @@ spec:
           readOnly: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
@@ -474,7 +472,7 @@ spec:
       dnsPolicy: Default # Don't use cluster DNS.
 `)
 
-	BootstrapControllerManagerTemplate = []byte(`apiVersion: v1
+var BootstrapControllerManagerTemplate = []byte(`apiVersion: v1
 kind: Pod
 metadata:
   name: bootstrap-kube-controller-manager
@@ -510,7 +508,8 @@ spec:
     hostPath:
       path: /usr/share/ca-certificates
 `)
-	ControllerManagerDisruptionTemplate = []byte(`apiVersion: policy/v1beta1
+
+var ControllerManagerDisruptionTemplate = []byte(`apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: kube-controller-manager
@@ -522,7 +521,8 @@ spec:
       tier: control-plane
       k8s-app: kube-controller-manager
 `)
-	SchedulerTemplate = []byte(`apiVersion: extensions/v1beta1
+
+var SchedulerTemplate = []byte(`apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kube-scheduler
@@ -571,6 +571,9 @@ spec:
           timeoutSeconds: 15
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
@@ -579,7 +582,7 @@ spec:
         effect: NoSchedule
 `)
 
-	BootstrapSchedulerTemplate = []byte(`apiVersion: v1
+var BootstrapSchedulerTemplate = []byte(`apiVersion: v1
 kind: Pod
 metadata:
   name: bootstrap-kube-scheduler
@@ -603,7 +606,8 @@ spec:
     hostPath:
       path: /etc/kubernetes
 `)
-	SchedulerDisruptionTemplate = []byte(`apiVersion: policy/v1beta1
+
+var SchedulerDisruptionTemplate = []byte(`apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: kube-scheduler
@@ -615,7 +619,8 @@ spec:
       tier: control-plane
       k8s-app: kube-scheduler
 `)
-	ProxyTemplate = []byte(`apiVersion: "extensions/v1beta1"
+
+var ProxyTemplate = []byte(`apiVersion: "extensions/v1beta1"
 kind: DaemonSet
 metadata:
   name: kube-proxy
@@ -636,7 +641,7 @@ spec:
       - name: kube-proxy
         image: {{ .Images.Hyperkube }}
         command:
-        - /hyperkube
+        - ./hyperkube
         - proxy
         - --cluster-cidr={{ .PodCIDR }}
         - --hostname-override=$(NODE_NAME)
@@ -671,7 +676,8 @@ spec:
         hostPath:
           path: /etc/kubernetes
 `)
-	DNSDeploymentTemplate = []byte(`apiVersion: extensions/v1beta1
+
+var DNSDeploymentTemplate = []byte(`apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kube-dns
@@ -827,7 +833,8 @@ spec:
           name: kube-dns
           optional: true
 `)
-	DNSSvcTemplate = []byte(`apiVersion: v1
+
+var DNSSvcTemplate = []byte(`apiVersion: v1
 kind: Service
 metadata:
   name: kube-dns
@@ -849,7 +856,7 @@ spec:
     protocol: TCP
 `)
 
-	EtcdOperatorTemplate = []byte(`apiVersion: extensions/v1beta1
+var EtcdOperatorTemplate = []byte(`apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: etcd-operator
@@ -877,13 +884,16 @@ spec:
               fieldPath: metadata.name
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
 `)
 
-	EtcdSvcTemplate = []byte(`apiVersion: v1
+var EtcdSvcTemplate = []byte(`apiVersion: v1
 kind: Service
 metadata:
   name: {{ .EtcdServiceName }}
@@ -899,7 +909,7 @@ spec:
     protocol: TCP
 `)
 
-	BootstrapEtcdTemplate = []byte(`apiVersion: v1
+var BootstrapEtcdTemplate = []byte(`apiVersion: v1
 kind: Pod
 metadata:
   name: bootstrap-etcd
@@ -925,7 +935,7 @@ spec:
   restartPolicy: Never
 `)
 
-	BootstrapEtcdSvcTemplate = []byte(`{
+var BootstrapEtcdSvcTemplate = []byte(`{
   "apiVersion": "v1",
   "kind": "Service",
   "metadata": {
@@ -952,7 +962,7 @@ spec:
   }
 }`)
 
-	EtcdTPRTemplate = []byte(`{
+var EtcdTPRTemplate = []byte(`{
   "apiVersion": "etcd.coreos.com/v1beta1",
   "kind": "Cluster",
   "metadata": {
@@ -980,7 +990,7 @@ spec:
   }
 }`)
 
-	KubeFlannelCfgTemplate = []byte(`apiVersion: v1
+var KubeFlannelCfgTemplate = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kube-flannel-cfg
@@ -1006,7 +1016,7 @@ data:
     }
 `)
 
-	KubeFlannelTemplate = []byte(`apiVersion: extensions/v1beta1
+var KubeFlannelTemplate = []byte(`apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-flannel
@@ -1071,4 +1081,5 @@ spec:
           configMap:
             name: kube-flannel-cfg
 `)
-)
+
+// vim: set expandtab:tabstop=2

--- a/pkg/recovery/recover_test.go
+++ b/pkg/recovery/recover_test.go
@@ -40,7 +40,7 @@ var (
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
 								Name:    "kube-apiserver",
-								Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+								Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.1",
 								Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
 								VolumeMounts: []v1.VolumeMount{{
 									Name:      "ssl-certs-host",
@@ -79,7 +79,7 @@ var (
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
 								Name:    "kube-scheduler",
-								Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+								Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.1",
 								Command: []string{"/hyperkube", "scheduler"},
 							}},
 						},
@@ -113,7 +113,7 @@ func TestExtractBootstrapPods(t *testing.T) {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{{
 				Name:    "kube-apiserver",
-				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.1",
 				Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
 				VolumeMounts: []v1.VolumeMount{{
 					Name:      "ssl-certs-host",
@@ -145,7 +145,7 @@ func TestExtractBootstrapPods(t *testing.T) {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{{
 				Name:    "kube-scheduler",
-				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.1",
 				Command: []string{"/hyperkube", "scheduler"},
 			}},
 		},
@@ -170,7 +170,7 @@ func TestFixUpBootstrapPods(t *testing.T) {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{{
 				Name:    "kube-apiserver",
-				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.1",
 				Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
 				VolumeMounts: []v1.VolumeMount{{
 					Name:      "ssl-certs-host",
@@ -209,7 +209,7 @@ func TestFixUpBootstrapPods(t *testing.T) {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{{
 				Name:    "kube-scheduler",
-				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.1",
 				Command: []string{"/hyperkube", "scheduler"},
 			}},
 		},
@@ -226,7 +226,7 @@ func TestFixUpBootstrapPods(t *testing.T) {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{{
 				Name:    "kube-apiserver",
-				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.1",
 				Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
 				VolumeMounts: []v1.VolumeMount{{
 					Name:      "ssl-certs-host",
@@ -268,7 +268,7 @@ func TestFixUpBootstrapPods(t *testing.T) {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{{
 				Name:    "kube-scheduler",
-				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.0",
+				Image:   "quay.io/coreos/hyperkube:v1.6.2_coreos.1",
 				Command: []string{"/hyperkube", "scheduler", "--kubeconfig=/kubeconfig/kubeconfig"},
 				VolumeMounts: []v1.VolumeMount{{
 					Name:      "kubeconfig",


### PR DESCRIPTION
With the exception of a few prvileged services, this makes as many
control plane components as possible run as non-root.

This requires a special hyperkube build that grants CAP_NET_BIND_SERVICE
to the hyperkube binary.

In addition, this removes the use of the flock since /var/lock requires
root access. In order to prevent a checkpointer race condition a simple
'sleep infinite' container is added instead.

Finally, I got tired of fighting my editor in templates.go, so I
removed all the tabs in the file and added a directive to make it behave
more like a YAML file.