### PR TITLE
Fix pod-checkpointer container name.

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -362,7 +362,7 @@ spec:
         checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:
       containers:
-      - name: checkpoint
+      - name: pod-checkpointer
         image: {{ .Images.PodCheckpointer }}
         command:
         - /checkpoint


### PR DESCRIPTION
By convention the primary container should match the name of the
daemonset.