### PR TITLE
Add fluentd during bootstrap

### DIFF
--- a/hack/multi-node/bootkube-up
+++ b/hack/multi-node/bootkube-up
@@ -26,6 +26,13 @@ if [ ! -d "cluster" ]; then
   sed -i.bak -e '/node-role.kubernetes.io\/master/d' cluster/user-data-worker
 fi
 
+# Add fluentd static pod
+ENABLE_BOOTSTRAP_LOGS=${ENABLE_BOOTSTRAP_LOGS:-false}
+if [ ${ENABLE_BOOTSTRAP_LOGS} = "true" ]; then
+    echo "Writing asset: cluster/bootstrap-manifests/bootstrap-fluentd.yaml"
+    cp bootstrap-fluentd.sample cluster/bootstrap-manifests/bootstrap-fluentd.yaml
+fi
+
 # Start the VM
 vagrant up
 vagrant ssh-config c1 > ssh_config
@@ -41,3 +48,9 @@ echo
 echo "Bootstrap complete. Access your kubernetes cluster using:"
 echo "kubectl --kubeconfig=cluster/auth/kubeconfig get nodes"
 echo
+
+if [ ${ENABLE_BOOTSTRAP_LOGS} = "true" ]; then
+    echo "Fetch bootstrap logs using:"
+    echo "scp -q -r -C -F ssh_config core@c1:/var/log/bootkube-bootstrap bootstrap-logs"
+    echo
+fi

--- a/hack/multi-node/bootstrap-fluentd.sample
+++ b/hack/multi-node/bootstrap-fluentd.sample
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bootstrap-fluentd
+  namespace: kube-system
+spec:
+  containers:
+  - name: bootstrap-fluentd
+    image: quay.io/abhinavdahiya/bootkube-fluentd
+    env:
+    - name: FLUENTD_OPT
+      value: "--no-supervisor -q"
+    resources:
+      limits:
+        memory: 300Mi
+      requests:
+        cpu: 100m
+        memory: 200Mi
+    volumeMounts:
+    - name: varlog
+      mountPath: /var/log
+      readOnly: false
+    - name: varlibdockercontainers
+      mountPath: /var/lib/docker/containers
+      readOnly: true
+    - name: libsystemddir
+      mountPath: /host/lib
+      readOnly: true
+  hostNetwork: true  
+  volumes:
+  - name: varlog
+    hostPath:
+      path: /var/log
+  - name: varlibdockercontainers
+    hostPath:
+      path: /var/lib/docker/containers
+  - name: libsystemddir
+    hostPath:
+      path: /usr/lib64
+  terminationGracePeriodSeconds: 120

--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -11,6 +11,8 @@ coreos:
         Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
         Environment=KUBELET_IMAGE_TAG=v1.6.4_coreos.0
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
+          --volume var-log,kind=host,source=/var/log \
+          --mount volume=var-log,target=/var/log \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --mount volume=var-lib-cni,target=/var/lib/cni"
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests

--- a/hack/quickstart/bootstrap-fluentd.sample
+++ b/hack/quickstart/bootstrap-fluentd.sample
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bootstrap-fluentd
+  namespace: kube-system
+spec:
+  containers:
+  - name: bootstrap-fluentd
+    image: quay.io/abhinavdahiya/bootkube-fluentd
+    env:
+    - name: FLUENTD_OPT
+      value: "--no-supervisor -q"
+    resources:
+      limits:
+        memory: 300Mi
+      requests:
+        cpu: 100m
+        memory: 200Mi
+    volumeMounts:
+    - name: varlog
+      mountPath: /var/log
+      readOnly: false
+    - name: varlibdockercontainers
+      mountPath: /var/lib/docker/containers
+      readOnly: true
+    - name: libsystemddir
+      mountPath: /host/lib
+      readOnly: true
+  hostNetwork: true  
+  volumes:
+  - name: varlog
+    hostPath:
+      path: /var/log
+  - name: varlibdockercontainers
+    hostPath:
+      path: /var/lib/docker/containers
+  - name: libsystemddir
+    hostPath:
+      path: /usr/lib64
+  terminationGracePeriodSeconds: 120

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -4,6 +4,7 @@ Environment=KUBELET_IMAGE_TAG=v1.6.4_coreos.0
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/cache/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
+--volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log \
 --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -4,6 +4,7 @@ Environment=KUBELET_IMAGE_TAG=v1.6.4_coreos.0
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/cache/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
+--volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log \
 --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests

--- a/hack/single-node/bootkube-up
+++ b/hack/single-node/bootkube-up
@@ -26,6 +26,13 @@ if [ ! -d "cluster" ]; then
 	fi
 fi
 
+# Add fluentd static pod
+ENABLE_BOOTSTRAP_LOGS=${ENABLE_BOOTSTRAP_LOGS:-false}
+if [ ${ENABLE_BOOTSTRAP_LOGS} = "true" ]; then
+    echo "Writing asset: cluster/bootstrap-manifests/bootstrap-fluentd.yaml"
+    cp bootstrap-fluentd.sample cluster/bootstrap-manifests/bootstrap-fluentd.yaml
+fi
+
 # Start the VM
 vagrant up
 vagrant ssh-config > ssh_config
@@ -41,3 +48,9 @@ echo
 echo "Bootstrap complete. Access your kubernetes cluster using:"
 echo "kubectl --kubeconfig=cluster/auth/kubeconfig get nodes"
 echo
+
+if [ ${ENABLE_BOOTSTRAP_LOGS} = "true" ]; then
+    echo "Fetch bootstrap logs using:"
+    echo "scp -q -r -C -F ssh_config core@default:/var/log/bootkube-bootstrap bootstrap-logs"
+    echo
+fi

--- a/hack/single-node/bootstrap-fluentd.sample
+++ b/hack/single-node/bootstrap-fluentd.sample
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bootstrap-fluentd
+  namespace: kube-system
+spec:
+  containers:
+  - name: bootstrap-fluentd
+    image: quay.io/abhinavdahiya/bootkube-fluentd
+    env:
+    - name: FLUENTD_OPT
+      value: "--no-supervisor -q"
+    resources:
+      limits:
+        memory: 300Mi
+      requests:
+        cpu: 100m
+        memory: 200Mi
+    volumeMounts:
+    - name: varlog
+      mountPath: /var/log
+      readOnly: false
+    - name: varlibdockercontainers
+      mountPath: /var/lib/docker/containers
+      readOnly: true
+    - name: libsystemddir
+      mountPath: /host/lib
+      readOnly: true
+  hostNetwork: true  
+  volumes:
+  - name: varlog
+    hostPath:
+      path: /var/log
+  - name: varlibdockercontainers
+    hostPath:
+      path: /var/lib/docker/containers
+  - name: libsystemddir
+    hostPath:
+      path: /usr/lib64
+  terminationGracePeriodSeconds: 120

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -11,6 +11,8 @@ coreos:
         Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
         Environment=KUBELET_IMAGE_TAG=v1.6.4_coreos.0
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
+          --volume var-log,kind=host,source=/var/log \
+          --mount volume=var-log,target=/var/log \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --mount volume=var-lib-cni,target=/var/lib/cni"
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests

--- a/hack/terraform-quickstart/start-cluster.sh
+++ b/hack/terraform-quickstart/start-cluster.sh
@@ -6,6 +6,7 @@ export WORKER_IPS=`terraform output -json worker_ips | jq -r '.value[]'`
 export MASTER_IPS=`terraform output -json master_ips | jq -r '.value[]'`
 export SELF_HOST_ETCD=`terraform output self_host_etcd`
 export SSH_OPTS=${SSH_OPTS:-}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+export ENABLE_BOOTSTRAP_LOGS=true
 export CLOUD_PROVIDER=aws
 
 cd ../quickstart


### PR DESCRIPTION
#557 
collects logs from bootstrap phase to
`var/log/bootkube-bootstrap/containers.*.log` &
`var/log/bootkube-bootstrap/services.*.log` using fluentd on the bootstrap node.

currently the image used is https://github.com/abhinavdahiya/bootkube-fluentd.

/cc: @yifan-gu 
