### PR TITLE
*: bump etcd-operator to 0.3.2

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -4,10 +4,10 @@ package asset
 var DefaultImages = ImageVersions{
 	Busybox:         "busybox",
 	Etcd:            "quay.io/coreos/etcd:v3.1.8",
-	EtcdOperator:    "quay.io/coreos/etcd-operator:v0.3.0",
+	EtcdOperator:    "quay.io/coreos/etcd-operator:v0.3.2",
 	Flannel:         "quay.io/coreos/flannel:v0.7.1-amd64",
 	Hyperkube:       "quay.io/coreos/hyperkube:v1.6.4_coreos.0",
-	Kenc:            "quay.io/coreos/kenc:48b6feceeee56c657ea9263f47b6ea091e8d3035",
+	Kenc:            "quay.io/coreos/kenc:8f6e2e885f790030fbbb0496ea2a2d8830e58b8f",
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1",
 	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1",
 	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1",

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -316,6 +316,9 @@ spec:
         - mountPath: /etc/kubernetes/selfhosted-etcd
           name: checkpoint-dir
           readOnly: false
+        - mountPath: /var/etcd
+          name: etcd-dir
+          readOnly: false
         - mountPath: /var/lock
           name: var-lock
           readOnly: false
@@ -335,6 +338,9 @@ spec:
       - name: checkpoint-dir
         hostPath:
           path: /etc/kubernetes/checkpoint-iptables
+      - name: etcd-dir
+        hostPath:
+          path: /var/etcd
       - name: var-lock
         hostPath:
           path: /var/lock
@@ -885,6 +891,11 @@ metadata:
   labels:
     k8s-app: etcd-operator
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
   replicas: 1
   template:
     metadata:
@@ -954,6 +965,7 @@ spec:
     - --data-dir=/var/etcd/data
   hostNetwork: true
   restartPolicy: Never
+  dnsPolicy: ClusterFirstWithHostNet
 `)
 
 var BootstrapEtcdSvcTemplate = []byte(`{


### PR DESCRIPTION
This changes the self hosted etcd pods to use FQDN:
```
${member-name}.${cluster-name}.${namespace}.svc.cluster.local
```

We also need to change the bootstrap etcd pod to use cluster DNS.

In order to survive reboot, we update kenc to checkpoint etcd hosts onto
/var/etcd (where etcd data-dir resides).