### PR TITLE
Change `bootkube recover` flag to --recovery-dir.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,19 +69,19 @@ bootkube recover --help
 Recover from an external running etcd cluster:
 
 ```
-bootkube recover --asset-dir=recovered --etcd-servers=http://127.0.0.1:2379 --kubeconfig=/etc/kubernetes/kubeconfig
+bootkube recover --recovery-dir=recovered --etcd-servers=http://127.0.0.1:2379 --kubeconfig=/etc/kubernetes/kubeconfig
 ```
 
 Recover from a running apiserver (i.e. if the scheduler pods are all down):
 
 ```
-bootkube recover --asset-dir=recovered --kubeconfig=/etc/kubernetes/kubeconfig
+bootkube recover --recovery-dir=recovered --kubeconfig=/etc/kubernetes/kubeconfig
 ```
 
 Recover from an etcd backup when self hosted etcd is enabled:
 
 ```
-bootkube recover --asset-dir=recovered --etcd-backup-file=backup --kubeconfig=/etc/kubernetes/kubeconfig
+bootkube recover --recovery-dir=recovered --etcd-backup-file=backup --kubeconfig=/etc/kubernetes/kubeconfig
 ```
 
 For a complete recovery example please see the [hack/multi-node/bootkube-test-recovery](hack/multi-node/bootkube-test-recovery) and the [hack/multi-node/bootkube-test-recovery-self-hosted-etcd](hack/multi-node/bootkube-test-recovery-self-hosted-etcd) scripts.

--- a/cmd/bootkube/recover.go
+++ b/cmd/bootkube/recover.go
@@ -23,14 +23,14 @@ var (
 	cmdRecover = &cobra.Command{
 		Use:          "recover",
 		Short:        "Recover a self-hosted control plane",
-		Long:         "This command reads control plane manifests from a running apiserver or etcd and writes them to asset-dir. Users can then use `bootkube start` pointed at this asset-dir to re-the a self-hosted cluster. Please see the project README for more details and examples.",
+		Long:         "This command reads control plane manifests from a running apiserver or etcd and writes them to recovery-dir. Users can then use `bootkube start` pointed at this recovery-dir to re-the a self-hosted cluster. Please see the project README for more details and examples.",
 		PreRunE:      validateRecoverOpts,
 		RunE:         runCmdRecover,
 		SilenceUsage: true,
 	}
 
 	recoverOpts struct {
-		assetDir            string
+		recoveryDir         string
 		etcdCAPath          string
 		etcdCertificatePath string
 		etcdPrivateKeyPath  string
@@ -44,7 +44,7 @@ var (
 
 func init() {
 	cmdRoot.AddCommand(cmdRecover)
-	cmdRecover.Flags().StringVar(&recoverOpts.assetDir, "asset-dir", "", "Output path for writing recovered cluster assets.")
+	cmdRecover.Flags().StringVar(&recoverOpts.recoveryDir, "recovery-dir", "", "Output path for writing recovered cluster assets.")
 	cmdRecover.Flags().StringVar(&recoverOpts.etcdCAPath, "etcd-ca-path", "", "Path to an existing PEM encoded CA that will be used for TLS-enabled communication between the apiserver and etcd. Must be used in conjunction with --etcd-certificate-path and --etcd-private-key-path, and must have etcd configured to use TLS with matching secrets.")
 	cmdRecover.Flags().StringVar(&recoverOpts.etcdCertificatePath, "etcd-certificate-path", "", "Path to an existing certificate that will be used for TLS-enabled communication between the apiserver and etcd. Must be used in conjunction with --etcd-ca-path and --etcd-private-key-path, and must have etcd configured to use TLS with matching secrets.")
 	cmdRecover.Flags().StringVar(&recoverOpts.etcdPrivateKeyPath, "etcd-private-key-path", "", "Path to an existing private key that will be used for TLS-enabled communication between the apiserver and etcd. Must be used in conjunction with --etcd-ca-path and --etcd-certificate-path, and must have etcd configured to use TLS with matching secrets.")
@@ -111,12 +111,12 @@ func runCmdRecover(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return as.WriteFiles(recoverOpts.assetDir)
+	return as.WriteFiles(recoverOpts.recoveryDir)
 }
 
 func validateRecoverOpts(cmd *cobra.Command, args []string) error {
-	if recoverOpts.assetDir == "" {
-		return errors.New("missing required flag: --asset-dir")
+	if recoverOpts.recoveryDir == "" {
+		return errors.New("missing required flag: --recovery-dir")
 	}
 	if (recoverOpts.etcdCAPath != "" || recoverOpts.etcdCertificatePath != "" || recoverOpts.etcdPrivateKeyPath != "") && (recoverOpts.etcdCAPath == "" || recoverOpts.etcdCertificatePath == "" || recoverOpts.etcdPrivateKeyPath == "") {
 		return errors.New("you must specify either all or none of --etcd-ca-path, --etcd-certificate-path, and --etcd-private-key-path")

--- a/hack/multi-node/bootkube-test-recovery
+++ b/hack/multi-node/bootkube-test-recovery
@@ -35,7 +35,7 @@ echo
 
 scp -q -F ssh_config ../../_output/bin/linux/bootkube cluster/auth/kubeconfig cluster/tls/etcd-* core@$HOST:/home/core
 ssh -q -F ssh_config core@$HOST "GLOG_v=${GLOG_v} /home/core/bootkube recover \
-  --asset-dir=/home/core/recovered \
+  --recovery-dir=/home/core/recovered \
   --etcd-ca-path=/home/core/etcd-ca.crt \
   --etcd-certificate-path=/home/core/etcd-client.crt \
   --etcd-private-key-path=/home/core/etcd-client.key \

--- a/hack/multi-node/bootkube-test-recovery-self-hosted-etcd
+++ b/hack/multi-node/bootkube-test-recovery-self-hosted-etcd
@@ -41,7 +41,7 @@ echo
 
 scp -q -F ssh_config ../../_output/bin/linux/bootkube cluster/auth/kubeconfig cluster/etcdbackup core@$HOST:/home/core
 ssh -q -F ssh_config core@$HOST "sudo GLOG_v=${GLOG_v} /home/core/bootkube recover \
-  --asset-dir=/home/core/recovered \
+  --recovery-dir=/home/core/recovered \
   --etcd-backup-file=/home/core/etcdbackup \
   --kubeconfig=/home/core/kubeconfig 2>> /home/core/recovery.log"
 


### PR DESCRIPTION
Field ops reports that people find the --asset-dir flag confusing; they
think that means you need to pass in the same --asset-dir that was used
to create the cluster.

cc @coresolve