### PR TITLE
templates: EtcdOperator shouldn't run as nobody

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -916,9 +916,6 @@ spec:
               fieldPath: metadata.name
       nodeSelector:
         node-role.kubernetes.io/master: ""
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists


### PR DESCRIPTION
fix https://github.com/kubernetes-incubator/bootkube/issues/581