### PR TITLE
*: bootFromBackupEtcd should use `dnsPolicy: ClusterFirstWithHostNet`

### DIFF
--- a/pkg/recovery/etcd_template.go
+++ b/pkg/recovery/etcd_template.go
@@ -128,6 +128,7 @@ spec:
           name: etcd
           readOnly: false
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   restartPolicy: Never
   volumes:
     - name: etcd


### PR DESCRIPTION
Current master is broken on self-hosted etcd recovery. We need this to fix it.
@diegs @aaronlevy @xiang90