### PR TITLE
hack/terraform-quickstart: remove dependancy on default network

### DIFF
--- a/hack/terraform-quickstart/main.tf
+++ b/hack/terraform-quickstart/main.tf
@@ -10,8 +10,13 @@ resource "aws_instance" "bootstrap_node" {
   key_name             = "${var.ssh_key}"
   iam_instance_profile = "${aws_iam_instance_profile.bk_profile.id}"
 
+  vpc_security_group_ids      = ["${aws_security_group.allow_all.id}"]
+  subnet_id                   = "${aws_subnet.main.id}"
+  associate_public_ip_address = true
+  depends_on                  = ["aws_internet_gateway.main"]
+
   tags {
-    Name = "${var.instance_tags}"
+    Name = "${var.resource_owner}"
   }
 
   root_block_device {
@@ -27,8 +32,13 @@ resource "aws_instance" "worker_node" {
   count                = "${var.num_workers}"
   iam_instance_profile = "${aws_iam_instance_profile.bk_profile.id}"
 
+  vpc_security_group_ids      = ["${aws_security_group.allow_all.id}"]
+  subnet_id                   = "${aws_subnet.main.id}"
+  associate_public_ip_address = true
+  depends_on                  = ["aws_internet_gateway.main"]
+
   tags {
-    Name = "${var.instance_tags}"
+    Name = "${var.resource_owner}"
   }
 
   root_block_device {
@@ -44,8 +54,13 @@ resource "aws_instance" "master_node" {
   count                = "${var.additional_masters}"
   iam_instance_profile = "${aws_iam_instance_profile.bk_profile.id}"
 
+  vpc_security_group_ids      = ["${aws_security_group.allow_all.id}"]
+  subnet_id                   = "${aws_subnet.main.id}"
+  associate_public_ip_address = true
+  depends_on                  = ["aws_internet_gateway.main"]
+
   tags {
-    Name = "${var.instance_tags}"
+    Name = "${var.resource_owner}"
   }
 
   root_block_device {

--- a/hack/terraform-quickstart/network.tf
+++ b/hack/terraform-quickstart/network.tf
@@ -1,0 +1,95 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.8.0.0/16"
+
+  tags {
+    Name = "${var.resource_owner}"
+  }
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_subnet" "main" {
+  vpc_id            = "${aws_vpc.main.id}"
+  cidr_block        = "10.8.0.0/24"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+
+  tags {
+    Name = "${var.resource_owner}"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = "${aws_vpc.main.id}"
+
+  tags {
+    Name = "${var.resource_owner}"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = "${aws_vpc.main.id}"
+
+  tags {
+    Name = "${var.resource_owner}"
+  }
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.main.id}"
+  }
+}
+
+resource "aws_route_table_association" "main_subnet" {
+  subnet_id      = "${aws_subnet.main.id}"
+  route_table_id = "${aws_route_table.public.id}"
+}
+
+resource "aws_security_group" "allow_all" {
+  name_prefix = "allow_all"
+  description = "Allow all inbound traffic"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${var.resource_owner}"
+  }
+}
+
+resource "aws_network_acl" "all" {
+  vpc_id = "${aws_vpc.main.id}"
+
+  egress {
+    protocol   = "-1"
+    rule_no    = 2
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 1
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags {
+    Name = "${var.resource_owner}"
+  }
+}

--- a/hack/terraform-quickstart/terraform.tfvars.example
+++ b/hack/terraform-quickstart/terraform.tfvars.example
@@ -1,5 +1,5 @@
 access_key_id = ""
 access_key = ""
-instance_tags = "bootkube_example_terraform"
+resource_owner = "bootkube_example_terraform"
 ssh_key = ""
 

--- a/hack/terraform-quickstart/variables.tf
+++ b/hack/terraform-quickstart/variables.tf
@@ -11,9 +11,10 @@ variable "ssh_key" {
   type        = "string"
 }
 
-variable "instance_tags" {
-  description = "Name all instances behind a single tag based on who/what is running terraform"
+variable "resource_owner" {
+  description = "Tag all resources behind a single tag based on who/what is running terraform"
   type        = "string"
+  default     = "bootkube-terraform-example-deleteme"
 }
 
 variable "instance_type" {


### PR DESCRIPTION
This PR avoids terraform depending on a sane default network existing to
expose the nodes. This includes creating a VPC, subnet, route table,
internet gateway, open security group, and a network ACL.  This will be
useful once tools to auto-wipe a region are used so that it doesn't take
out all our tests that depend on default networks lying around.

Besides changing the variable `instance_tags` to `resource_owner` to tag our resources this should ultimately be creating nodes that are no different from before. As an aside, we should probably conform to the new tagging standard, but since most uses of this terraform are transient anyway its not urgent.

Also, its important we get this in tomorrow or CI will likely break.

cc @aaronlevy 