### PR TITLE
e2e: add ability to drop out of test and into SSH shell

### DIFF
--- a/e2e/ssh_client.go
+++ b/e2e/ssh_client.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
@@ -9,6 +10,7 @@ import (
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 type SSHClient struct {
@@ -78,4 +80,59 @@ func (c *SSHClient) SSH(host, cmd string) (stdout, stderr []byte, err error) {
 	stderr = bytes.TrimSpace(errBuf.Bytes())
 
 	return stdout, stderr, err
+}
+
+// Manhole connects os.Stdin, os.Stdout, and os.Stderr to an interactive shell
+// session on the Machine m. Manhole blocks until the shell session has ended.
+// If os.Stdin does not refer to a TTY, Manhole returns immediately with a nil
+// error. Copied from github.com/coreos/mantle/platform/util.go
+func (c *SSHClient) Manhole(host string) error {
+	fd := int(os.Stdin.Fd())
+	if !terminal.IsTerminal(fd) {
+		return nil
+	}
+
+	tstate, _ := terminal.MakeRaw(fd)
+	defer terminal.Restore(fd, tstate)
+
+	client, err := ssh.Dial("tcp", host+":22", c.ClientConfig)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return fmt.Errorf("SSH session failed: %v", err)
+	}
+
+	defer session.Close()
+
+	session.Stdin = os.Stdin
+	session.Stdout = os.Stdout
+	session.Stderr = os.Stderr
+
+	modes := ssh.TerminalModes{
+		ssh.TTY_OP_ISPEED: 115200,
+		ssh.TTY_OP_OSPEED: 115200,
+	}
+
+	cols, lines, err := terminal.GetSize(int(os.Stdin.Fd()))
+	if err != nil {
+		return err
+	}
+
+	if err = session.RequestPty(os.Getenv("TERM"), lines, cols, modes); err != nil {
+		return fmt.Errorf("failed to request pseudo terminal: %s", err)
+	}
+
+	if err := session.Shell(); err != nil {
+		return fmt.Errorf("failed to start shell: %s", err)
+	}
+
+	if err := session.Wait(); err != nil {
+		return fmt.Errorf("failed to wait for session: %s", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
The ergonomics could be improved a bit (not all tests have ready access
to the list of hostnames), but that is more in-scope for other
framework-ish cleanups.

Posting this up while I wait for flakes to reproduce locally.

cc @diegs @yifan-gu 