### PR TITLE
pkg/asset/internal: allow controller-manager to use cluster+host DNS

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -457,7 +457,7 @@ spec:
       - name: ssl-host
         hostPath:
           path: /usr/share/ca-certificates
-      dnsPolicy: Default # Don't use cluster DNS.
+      dnsPolicy: ClusterFirstWithHostNet
 `)
 
 var ControllerManagerServiceAccount = []byte(`apiVersion: v1


### PR DESCRIPTION
Changing this to `Default` policy was originally to support cloud-providers. However, we can now allow it to use both the cluster and host DNS.