### PR TITLE
e2e: flake / debug improvements

### DIFF
--- a/e2e/network_test.go
+++ b/e2e/network_test.go
@@ -264,7 +264,7 @@ var wgetPodNT = &v1.Pod{
 			{
 				Name:    "wget-container",
 				Image:   "busybox:1.26",
-				Command: []string{"wget", "--timeout", "5", "--retry-connrefused", "--waitretry=1", "--tries", "5", "nginx-service-nt"},
+				Command: []string{"wget", "--timeout", "5", "--retry-connrefused", "--waitretry", "1", "--tries", "5", "nginx-service-nt"},
 			},
 		},
 		RestartPolicy: v1.RestartPolicyNever,

--- a/e2e/network_test.go
+++ b/e2e/network_test.go
@@ -264,7 +264,7 @@ var wgetPodNT = &v1.Pod{
 			{
 				Name:    "wget-container",
 				Image:   "busybox:1.26",
-				Command: []string{"wget", "--timeout", "5", "--retry-connrefused", "--waitretry", "1", "--tries", "5", "nginx-service-nt"},
+				Command: []string{"wget", "--timeout", "5", "nginx-service-nt"},
 			},
 		},
 		RestartPolicy: v1.RestartPolicyNever,

--- a/e2e/network_test.go
+++ b/e2e/network_test.go
@@ -65,7 +65,7 @@ func TestNetwork(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := retry(10, time.Second*10, getPod(testPodName)); err != nil {
+	if err := retry(10, time.Second*10, getSucceededPod(testPodName)); err != nil {
 		t.Fatalf(fmt.Sprintf("timed out waiting for wget pod to succeed: %v", err))
 	}
 
@@ -176,7 +176,7 @@ func HelperPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := retry(10, time.Second*10, getPod(testPodName)); err != nil {
+	if err := retry(10, time.Second*10, getSucceededPod(testPodName)); err != nil {
 		t.Fatalf(fmt.Sprintf("timed out waiting for wget pod to succeed: %v", err))
 	}
 
@@ -210,14 +210,15 @@ func getNginxPod() error {
 	return nil
 }
 
-func getPod(name string) func() error {
+//TODO(aaron): We shouldn't always be re-trying this until timeout. If the pod failed (not just hasn't been scheduled) it's not ever going to succeed.
+func getSucceededPod(name string) func() error {
 	return func() error {
 		p, err := client.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("couldn't get pod: %v", err)
+			return fmt.Errorf("couldn't get pod %q: %v", name, err)
 		}
 		if p.Status.Phase != v1.PodSucceeded {
-			return fmt.Errorf("pod did not succeed: %v", p.Status.Phase)
+			return fmt.Errorf("pod %q has not succeeded. Phase: %q, Reason %q: %v", name, p.Status.Phase, p.Status.Reason, p.Status.Message)
 		}
 		return nil
 	}
@@ -263,7 +264,7 @@ var wgetPodNT = &v1.Pod{
 			{
 				Name:    "wget-container",
 				Image:   "busybox:1.26",
-				Command: []string{"wget", "--timeout", "5", "nginx-service-nt"},
+				Command: []string{"wget", "--timeout", "5", "--retry-connrefused", "--waitretry=1", "--tries", "5", "nginx-service-nt"},
 			},
 		},
 		RestartPolicy: v1.RestartPolicyNever,

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -32,14 +32,14 @@ func TestSmoke(t *testing.T) {
 	getPod := func() error {
 		l, err := client.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: "app=smoke-nginx"})
 		if err != nil || len(l.Items) == 0 {
-			return fmt.Errorf("pod not yet running: %v", err)
+			return fmt.Errorf("failed to list smoke-nginx pod: %v", err)
 		}
 
 		// take the first pod
 		p = &l.Items[0]
 
 		if p.Status.Phase != v1.PodRunning {
-			return fmt.Errorf("pod not yet running: %v", p.Status.Phase)
+			return fmt.Errorf("smoke-nginx pod not running. Phase: %q, Reason %q: %v", p.Status.Phase, p.Status.Reason, p.Status.Message)
 		}
 		return nil
 	}
@@ -59,10 +59,10 @@ func TestSmoke(t *testing.T) {
 	getPod = func() error {
 		p, err = client.CoreV1().Pods(namespace).Get("wget-pod", metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("pod not yet running: %v", err)
+			return fmt.Errorf("failed to retrieve wget-pod: %v", err)
 		}
 		if p.Status.Phase != v1.PodSucceeded {
-			return fmt.Errorf("pod not yet running: %v", p.Status.Phase)
+			return fmt.Errorf("wget-pod not running. Phase: %q, Reason %q: %v", p.Status.Phase, p.Status.Reason, p.Status.Message)
 		}
 		return nil
 	}


### PR DESCRIPTION
Previously if the wget-pod, for example, was never running all we saw was the phase "Failed" -- but no reason why it failed. We should output a bit more info to help debugging flaky PR tests.