### PR TITLE
Documentation: Add integration & production user tracking docs

### DIFF
--- a/Documentation/users-integrations.md
+++ b/Documentation/users-integrations.md
@@ -1,0 +1,8 @@
+# Users and Integrations
+
+This document tracks projects, integrations, and use cases for bootkube. [Join the community](../README.md), and help us keep the list up-to-date.
+
+* [Tectonic](https://coreos.com/tectonic) - Enterprise-ready Kubernetes clusters
+* [Matchbox](https://coreos.com/matchbox/docs/latest/) - Easily launch self-hosted clusters on Bare-metal
+* [kubermesh](https://github.com/kubermesh/kubermesh) - Bare metal, self-hosted, self-healing/provisioning, mesh network kubernetes cluster. See the [blog post](http://ocadotechnology.com/blog/creating-a-distributed-data-centre-architecture-using-kubernetes-and-containers/) for more details.
+* [Archon](https://github.com/kubeup/archon) - Kubernetes management and automation tool based on the [operator pattern](https://coreos.com/blog/introducing-operators.html)

--- a/Documentation/users-integrations.md
+++ b/Documentation/users-integrations.md
@@ -6,3 +6,6 @@ This document tracks projects, integrations, and use cases for bootkube. [Join t
 * [Matchbox](https://coreos.com/matchbox/docs/latest/) - Easily launch self-hosted clusters on Bare-metal
 * [kubermesh](https://github.com/kubermesh/kubermesh) - Bare metal, self-hosted, self-healing/provisioning, mesh network kubernetes cluster. See the [blog post](http://ocadotechnology.com/blog/creating-a-distributed-data-centre-architecture-using-kubernetes-and-containers/) for more details.
 * [Archon](https://github.com/kubeup/archon) - Kubernetes management and automation tool based on the [operator pattern](https://coreos.com/blog/introducing-operators.html)
+* [Typhoon](https://github.com/poseidon/typhoon) - Minimal and free Kubernetes distribution
+* [bootkube-terraform](https://github.com/poseidon/bootkube-terraform) - Terraform module for rendering bootkube manifests and assets
+* [kube-linode](https://github.com/kahkhang/kube-linode) - Provision a CoreOS/Kubernetes cluster on Linode

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Want to contribute to bootkube? Have Questions? We are looking for active partic
 
 You can find us at the bootkube channel on [Kubernetes slack](https://github.com/kubernetes/community#slack-chat)
 
+## Related Links
+
+* [Users and Integrations](Documentation/users-integrations.md)
+
 ## License
 
 bootkube is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
I'd still like to gather a few more use-cases before initial merging. This is to get the scaffolding started.

Also on the table is what info we want to collect RE production users (can use etcd as a reference: https://github.com/coreos/etcd/blob/master/Documentation/production-users.md)