### PR TITLE
e2e: disable flaky etcd scale tests.

### DIFF
--- a/e2e/etcdscale_test.go
+++ b/e2e/etcdscale_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 func TestEtcdScale(t *testing.T) {
+	// TODO(etcd-team): re-enable this once scaling is stable.
+	t.Skip("disabled due to flakiness")
+
 	// check that we have 3 or more masters
 	etcdScalePreCheck(client, t)
 
@@ -27,10 +30,9 @@ func TestEtcdScale(t *testing.T) {
 	}
 
 	// scale back to 1
-	// TODO(diegs): re-enable this once scale-down issue is resolved.
-	// if err := resizeSelfHostedEtcd(client, 1); err != nil {
-	// 	t.Fatalf("scaling down: %v", err)
-	// }
+	if err := resizeSelfHostedEtcd(client, 1); err != nil {
+		t.Fatalf("scaling down: %v", err)
+	}
 }
 
 // Skip if not running 3 or more master nodes unless explicitly told to be
@@ -39,7 +41,7 @@ func TestEtcdScale(t *testing.T) {
 func etcdScalePreCheck(c kubernetes.Interface, t *testing.T) {
 	var requiredMasters int = 3
 	if expectedMasters < requiredMasters {
-		t.Skip(fmt.Errorf("Test requires %d masters, test was run expecting %d", requiredMasters, expectedMasters))
+		t.Skipf("Test requires %d masters, test was run expecting %d", requiredMasters, expectedMasters)
 	}
 
 	checkMasters := func() error {


### PR DESCRIPTION
We've seen issues scaling the cluster up:

https://jenkins-kube-lifecycle.prod.coreos.systems/job/bootkube-pr-e2e-selfetcd/417/consoleFull

and scaling the cluster down:

https://jenkins-kube-lifecycle.prod.coreos.systems/job/bootkube-pr-e2e-selfetcd/406/consoleFull

(many more examples seen).

Until these issues are investigated and resolved out-of-band, disabling these tests to make submitting PRs less difficult. The tests will still *stand up* self-hosted clusters, so basic functionality is still covered. This is just the scaling functionality.

cc @hongchaodeng @xiang90 