### PR TITLE
copyFile: close source and destination file handles

### DIFF
--- a/pkg/bootkube/bootstrap.go
+++ b/pkg/bootkube/bootstrap.go
@@ -70,11 +70,13 @@ func copyFile(src, dst string, overwrite bool) error {
 	if err != nil {
 		return err
 	}
+	defer dstfile.Close()
 
 	srcfile, err := os.Open(src)
 	if err != nil {
 		return err
 	}
+	defer srcfile.Close()
 
 	_, err = io.Copy(dstfile, srcfile)
 	return err


### PR DESCRIPTION
# Why

Fixes a file descriptor leak within the copyFile. The function leaks two handles for every file copied.

# Solution

Close the handles after the copy.