### PR TITLE
hack/quickstart: Mask locksmithd instead of update-engine

### DIFF
--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -50,7 +50,7 @@ EOF
 # Initialize a Master node
 function init_master_node() {
     systemctl daemon-reload
-    systemctl stop update-engine; systemctl mask update-engine
+    systemctl stop locksmithd; systemctl mask locksmithd
 
     if [ "$SELF_HOST_ETCD" = true ] ; then
         echo "WARNING: THIS IS NOT YET FULLY WORKING - merely here to make ongoing testing easier"

--- a/hack/quickstart/init-node.sh
+++ b/hack/quickstart/init-node.sh
@@ -33,7 +33,7 @@ function init_worker_node() {
 
     # Start services
     systemctl daemon-reload
-    systemctl stop update-engine; systemctl mask update-engine
+    systemctl stop locksmithd; systemctl mask locksmithd
     systemctl enable kubelet; sudo systemctl start kubelet
 }
 


### PR DESCRIPTION
update-engine was initially masked to prevent the servers from
rebooting, when testing.
This caused locksmithd to restart forever and spam the system log,
as it depend on the update-engine.
With this change, the system would update but won't reboot
automatic.