### PR TITLE
run e2e locally

### DIFF
--- a/hack/multi-node/README.md
+++ b/hack/multi-node/README.md
@@ -10,6 +10,15 @@ This will generate the default assets in the `cluster` directory and launch mult
 ./bootkube-up
 ```
 
+## Running E2E tests
+
+```
+$ ssh-add ~/.vagrant.d/insecure_private_key
+$ export KUBECONFIG=$PWD/cluster/auth/kubeconfig
+$ cd ../.. # project root
+$ go test -v ./e2e/ --kubeconfig=$KUBECONFIG
+```
+
 ## Cleaning up
 
 To stop the running cluster and remove generated assets, run:


### PR DESCRIPTION
This tweak allows for E2E tests to be ran with the multi-node config.

Trying to debug into the test flakiness with: https://github.com/kubernetes-incubator/bootkube/pull/674