### PR TITLE
flannel-cni: bump to v0.2.0

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -5,7 +5,7 @@ var DefaultImages = ImageVersions{
 	Etcd:            "quay.io/coreos/etcd:v3.1.8",
 	EtcdOperator:    "quay.io/coreos/etcd-operator:v0.4.2",
 	Flannel:         "quay.io/coreos/flannel:v0.8.0-amd64",
-	FlannelCNI:      "quay.io/coreos/flannel-cni:0.1.0",
+	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.2.0",
 	Calico:          "quay.io/calico/node:v2.4.0",
 	CalicoCNI:       "quay.io/calico/cni:v1.10.0",
 	Hyperkube:       "quay.io/coreos/hyperkube:v1.7.3_coreos.0",


### PR DESCRIPTION
I haven't tested it, but @dghubble has [tested it with bootkube](https://github.com/coreos/flannel-cni/pull/3#pullrequestreview-57941938).