### PR TITLE
pkg/asset: Disable etcd-operator analytics

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -908,6 +908,9 @@ spec:
       containers:
       - name: etcd-operator
         image: {{ .Images.EtcdOperator }}
+        command:
+        - /usr/local/bin/etcd-operator
+        - --analytics=false
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
An incubator project probably shouldn't have this enabled by default.