### PR TITLE
CNI: Enable portmap plugin by default

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -1070,10 +1070,21 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
-      "type": "flannel",
-      "delegate": {
-        "isDefaultGateway": true
-      }
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "isDefaultGateway": true
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
     }
   net-conf.json: |
     {
@@ -1129,8 +1140,6 @@ spec:
         image: {{ .Images.FlannelCNI }}
         command: ["/install-cni.sh"]
         env:
-        - name: CNI_CONF_NAME
-          value: "10-flannel.conf"
         - name: CNI_NETWORK_CONFIG
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
With this change, hostPort is finally working.

Fix #662

---
Require: https://github.com/coreos/flannel-cni/pull/5 (due to the file extension change).

cc @aaronlevy 

I have tested this on my bootkube cluster.