### PR TITLE
x509: ensure unique certificate subjects.

### DIFF
--- a/pkg/asset/tls.go
+++ b/pkg/asset/tls.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"net/url"
 
+	"github.com/pborman/uuid"
+
 	"github.com/kubernetes-incubator/bootkube/pkg/tlsutil"
 )
 
@@ -55,8 +57,9 @@ func newCACert() (*rsa.PrivateKey, *x509.Certificate, error) {
 	}
 
 	config := tlsutil.CertConfig{
-		CommonName:   "kube-ca",
-		Organization: []string{"bootkube"},
+		CommonName:         "kube-ca",
+		Organization:       []string{uuid.New()},
+		OrganizationalUnit: []string{"bootkube"},
 	}
 
 	cert, err := tlsutil.NewSelfSignedCACertificate(config, key)

--- a/pkg/tlsutil/tlsutil.go
+++ b/pkg/tlsutil/tlsutil.go
@@ -19,9 +19,10 @@ const (
 )
 
 type CertConfig struct {
-	CommonName   string
-	Organization []string
-	AltNames     AltNames
+	CommonName         string
+	Organization       []string
+	OrganizationalUnit []string
+	AltNames           AltNames
 }
 
 // AltNames contains the domain names and IP addresses that will be added
@@ -69,8 +70,9 @@ func NewSelfSignedCACertificate(cfg CertConfig, key *rsa.PrivateKey) (*x509.Cert
 	tmpl := x509.Certificate{
 		SerialNumber: new(big.Int).SetInt64(0),
 		Subject: pkix.Name{
-			CommonName:   cfg.CommonName,
-			Organization: cfg.Organization,
+			CommonName:         cfg.CommonName,
+			Organization:       cfg.Organization,
+			OrganizationalUnit: cfg.OrganizationalUnit,
 		},
 		NotBefore:             now.UTC(),
 		NotAfter:              now.Add(Duration365d * 10).UTC(),


### PR DESCRIPTION
Moves `bootkube` to the `OrganizationalUnit` and uses a UUID for the
`Organization`. This ensures that each CA's identifiers hash to a unique
value.

Fixes #696

cc @brianredbeard 