### PR TITLE
pkg/asset: Update flannel-cni from v0.2.0 to v0.3.0

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -5,7 +5,7 @@ var DefaultImages = ImageVersions{
 	Etcd:            "quay.io/coreos/etcd:v3.1.8",
 	EtcdOperator:    "quay.io/coreos/etcd-operator:v0.5.0",
 	Flannel:         "quay.io/coreos/flannel:v0.8.0-amd64",
-	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.2.0",
+	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
 	Calico:          "quay.io/calico/node:v2.5.1",
 	CalicoCNI:       "quay.io/calico/cni:v1.10.0",
 	Hyperkube:       "quay.io/coreos/hyperkube:v1.7.5_coreos.0",

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -1129,6 +1129,8 @@ spec:
         image: {{ .Images.FlannelCNI }}
         command: ["/install-cni.sh"]
         env:
+        - name: CNI_CONF_NAME
+          value: "10-flannel.conf"
         - name: CNI_NETWORK_CONFIG
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Bump flannel-cni to [v0.3.0](https://github.com/coreos/flannel-cni/releases/tag/v0.3.0), but retain the original flannel CNI config name. This should make no functional change in clusters and should pass tests since flannel-cni:v0.3.0 is [compatible](https://github.com/coreos/flannel-cni/pull/5#issuecomment-328663841) with prior versions.

Then, we can either merge this and followup with #697 or skip and go directly to an updated #697 which changes the CNI config to add portmap.

### Testing

I've tested a bare-metal cluster with this change.