### PR TITLE
[NOT TESTED] etcd-operator: bump to v0.5.2

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -3,7 +3,7 @@ package asset
 // DefaultImages are the defualt images bootkube components use.
 var DefaultImages = ImageVersions{
 	Etcd:            "quay.io/coreos/etcd:v3.1.8",
-	EtcdOperator:    "quay.io/coreos/etcd-operator:v0.5.0",
+	EtcdOperator:    "quay.io/coreos/etcd-operator:v0.5.2",
 	Flannel:         "quay.io/coreos/flannel:v0.8.0-amd64",
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.2.0",
 	Calico:          "quay.io/calico/node:v2.5.1",

--- a/pkg/asset/tls.go
+++ b/pkg/asset/tls.go
@@ -174,8 +174,8 @@ func newSelfHostedEtcdTLSAssets(etcdSvcIP, bootEtcdSvcIP string, caCert *x509.Ce
 		bootEtcdSvcIP,
 		"127.0.0.1",
 		"localhost",
-		"*.kube-etcd.kube-system.svc.cluster.local",
-		"kube-etcd-client.kube-system.svc.cluster.local",
+		"*.kube-etcd.kube-system.svc",
+		"kube-etcd-client.kube-system.svc",
 	})
 	if err != nil {
 		return nil, err
@@ -188,8 +188,8 @@ func newSelfHostedEtcdTLSAssets(etcdSvcIP, bootEtcdSvcIP string, caCert *x509.Ce
 
 	key, cert, err = newKeyAndCert(caCert, caPrivKey, "etcd member peer", []string{
 		bootEtcdSvcIP,
-		"*.kube-etcd.kube-system.svc.cluster.local",
-		"kube-etcd-client.kube-system.svc.cluster.local",
+		"*.kube-etcd.kube-system.svc",
+		"kube-etcd-client.kube-system.svc",
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Note: v0.5.1 contains a breaking TLS change, please check the
release note before upgrading:
https://github.com/coreos/etcd-operator/releases/tag/v0.5.1