### PR TITLE
Add network provider option and Calico support

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -113,8 +113,8 @@ func validateRenderOpts(cmd *cobra.Command, args []string) error {
 	if renderOpts.apiServers == "" {
 		return errors.New("Missing requried flag: --api-servers")
 	}
-	if renderOpts.networkProvider != asset.NetworkFlannel && renderOpts.networkProvider != asset.NetworkCanal {
-		return errors.New("Must specify --network-provider flannel or experimental-canal")
+	if renderOpts.networkProvider != asset.NetworkFlannel && renderOpts.networkProvider != asset.NetworkCalico && renderOpts.networkProvider != asset.NetworkCanal {
+		return errors.New("Must specify --network-provider flannel or experimental-calico or experimental-canal")
 	}
 	return nil
 }

--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -61,6 +61,8 @@ function init_master_node() {
 
     if [ "$NETWORK_PROVIDER" = "canal" ]; then
         network_provider_flags="--network-provider=experimental-canal"
+    elif [ "$NETWORK_PROVIDER" = "calico" ]; then
+        network_provider_flags="--network-provider=experimental-calico"
     else
         network_provider_flags="--network-provider=flannel"
     fi

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -40,6 +40,7 @@ const (
 	AssetPathKubeFlannel                 = "manifests/kube-flannel.yaml"
 	AssetPathKubeFlannelCfg              = "manifests/kube-flannel-cfg.yaml"
 	AssetPathCalico                      = "manifests/calico.yaml"
+	AssetPathCalicoPolicyOnly            = "manifests/calico-policy-only.yaml"
 	AssetPathCalicoCfg                   = "manifests/calico-config.yaml"
 	AssetPathCalcioSA                    = "manifests/calico-service-account.yaml"
 	AssetPathCalcioRole                  = "manifests/calico-role.yaml"

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -1225,6 +1225,130 @@ spec:
       hostNetwork: true
       serviceAccountName: calico-node
       tolerations:
+        # Allow the pod to run on master nodes
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        # Mark the pod as a critical add-on for rescheduling
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      containers:
+        - name: calico-node
+          image: {{ .Images.Calico }}
+          env:
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
+            - name: CLUSTER_TYPE
+              value: "k8s,bgp"
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            - name: CALICO_IPV4POOL_CIDR
+              value: "{{ .PodCIDR }}"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
+            - name: FELIX_IPINIPENABLED
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9099
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9099
+            periodSeconds: 10
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        - name: install-cni
+          image: quay.io/calico/cni:v1.10.0
+          command: ["/install-cni.sh"]
+          env:
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            - name: CNI_NET_DIR
+              value: "/etc/kubernetes/cni/net.d"
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/kubernetes/cni/net.d
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+`)
+
+var CalicoPolicyOnlyTemplate = []byte(`apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      serviceAccountName: calico-node
+      tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
         - key: "CriticalAddonsOnly"

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -20,6 +20,7 @@ const (
 	SecretEtcdClient = "etcd-client-tls"
 
 	NetworkFlannel = "flannel"
+	NetworkCalico  = "experimental-calico"
 	NetworkCanal   = "experimental-canal"
 
 	secretNamespace     = "kube-system"
@@ -73,13 +74,24 @@ func newDynamicAssets(conf Config) Assets {
 			MustCreateAssetFromTemplate(AssetPathKubeFlannelCfg, internal.KubeFlannelCfgTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathKubeFlannel, internal.KubeFlannelTemplate, conf),
 		)
-	case NetworkCanal:
+	case NetworkCalico:
 		assets = append(assets,
 			MustCreateAssetFromTemplate(AssetPathCalicoCfg, internal.CalicoCfgTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathCalcioRole, internal.CalicoRoleTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathCalcioRoleBinding, internal.CalicoRoleBindingTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathCalcioSA, internal.CalicoServiceAccountTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathCalico, internal.CalicoNodeTemplate, conf),
+			MustCreateAssetFromTemplate(AssetPathCalicoBGPConfigsCRD, internal.CalicoBGPConfigsCRD, conf),
+			MustCreateAssetFromTemplate(AssetPathCalicoFelixConfigsCRD, internal.CalicoFelixConfigsCRD, conf),
+			MustCreateAssetFromTemplate(AssetPathCalicoNetworkPoliciesCRD, internal.CalicoNetworkPoliciesCRD, conf),
+			MustCreateAssetFromTemplate(AssetPathCalicoIPPoolsCRD, internal.CalicoIPPoolsCRD, conf))
+	case NetworkCanal:
+		assets = append(assets,
+			MustCreateAssetFromTemplate(AssetPathCalicoCfg, internal.CalicoCfgTemplate, conf),
+			MustCreateAssetFromTemplate(AssetPathCalcioRole, internal.CalicoRoleTemplate, conf),
+			MustCreateAssetFromTemplate(AssetPathCalcioRoleBinding, internal.CalicoRoleBindingTemplate, conf),
+			MustCreateAssetFromTemplate(AssetPathCalcioSA, internal.CalicoServiceAccountTemplate, conf),
+			MustCreateAssetFromTemplate(AssetPathCalicoPolicyOnly, internal.CalicoPolicyOnlyTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathCalicoBGPConfigsCRD, internal.CalicoBGPConfigsCRD, conf),
 			MustCreateAssetFromTemplate(AssetPathCalicoFelixConfigsCRD, internal.CalicoFelixConfigsCRD, conf),
 			MustCreateAssetFromTemplate(AssetPathCalicoNetworkPoliciesCRD, internal.CalicoNetworkPoliciesCRD, conf),


### PR DESCRIPTION
* Support choosing Flannel or Calico networking (`--network-provider`)
* On Jenkins, I've added a new test to provision a cluster with calico and perform the usual e2e tests.

This is based on [poseidon/bootkube-terraform](https://github.com/poseidon/bootkube-terraform), which uses Calico or flannel as the network provider on [AWS, GCE, and bare-metal clusters](https://github.com/poseidon/typhoon) (Digital Ocean w caveats). I figured it would be nice to have in the upstream project in case others want to use it.

rel #405 
Closes #407 