### PR TITLE
e2e: Fix network test to condition on calico-node

### DIFF
--- a/e2e/network_test.go
+++ b/e2e/network_test.go
@@ -27,13 +27,13 @@ const (
 // 5. create NetworkPolicy that allows `allow=access`
 // 6. create a wget job with label `allow=access` that hits the nginx service
 func TestNetwork(t *testing.T) {
-	// check if kube-calico daemonset exists
+	// check if calico-node daemonset exists
 	// if absent skip this test
-	if _, err := client.ExtensionsV1beta1().DaemonSets("kube-system").Get("kube-calico", metav1.GetOptions{}); err != nil {
+	if _, err := client.ExtensionsV1beta1().DaemonSets("kube-system").Get("calico-node", metav1.GetOptions{}); err != nil {
 		if apierrors.IsNotFound(err) {
-			t.Skip("kube-calico daemonset is not installed")
+			t.Skip("calico-node daemonset is not installed")
 		}
-		t.Fatalf("error getting kube-calico daemonset: %v", err)
+		t.Fatalf("error getting calico-node daemonset: %v", err)
 	}
 
 	var nginx *testworkload.Nginx


### PR DESCRIPTION
* Calico DaemonSet is named calico-node, not kube-calico

Before:

```
[669905.121365] golang[5]: --- SKIP: TestNetwork (0.01s)
[669905.121659] golang[5]: 	network_test.go:34: kube-calico daemonset is not installed
```

After

```
[1193097.434229] golang[5]: === RUN   TestNetwork
[1193109.676259] golang[5]: === RUN   TestNetwork/DefaultDeny
[1193120.880809] golang[5]: === RUN   TestNetwork/NetworkPolicy
[1193127.124359] golang[5]: --- PASS: TestNetwork (29.69s)
[1193127.124911] golang[5]:     --- PASS: TestNetwork/DefaultDeny (11.20s)
[1193127.125206] golang[5]:     --- PASS: TestNetwork/NetworkPolicy (6.10s)
```