### PR TITLE
Documentation: Refresh the cluster upgrade guide

### DIFF
--- a/Documentation/upgrading.md
+++ b/Documentation/upgrading.md
@@ -1,173 +1,163 @@
+# Upgrading self-hosted Kubernetes
 
-# Upgrading Self-hosted Kubernetes
+"Self-hosted" Kubernetes clusters run the apiserver, scheduler, controller-manager, kube-dns, kube-proxy, and flannel or calico as pods, like ordinary applications. This allows upgrades to be performed in-place using (mostly) `kubectl`, as an alternative to re-provisioning.
 
-Self-hosted Kubernetes clusters schedule Kubernetes components such as the apiserver, kubelet, scheduler, and controller-manager as pods like other applications (except with node selectors). This allows Kubernetes level operations to be performed to upgrade clusters in place, rather than by re-provisioning.
+Let's upgrade a Kubernetes v1.6.6 cluster to v1.6.7 as an example.
 
-Let's upgrade a self-hosted Kubernetes v1.4.1 cluster to v1.4.3 as an example.
+## Status
+
+The process of in-place upgrading a self-hosted Kubernetes cluster can be straight-forward, but there may be complex underlying changes that affect your cluster. In most cases, patch version upgrades (e.g. v1.6.6 to v1.6.7) are safe.
+
+Before beginning an upgrade, it is recommended you evaluate if an in-place upgrade is appropriate for your Kubernetes cluster and risk tolerance. You may wish to test the in-place upgrade on a development cluster, failover important workloads to another cluster, or be prepared to handle unforseen issues.
+
+## Prepare
+
+Find the diff between bootkube assets generated for the existing cluster version and the desired version. This depends on the tool used to generate assets:
+
+* Github [compare](https://github.com/kubernetes-incubator/bootkube/compare/v0.5.0...v0.5.1) changes between the existing and desired versions and infer the appropriate cluster changes.
+* [bootkube render](https://github.com/kubernetes-incubator/bootkube) - Install the `bootkube` binaries for the existing and desired versions. Render assets to different locations with each binary and diff the assets.
+* [External Tools](users-integrations.md) - Check the docs for the external tool and compare assets generated for each version.
+
+In simple cases, you may only need to bump the version of a few images. In more complex cases, there may be entirely new components, configuration, or flags.
 
 ## Inspect
 
-Show the control plane daemonsets and deployments which will need to be updated.
-
-    $ kubectl get daemonsets -n=kube-system
-    NAME             DESIRED   CURRENT   NODE-SELECTOR                    AGE
-    kube-apiserver   1         1         node-role.kubernetes.io/master   5m
-    kube-proxy       3         3         <none>                           5m
-    kubelet          3         3         <none>                           5m
-
-    $ kubectl get deployments -n=kube-system
-    NAME                      DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-    kube-controller-manager   1         1         1            1           5m
-    kube-dns-v20              1         1         1            1           5m
-    kube-scheduler            1         1         1            1           5m
-
 Check the current Kubernetes version.
 
-    $ kubectl version
-    Client Version: version.Info{Major:"1", Minor:"4", GitVersion:"v1.4.0", GitCommit:"a16c0a7f71a6f93c7e0f222d961f4675cd97a46b", GitTreeState:"clean", BuildDate:"2016-09-26T18:16:57Z", GoVersion:"go1.6.3", Compiler:"gc", Platform:"linux/amd64"}
-    Server Version: version.Info{Major:"1", Minor:"4", GitVersion:"v1.4.1+coreos.0", GitCommit:"b7a02f46b972c5211e5c04fdb1d5b86ac16c00eb", GitTreeState:"clean", BuildDate:"2016-10-11T20:13:55Z", GoVersion:"go1.6.3", Compiler:"gc", Platform:"linux/amd64"}
+```sh
+$ kubectl version
+Client Version: version.Info{Major:"1", Minor:"6", GitVersion:"v1.6.2", GitCommit:"477efc3cbe6a7effca06bd1452fa356e2201e1ee", GitTreeState:"clean", BuildDate:"2017-04-19T20:33:11Z", GoVersion:"go1.7.5", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"6", GitVersion:"v1.6.6+coreos.1", GitCommit:"42a5c8b99c994a51d9ceaed5d0254f177e97d419", GitTreeState:"clean", BuildDate:"2017-06-21T01:10:07Z", GoVersion:"go1.7.6", Compiler:"gc", Platform:"linux/amd64"}
+```
 
-In this case, Kubernetes is `v1.4.1+coreos.0` and our goal is to upgrade to `v1.4.3+coreos.0`. First, update the control plane pods. Then the kubelets and proxies on all nodes.
+```sh
+$ kubectl get nodes
+NAME                               STATUS    AGE       VERSION
+node1.example.com                  Ready     21d       v1.6.6+coreos.1
+node2.example.com                  Ready     21d       v1.6.6+coreos.1
+node3.example.com                  Ready     21d       v1.6.6+coreos.1
+node4.example.com                  Ready     21d       v1.6.6+coreos.1
+```
 
 ## Control Plane
 
+Show the control plane DaemonSets and Deployments that will need to be updated.
+
+```sh
+$ kubectl get daemonsets -n=kube-system
+NAME                             DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE   NODE-SELECTOR                     AGE
+kube-apiserver                   1         1         1         1            1           node-role.kubernetes.io/master=   21d
+kube-flannel                     4         4         4         4            4           <none>                            21d
+kube-proxy                       4         4         4         4            4           <none>                            21d
+pod-checkpointer                 1         1         1         1            1           node-role.kubernetes.io/master=   21d
+
+$ kubectl get deployments -n=kube-system
+kube-controller-manager           2         2         2            2           21d
+kube-dns                          1         1         1            1           21d
+kube-scheduler                    2         2         2            2           21d
+```
+
 ### kube-apiserver
 
-Edit the kube-apiserver daemonset. Change the container image name to `quay.io/coreos/hyperkube:v1.4.3_coreos.0`.
+If only the container image version has changed, update the image with a single command.
 
-    $ kubectl edit daemonset kube-apiserver -n=kube-system
+```
+kubectl set image daemonset kube-apiserver kube-apiserver=quay.io/coreos/hyperkube:v1.6.7_coreos.0
+```
 
-Since daemonsets don't yet support rolling, manually delete each apiserver one by one and wait for each to be re-scheduled.
+You can edit the daemonset directly if other changes are needed.
 
-    $ kubectl get pods -n=kube-system
-    # WARNING: Self-hosted Kubernetes is still new and this may fail
-    $ kubectl delete pod kube-apiserver-s62kb -n=kube-system
+```sh
+$ kubectl edit daemonset kube-apiserver -n=kube-system
+```
 
-If you only have one, your cluster will be temporarily unavailable. Remember the Hyperkube image is quite large and this can take a minute.
-
-    kubectl get pods -n=kube-system
-    NAME                                       READY     STATUS    RESTARTS   AGE
-    kube-apiserver-vyg3t                       2/2       Running   0          2m
-    kube-controller-manager-1510822774-qebia   1/1       Running   2          12m
-    kube-dns-v20-3531996453-0tlv9              3/3       Running   0          12m
-    kube-proxy-8jthl                           1/1       Running   0          12m
-    kube-proxy-bnvgy                           1/1       Running   0          12m
-    kube-proxy-gkyx8                           1/1       Running   0          12m
-    kube-scheduler-2099299605-67ezp            1/1       Running   2          12m
-    kubelet-exe5k                              1/1       Running   0          12m
-    kubelet-p3g98                              1/1       Running   0          12m
-    kubelet-quhhg                              1/1       Running   0          12m
-    pod-checkpointer-node1.example.com         1/1       Running   0          12m
+With only one apiserver, the cluster may be momentarily unavailable.
 
 ### kube-scheduler
 
-Edit the scheduler deployment to rolling update the scheduler. Change the container image name for the hyperkube.
+Again, if only the container image version has changed, update the image with a single command.
 
-    kubectl edit deployments kube-scheduler -n=kube-system
+```
+kubectl set image deployment kube-scheduler kube-scheduler=quay.io/coreos/hyperkube:v1.6.7_coreos.0
+```
 
-Wait for the schduler to be deployed.
+You can edit the deployment directly if other changes are needed.
+
+```sh
+$ kubectl edit deployments kube-scheduler -n=kube-system
+```
 
 ### kube-controller-manager
 
-Edit the controller-manager deployment to rolling update the controller manager. Change the container image name for the hyperkube.
+Again, if only the container image version has changed, update the image with a single command.
 
-    kubectl edit deployments kube-controller-manager -n=kube-system
+```
+kubectl set image deployment kube-controller-manager kube-controller-manager=quay.io/coreos/hyperkube:v1.6.7_coreos.0
+```
 
-Wait for the controller manager to be deployed.
+You can edit the deployment directly if other changes are needed.
 
-    $ kubectl get pods -n=kube-system
-    NAME                                       READY     STATUS    RESTARTS   AGE
-    kube-apiserver-vyg3t                       2/2       Running   0          18m
-    kube-controller-manager-1709527928-zj8c4   1/1       Running   0          4m
-    kube-dns-v20-3531996453-0tlv9              3/3       Running   0          28m
-    kube-proxy-8jthl                           1/1       Running   0          28m
-    kube-proxy-bnvgy                           1/1       Running   0          28m
-    kube-proxy-gkyx8                           1/1       Running   0          28m
-    kube-scheduler-2255275287-hti6w            1/1       Running   0          6m
-    kubelet-exe5k                              1/1       Running   0          28m
-    kubelet-p3g98                              1/1       Running   0          28m
-    kubelet-quhhg                              1/1       Running   0          28m
-    pod-checkpointer-node1.example.com         1/1       Running   0          28m
+```sh
+$ kubectl edit deployments kube-controller-manager -n=kube-system
+```
+
+### kube-proxy
+
+Edit the `kube-proxy` daemonset to rolling update the proxy.
+
+```sh
+$ kubectl edit daemonset kube-proxy -n=kube-system
+```
+
+### Others
+
+Update any other components which have changes between the existing version and desired version manifests. Update the `kube-dns` deployment, `kube-flannel` daemonset, or `pod-checkpointer` daemonset.
 
 ### Verify
 
-At this point, the control plane components have been upgraded to v1.4.3.
+Verify the control plane components updated.
 
-    $ kubectl version
-    Client Version: version.Info{Major:"1", Minor:"4", GitVersion:"v1.4.0", GitCommit:"a16c0a7f71a6f93c7e0f222d961f4675cd97a46b", GitTreeState:"clean", BuildDate:"2016-09-26T18:16:57Z", GoVersion:"go1.6.3", Compiler:"gc", Platform:"linux/amd64"}
-    Server Version: version.Info{Major:"1", Minor:"4", GitVersion:"v1.4.3+coreos.0", GitCommit:"7819c84f25e8c661321ee80d6b9fa5f4ff06676f", GitTreeState:"clean", BuildDate:"2016-10-17T21:19:17Z", GoVersion:"go1.6.3", Compiler:"gc", Platform:"linux/amd64"}
+```sh
+$ kubectl version
+Client Version: version.Info{Major:"1", Minor:"6", GitVersion:"v1.6.2", GitCommit:"477efc3cbe6a7effca06bd1452fa356e2201e1ee", GitTreeState:"clean", BuildDate:"2017-04-19T20:33:11Z", GoVersion:"go1.7.5", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"6", GitVersion:"v1.6.7+coreos.0", GitCommit:"c8c505ee26ac3ab4d1dff506c46bc5538bc66733", GitTreeState:"clean", BuildDate:"2017-07-06T17:38:33Z", GoVersion:"go1.7.6", Compiler:"gc", Platform:"linux/amd64"}
+```
 
-Finally, upgrade the kubelets and kube-proxies.
+```sh
+$ kubectl get nodes
+NAME                               STATUS    AGE       VERSION
+node1.example.com                  Ready     21d       v1.6.7+coreos.0
+node2.example.com                  Ready     21d       v1.6.7+coreos.0
+node3.example.com                  Ready     21d       v1.6.7+coreos.0
+node4.example.com                  Ready     21d       v1.6.7+coreos.0
+```
 
-## Kubelet and Proxy
+## kubelet
 
-Show the current kubelet and kube-proxy version on each node.
+SSH to each node and update the `KUBELET_IMAGE_TAG` in `kubelet.service` or `/etc/kubernetes/kubelet.env`, depending on the provisioning tool used. Restart the `kubelet.service`.
 
-    $ kubectl get nodes -o yaml | grep 'kubeletVersion\|kubeProxyVersion'
-        kubeProxyVersion: v1.4.1+coreos.0
-        kubeletVersion: v1.4.1+coreos.0
-        kubeProxyVersion: v1.4.1+coreos.0
-        kubeletVersion: v1.4.1+coreos.0
-        kubeProxyVersion: v1.4.1+coreos.0
-        kubeletVersion: v1.4.1+coreos.0
+```sh
+ssh core@node1.example.com
+sudo vim /etc/systemd/system/kubelet.service
+sudo vim /etc/kubernetes/kubelet.env
+sudo systemctl restart kubelet
+```
 
-Edit the kubelet and kube-proxy daemonsets. Change the container image name for the hyperkube.
+### Verify
 
-    $ kubectl edit daemonset kubelet -n=kube-system
-    $ kubectl edit daemonset kube-proxy -n=kube-system
+Verify the kubelet and kube-proxy of each node updated.
 
-Since daemonsets don't yet support rolling, manually delete each kubelet and each kube-proxy. The daemonset controller will create new (upgraded) replics.
+```sh
+$ kubectl get nodes -o yaml | grep 'kubeletVersion\|kubeProxyVersion'
+      kubeProxyVersion: v1.6.7+coreos.0
+      kubeletVersion: v1.6.7+coreos.0
+      kubeProxyVersion: v1.6.7+coreos.0
+      kubeletVersion: v1.6.7+coreos.0
+      kubeProxyVersion: v1.6.7+coreos.0
+      kubeletVersion: v1.6.7+coreos.0
+      kubeProxyVersion: v1.6.7+coreos.0
+      kubeletVersion: v1.6.7+coreos.0
+```
 
-    $ kubectl get pods -n=kube-system
-    $ kubectl delete pod kubelet-quhhg
-    ...repeat
-    $ kubectl delete pod kube-proxy-8jthl -n=kube-system
-    ...repeat
+Kubernetes control plane components have been successfully updated!
 
-    $ kubectl get pods -n=kube-system
-    NAME                                       READY     STATUS    RESTARTS   AGE
-    kube-apiserver-vyg3t                       2/2       Running   0          1h
-    kube-controller-manager-1709527928-zj8c4   1/1       Running   0          47m
-    kube-dns-v20-3531996453-0tlv9              3/3       Running   0          1h
-    kube-proxy-6dbne                           1/1       Running   0          1s
-    kube-proxy-sm4jv                           1/1       Running   0          8s
-    kube-proxy-xmuao                           1/1       Running   0          14s
-    kube-scheduler-2255275287-hti6w            1/1       Running   0          49m
-    kubelet-hfdwr                              1/1       Running   0          38s
-    kubelet-oia47                              1/1       Running   0          52s
-    kubelet-s6dab                              1/1       Running   0          59s
-    pod-checkpointer-node1.example.com         1/1       Running   0          1h
-
-## Verify
-
-Verify that the kubelet and kube-proxy on each node have been upgraded.
-
-    $ kubectl get nodes -o yaml | grep 'kubeletVersion\|kubeProxyVersion'
-          kubeProxyVersion: v1.4.3+coreos.0
-          kubeletVersion: v1.4.3+coreos.0
-          kubeProxyVersion: v1.4.3+coreos.0
-          kubeletVersion: v1.4.3+coreos.0
-          kubeProxyVersion: v1.4.3+coreos.0
-          kubeletVersion: v1.4.3+coreos.0
-
-Now, all self-hosted Kubernetes components have been upgraded to a new version of Kubernetes!
-
-## On-host Kubelet
-
-The on-host kubelet is started by systemd, and is used to launch, and be replaced by, the self-hosted kubelet. While the on-host kubelet is short-lived, it should be kept up to date with the self hosted components.
-
-On each host running a kubelet, modify the kubelet systemd unit to reference a new `KUBELET_IMAGE_TAG` (an example snippet is below)
-
-`/etc/systemd/system/kubelet.service`
-
-    [Service]
-    Environment=KUBELET_IMAGE_TAG=v1.4.3_coreos.0
-
-Reload systemd daemon and restart the kubelet unit:
-
-    $ sudo systemctl daemon-reload
-    $ sudo systemctl restart kubelet
-
-## Going Further
-
-Check upstream for updates to addons like `kube-dns` or `kube-dashboard` and update them like any other applications. Some kube-system components use version labels and you may wish to clean those up as well.


### PR DESCRIPTION
Upgrade docs taken from https://github.com/coreos/matchbox/blob/master/Documentation/bootkube-upgrades.md, but polished a bit for kubernetes-incubator/bootkube.

Closes #673 