### PR TITLE
pkg: Move experimental-network-policy to network-provider canal

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -50,8 +50,8 @@ var (
 		serviceCIDR         string
 		selfHostKubelet     bool
 		cloudProvider       string
+		networkProvider     string
 		selfHostedEtcd      bool
-		calicoNetworkPolicy bool
 	}
 
 	imageVersions = asset.DefaultImages
@@ -72,8 +72,8 @@ func init() {
 	cmdRender.Flags().StringVar(&renderOpts.serviceCIDR, "service-cidr", "10.3.0.0/24", "The CIDR range of cluster services.")
 	cmdRender.Flags().BoolVar(&renderOpts.selfHostKubelet, "experimental-self-hosted-kubelet", false, "(Experimental) Create a self-hosted kubelet daemonset.")
 	cmdRender.Flags().StringVar(&renderOpts.cloudProvider, "cloud-provider", "", "The provider for cloud services.  Empty string for no provider")
+	cmdRender.Flags().StringVar(&renderOpts.networkProvider, "network-provider", "flannel", "CNI network provider (flannel or experimental-canal).")
 	cmdRender.Flags().BoolVar(&renderOpts.selfHostedEtcd, "experimental-self-hosted-etcd", false, "(Experimental) Create self-hosted etcd assets.")
-	cmdRender.Flags().BoolVar(&renderOpts.calicoNetworkPolicy, "experimental-calico-network-policy", false, "(Experimental) Add network policy support by calico.")
 }
 
 func runCmdRender(cmd *cobra.Command, args []string) error {
@@ -112,6 +112,9 @@ func validateRenderOpts(cmd *cobra.Command, args []string) error {
 	}
 	if renderOpts.apiServers == "" {
 		return errors.New("Missing requried flag: --api-servers")
+	}
+	if renderOpts.networkProvider != asset.NetworkFlannel && renderOpts.networkProvider != asset.NetworkCanal {
+		return errors.New("Must specify --network-provider flannel or experimental-canal")
 	}
 	return nil
 }
@@ -223,26 +226,26 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 	}
 
 	return &asset.Config{
-		EtcdCACert:          etcdCACert,
-		EtcdClientCert:      etcdClientCert,
-		EtcdClientKey:       etcdClientKey,
-		EtcdServers:         etcdServers,
-		EtcdUseTLS:          etcdUseTLS,
-		CACert:              caCert,
-		CAPrivKey:           caPrivKey,
-		APIServers:          apiServers,
-		AltNames:            altNames,
-		PodCIDR:             podNet,
-		ServiceCIDR:         serviceNet,
-		APIServiceIP:        apiServiceIP,
-		BootEtcdServiceIP:   bootEtcdServiceIP,
-		DNSServiceIP:        dnsServiceIP,
-		EtcdServiceIP:       etcdServiceIP,
-		SelfHostKubelet:     renderOpts.selfHostKubelet,
-		CloudProvider:       renderOpts.cloudProvider,
-		SelfHostedEtcd:      renderOpts.selfHostedEtcd,
-		CalicoNetworkPolicy: renderOpts.calicoNetworkPolicy,
-		Images:              imageVersions,
+		EtcdCACert:        etcdCACert,
+		EtcdClientCert:    etcdClientCert,
+		EtcdClientKey:     etcdClientKey,
+		EtcdServers:       etcdServers,
+		EtcdUseTLS:        etcdUseTLS,
+		CACert:            caCert,
+		CAPrivKey:         caPrivKey,
+		APIServers:        apiServers,
+		AltNames:          altNames,
+		PodCIDR:           podNet,
+		ServiceCIDR:       serviceNet,
+		APIServiceIP:      apiServiceIP,
+		BootEtcdServiceIP: bootEtcdServiceIP,
+		DNSServiceIP:      dnsServiceIP,
+		EtcdServiceIP:     etcdServiceIP,
+		SelfHostKubelet:   renderOpts.selfHostKubelet,
+		CloudProvider:     renderOpts.cloudProvider,
+		NetworkProvider:   renderOpts.networkProvider,
+		SelfHostedEtcd:    renderOpts.selfHostedEtcd,
+		Images:            imageVersions,
 	}, nil
 }
 

--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -8,8 +8,8 @@ CLUSTER_DIR=${CLUSTER_DIR:-cluster}
 IDENT=${IDENT:-${HOME}/.ssh/id_rsa}
 SSH_OPTS=${SSH_OPTS:-}
 SELF_HOST_ETCD=${SELF_HOST_ETCD:-false}
-CALICO_NETWORK_POLICY=${CALICO_NETWORK_POLICY:-false}
 CLOUD_PROVIDER=${CLOUD_PROVIDER:-}
+NETWORK_PROVIDER=${NETWORK_PROVIDER:-flannel}
 
 function usage() {
     echo "USAGE:"
@@ -59,15 +59,14 @@ function init_master_node() {
         etcd_render_flags="--etcd-servers=https://${COREOS_PRIVATE_IPV4}:2379"
     fi
 
-    if [ "$CALICO_NETWORK_POLICY" = true ]; then
-        echo "WARNING: THIS IS EXPERIMENTAL SUPPORT FOR NETWORK POLICY"
-        cnp_render_flags="--experimental-calico-network-policy"
+    if [ "$NETWORK_PROVIDER" = "canal" ]; then
+        network_provider_flags="--network-provider=experimental-canal"
     else
-        cnp_render_flags=""
+        network_provider_flags="--network-provider=flannel"
     fi
 
     # Render cluster assets
-    /home/${REMOTE_USER}/bootkube render --asset-dir=/home/${REMOTE_USER}/assets ${etcd_render_flags} ${cnp_render_flags} \
+    /home/${REMOTE_USER}/bootkube render --asset-dir=/home/${REMOTE_USER}/assets ${etcd_render_flags} ${network_provider_flags} \
       --api-servers=https://${COREOS_PUBLIC_IPV4}:443,https://${COREOS_PRIVATE_IPV4}:443
 
     # Move the local kubeconfig into expected location
@@ -121,7 +120,7 @@ if [ "${REMOTE_HOST}" != "local" ]; then
     fi
     # Copy self to remote host so script can be executed in "local" mode
     scp -i ${IDENT} -P ${REMOTE_PORT} ${SSH_OPTS} ${BASH_SOURCE[0]} ${REMOTE_USER}@${REMOTE_HOST}:/home/${REMOTE_USER}/init-master.sh
-    ssh -i ${IDENT} -p ${REMOTE_PORT} ${SSH_OPTS} ${REMOTE_USER}@${REMOTE_HOST} "sudo REMOTE_USER=${REMOTE_USER} CLOUD_PROVIDER=${CLOUD_PROVIDER} SELF_HOST_ETCD=${SELF_HOST_ETCD} CALICO_NETWORK_POLICY=${CALICO_NETWORK_POLICY} /home/${REMOTE_USER}/init-master.sh local"
+    ssh -i ${IDENT} -p ${REMOTE_PORT} ${SSH_OPTS} ${REMOTE_USER}@${REMOTE_HOST} "sudo REMOTE_USER=${REMOTE_USER} CLOUD_PROVIDER=${CLOUD_PROVIDER} SELF_HOST_ETCD=${SELF_HOST_ETCD} NETWORK_PROVIDER=${NETWORK_PROVIDER} /home/${REMOTE_USER}/init-master.sh local"
 
     # Copy assets from remote host to a local directory. These can be used to launch additional nodes & contain TLS assets
     mkdir ${CLUSTER_DIR}

--- a/hack/terraform-quickstart/outputs.tf
+++ b/hack/terraform-quickstart/outputs.tf
@@ -14,6 +14,6 @@ output "self_host_etcd" {
   value = "${var.self_host_etcd}"
 }
 
-output "calico_network_policy" {
-  value = "${var.calico_network_policy}"
+output "network_provider" {
+  value = "${var.network_provider}"
 }

--- a/hack/terraform-quickstart/start-cluster.sh
+++ b/hack/terraform-quickstart/start-cluster.sh
@@ -5,9 +5,9 @@ export BOOTSTRAP_IP=`terraform output bootstrap_node_ip`
 export WORKER_IPS=`terraform output -json worker_ips | jq -r '.value[]'`
 export MASTER_IPS=`terraform output -json master_ips | jq -r '.value[]'`
 export SELF_HOST_ETCD=`terraform output self_host_etcd`
-export CALICO_NETWORK_POLICY=`terraform output calico_network_policy`
 export SSH_OPTS=${SSH_OPTS:-}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 export CLOUD_PROVIDER=${CLOUD_PROVIDER:-aws}
+export NETWORK_PROVIDER=`terraform output network_provider`
 
 # Normally we want to default to aws here since that is all terraform
 # supports and it is required for the e2e tests. However because of an

--- a/hack/terraform-quickstart/variables.tf
+++ b/hack/terraform-quickstart/variables.tf
@@ -28,9 +28,9 @@ variable "self_host_etcd" {
   default = "true"
 }
 
-variable "calico_network_policy" {
+variable "network_provider" {
   type    = "string"
-  default = "true"
+  default = "flannel"
 }
 
 variable "num_workers" {

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -100,8 +100,8 @@ type Config struct {
 	EtcdServiceName        string
 	SelfHostKubelet        bool
 	SelfHostedEtcd         bool
-	CalicoNetworkPolicy    bool
 	CloudProvider          string
+	NetworkProvider        string
 	BootstrapSecretsSubdir string
 	Images                 ImageVersions
 }

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -19,6 +19,9 @@ const (
 	SecretEtcdServer = "etcd-server-tls"
 	SecretEtcdClient = "etcd-client-tls"
 
+	NetworkFlannel = "flannel"
+	NetworkCanal   = "experimental-canal"
+
 	secretNamespace     = "kube-system"
 	secretAPIServerName = "kube-apiserver"
 	secretCMName        = "kube-controller-manager"
@@ -46,8 +49,6 @@ func newDynamicAssets(conf Config) Assets {
 		MustCreateAssetFromTemplate(AssetPathControllerManager, internal.ControllerManagerTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathAPIServer, internal.APIServerTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathProxy, internal.ProxyTemplate, conf),
-		MustCreateAssetFromTemplate(AssetPathKubeFlannelCfg, internal.KubeFlannelCfgTemplate, conf),
-		MustCreateAssetFromTemplate(AssetPathKubeFlannel, internal.KubeFlannelTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathKubeDNSSvc, internal.DNSSvcTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathBootstrapAPIServer, internal.BootstrapAPIServerTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathBootstrapControllerManager, internal.BootstrapControllerManagerTemplate, conf),
@@ -66,7 +67,13 @@ func newDynamicAssets(conf Config) Assets {
 			MustCreateAssetFromTemplate(AssetPathBootstrapEtcdService, internal.BootstrapEtcdSvcTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathMigrateEtcdCluster, internal.EtcdCRDTemplate, conf))
 	}
-	if conf.CalicoNetworkPolicy {
+	switch conf.NetworkProvider {
+	case NetworkFlannel:
+		assets = append(assets,
+			MustCreateAssetFromTemplate(AssetPathKubeFlannelCfg, internal.KubeFlannelCfgTemplate, conf),
+			MustCreateAssetFromTemplate(AssetPathKubeFlannel, internal.KubeFlannelTemplate, conf),
+		)
+	case NetworkCanal:
 		assets = append(assets,
 			MustCreateAssetFromTemplate(AssetPathCalicoCfg, internal.CalicoCfgTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathCalcioRole, internal.CalicoRoleTemplate, conf),


### PR DESCRIPTION
* Canal is a setup that uses flannel for network connectivity and adds manifests for Calico in policy-only mode (i.e. user supplied networking)
* Rearranges flags as this was said to be desired before merging Calico support #714 

Author's note: I'd recommend users choose `--network-provider=calico` (added in #714) or stick with `--network-provider=flannel`. There are [known issues](#698) with choosing `experimental-canal` (flannel with Calico run in policy-only mode).