### PR TITLE
golang: bump to 1.8.4 everywhere.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
   - 1.8
+  - 1.9
 script:
   - make clean release

--- a/build/build-release.sh
+++ b/build/build-release.sh
@@ -5,5 +5,5 @@ BOOTKUBE_ROOT=$(git rev-parse --show-toplevel)
 sudo rkt run \
     --volume bk,kind=host,source=${BOOTKUBE_ROOT} \
     --mount volume=bk,target=/go/src/github.com/kubernetes-incubator/bootkube \
-    --insecure-options=image docker://golang:1.8.3 --exec /bin/bash -- -c \
+    --insecure-options=image docker://golang:1.8.4 --exec /bin/bash -- -c \
     "cd /go/src/github.com/kubernetes-incubator/bootkube && make release"

--- a/hack/tests/conformance-gce.sh
+++ b/hack/tests/conformance-gce.sh
@@ -115,6 +115,6 @@ else
 
     #TODO(pb): See if there is a way to make the --inherit-env option replace
     #passing all the variables manually. 
-    sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.7.5 --exec /bin/bash -- -c \
+    sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.8.4 --exec /bin/bash -- -c \
         "IN_CONTAINER=true COREOS_CHANNEL=${COREOS_CHANNEL} GCE_PREFIX=${GCE_PREFIX} GCE_SERVICE_ACCOUNT=${GCE_SERVICE_ACCOUNT} GCE_PROJECT=${GCE_PROJECT} SELF_HOST_ETCD=${SELF_HOST_ETCD} /build/bootkube/hack/tests/$(basename $0)"
 fi

--- a/hack/tests/conformance-test.sh
+++ b/hack/tests/conformance-test.sh
@@ -44,5 +44,5 @@ CONFORMANCE="\
  KUBECONFIG=/kubeconfig KUBERNETES_CONFORMANCE_TEST=Y go run hack/e2e.go \
  -- -v --test -check-version-skew=false --provider=skeleton --test_args='--ginkgo.focus=\[Conformance\]'"
 
-CMD="sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.8.3 --exec /bin/bash -- -c \"${INIT} && ${BUILD} && ${CONFORMANCE}\""
+CMD="sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.8.4 --exec /bin/bash -- -c \"${INIT} && ${BUILD} && ${CONFORMANCE}\""
 ssh -q  -o UserKnownHostsFile=/dev/null -o stricthostkeychecking=no -i ${ssh_key} -p ${ssh_port} core@${ssh_host} "${CMD}"


### PR DESCRIPTION
Just to be extra sure. Also adds 1.9 to .travis.yml to increase build
coverage.