### PR TITLE
Add /lib/modules mount to kube-proxy

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -706,6 +706,9 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ssl-certs-host
           readOnly: true
@@ -720,9 +723,12 @@ spec:
         operator: Exists
         effect: NoSchedule
       volumes:
-      - hostPath:
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: ssl-certs-host
+        hostPath:
           path: /usr/share/ca-certificates
-        name: ssl-certs-host
       - name: etc-kubernetes
         hostPath:
           path: /etc/kubernetes


### PR DESCRIPTION
Wait for Kubernetes v1.8.3 and test that this addresses the warning log in #741. This paves the way to use `ip_vs` in kube-proxy in future, but does not enable it for now.

rel: https://github.com/kubernetes/kubernetes/issues/17470, https://github.com/kubernetes/kubernetes/pull/52003
Closes #741 