### PR TITLE
pkg/assets: Update flannel from v0.8.0 to v0.9.0

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -4,7 +4,7 @@ package asset
 var DefaultImages = ImageVersions{
 	Etcd:            "quay.io/coreos/etcd:v3.1.8",
 	EtcdOperator:    "quay.io/coreos/etcd-operator:v0.5.0",
-	Flannel:         "quay.io/coreos/flannel:v0.8.0-amd64",
+	Flannel:         "quay.io/coreos/flannel:v0.9.0-amd64",
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
 	Calico:          "quay.io/calico/node:v2.6.1",
 	CalicoCNI:       "quay.io/calico/cni:v1.11.0",


### PR DESCRIPTION
Initial testing for https://github.com/coreos/flannel/releases/tag/v0.9.0

cc @squeed