### PR TITLE
Switch from quay.io to gcr.io hyperkube image

### DIFF
--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -8,15 +8,16 @@ coreos:
       content: |
         [Service]
         EnvironmentFile=/etc/environment
-        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-        Environment=KUBELET_IMAGE_TAG=v1.8.1_coreos.0
+        Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
+        Environment=KUBELET_IMAGE_TAG=v1.8.1
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log \
           --mount volume=var-lib-cni,target=/var/lib/cni \
-          --mount volume=opt-cni-bin,target=/opt/cni/bin"
+          --mount volume=opt-cni-bin,target=/opt/cni/bin \
+          --insecure-options=image"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -1,12 +1,13 @@
 [Service]
-Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-Environment=KUBELET_IMAGE_TAG=v1.8.1_coreos.0
+Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
+Environment=KUBELET_IMAGE_TAG=v1.8.1
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/cache/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
 --volume opt-cni-bin,kind=host,source=/opt/cni/bin --mount volume=opt-cni-bin,target=/opt/cni/bin \
 --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log \
---volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
+--volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni \
+--insecure-options=image"
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/bin/mkdir -p /opt/cni/bin

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -1,12 +1,13 @@
 [Service]
-Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-Environment=KUBELET_IMAGE_TAG=v1.8.1_coreos.0
+Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
+Environment=KUBELET_IMAGE_TAG=v1.8.1
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/cache/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
 --volume opt-cni-bin,kind=host,source=/opt/cni/bin --mount volume=opt-cni-bin,target=/opt/cni/bin \
 --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log \
---volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
+--volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni \
+--insecure-options=image"
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/bin/mkdir -p /opt/cni/bin

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -8,15 +8,16 @@ coreos:
       content: |
         [Service]
         EnvironmentFile=/etc/environment
-        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-        Environment=KUBELET_IMAGE_TAG=v1.8.1_coreos.0
+        Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
+        Environment=KUBELET_IMAGE_TAG=v1.8.1
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log \
           --mount volume=var-lib-cni,target=/var/lib/cni \
-          --mount volume=opt-cni-bin,target=/opt/cni/bin"
+          --mount volume=opt-cni-bin,target=/opt/cni/bin \
+          --insecure-options=image"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d

--- a/hack/tests/conformance-test.sh
+++ b/hack/tests/conformance-test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONFORMANCE_REPO=${CONFORMANCE_REPO:-github.com/coreos/kubernetes}
-CONFORMANCE_VERSION=${CONFORMANCE_VERSION:-v1.8.1+coreos.0}
+CONFORMANCE_REPO=${CONFORMANCE_REPO:-github.com/kubernetes/kubernetes}
+CONFORMANCE_VERSION=${CONFORMANCE_VERSION:-v1.8.1}
 
 usage() {
     echo "USAGE:"
@@ -42,7 +42,7 @@ BUILD="cd /go/src/k8s.io/kubernetes && \
 
 CONFORMANCE="\
  KUBECONFIG=/kubeconfig KUBERNETES_CONFORMANCE_TEST=Y go run hack/e2e.go \
- -- -v --test -check-version-skew=false --provider=skeleton --test_args='--ginkgo.focus=\[Conformance\]'"
+ -- -v --test --check-version-skew=false --provider=skeleton --test_args='--ginkgo.focus=\[Conformance\]'"
 
 CMD="sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.8.4 --exec /bin/bash -- -c \"${INIT} && ${BUILD} && ${CONFORMANCE}\""
 ssh -q  -o UserKnownHostsFile=/dev/null -o stricthostkeychecking=no -i ${ssh_key} -p ${ssh_port} core@${ssh_host} "${CMD}"

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -8,7 +8,7 @@ var DefaultImages = ImageVersions{
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
 	Calico:          "quay.io/calico/node:v2.6.1",
 	CalicoCNI:       "quay.io/calico/cni:v1.11.0",
-	Hyperkube:       "quay.io/coreos/hyperkube:v1.8.1_coreos.0",
+	Hyperkube:       "gcr.io/google_containers/hyperkube:v1.8.1",
 	Kenc:            "quay.io/coreos/kenc:0.0.2",
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5",
 	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5",


### PR DESCRIPTION
Updated the conformance test job to use kubernetes/kubernetes when launching conformance clusters.

### Note

The rkt flag `--insecure-options=image` isn't as scary as it sounds. rkt had different ideas about image security and originally required GPG signed ACIs. When pulling `docker://` images, those signatures aren't present which is why rkt calls them insecure. In a post-OCI world, it doesn't have so much weight.

Closes #744 