### PR TITLE
Update hyperkube from v1.8.1 to v1.8.2

### DIFF
--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -9,7 +9,7 @@ coreos:
         [Service]
         EnvironmentFile=/etc/environment
         Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
-        Environment=KUBELET_IMAGE_TAG=v1.8.1
+        Environment=KUBELET_IMAGE_TAG=v1.8.2
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --volume opt-cni-bin,kind=host,source=/opt/cni/bin \

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -1,6 +1,6 @@
 [Service]
 Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
-Environment=KUBELET_IMAGE_TAG=v1.8.1
+Environment=KUBELET_IMAGE_TAG=v1.8.2
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/cache/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -1,6 +1,6 @@
 [Service]
 Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
-Environment=KUBELET_IMAGE_TAG=v1.8.1
+Environment=KUBELET_IMAGE_TAG=v1.8.2
 Environment="RKT_RUN_ARGS=\
 --uuid-file-save=/var/cache/kubelet-pod.uuid \
 --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -9,7 +9,7 @@ coreos:
         [Service]
         EnvironmentFile=/etc/environment
         Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
-        Environment=KUBELET_IMAGE_TAG=v1.8.1
+        Environment=KUBELET_IMAGE_TAG=v1.8.2
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --volume opt-cni-bin,kind=host,source=/opt/cni/bin \

--- a/hack/tests/conformance-test.sh
+++ b/hack/tests/conformance-test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CONFORMANCE_REPO=${CONFORMANCE_REPO:-github.com/kubernetes/kubernetes}
-CONFORMANCE_VERSION=${CONFORMANCE_VERSION:-v1.8.1}
+CONFORMANCE_VERSION=${CONFORMANCE_VERSION:-v1.8.2}
 
 usage() {
     echo "USAGE:"

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -8,7 +8,7 @@ var DefaultImages = ImageVersions{
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
 	Calico:          "quay.io/calico/node:v2.6.1",
 	CalicoCNI:       "quay.io/calico/cni:v1.11.0",
-	Hyperkube:       "gcr.io/google_containers/hyperkube:v1.8.1",
+	Hyperkube:       "gcr.io/google_containers/hyperkube:v1.8.2",
 	Kenc:            "quay.io/coreos/kenc:0.0.2",
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5",
 	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5",


### PR DESCRIPTION
Builds atop #745 to update to `gcr.io/google_containers/hyperkube:v1.8.2`.

* v1.8.2 has fixes for apiserver memory leak issues
