### PR TITLE
checkpointer: implement state machine.

### DIFF
--- a/pkg/checkpoint/apiserver.go
+++ b/pkg/checkpoint/apiserver.go
@@ -9,7 +9,8 @@ import (
 )
 
 // getAPIParentPods will retrieve all pods from apiserver that are parents & should be checkpointed
-func (c *checkpointer) getAPIParentPods(nodeName string) map[string]*v1.Pod {
+// Returns false if we could not contact the apiserver.
+func (c *checkpointer) getAPIParentPods(nodeName string) (bool, map[string]*v1.Pod) {
 	opts := metav1.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(api.PodHostField, nodeName).String(),
 	}
@@ -17,7 +18,7 @@ func (c *checkpointer) getAPIParentPods(nodeName string) map[string]*v1.Pod {
 	podList, err := c.apiserver.CoreV1().Pods(api.NamespaceAll).List(opts)
 	if err != nil {
 		glog.Warningf("Unable to contact APIServer, skipping garbage collection: %v", err)
-		return nil
+		return false, nil
 	}
-	return podListToParentPods(podList)
+	return true, podListToParentPods(podList)
 }

--- a/pkg/checkpoint/manifest.go
+++ b/pkg/checkpoint/manifest.go
@@ -52,10 +52,6 @@ func writeCheckpointManifest(pod *v1.Pod) (bool, error) {
 		return false, err
 	}
 	path := filepath.Join(inactiveCheckpointPath, pod.Namespace+"-"+pod.Name+".json")
-	// Make sure the inactive checkpoint path exists.
-	if err := os.MkdirAll(filepath.Dir(path), 0600); err != nil {
-		return false, err
-	}
 	return writeManifestIfDifferent(path, podFullName(pod), buff.Bytes())
 }
 

--- a/pkg/checkpoint/manifest.go
+++ b/pkg/checkpoint/manifest.go
@@ -73,3 +73,11 @@ func writeManifestIfDifferent(path, name string, data []byte) (bool, error) {
 	glog.Infof("Writing manifest for %q to %q", name, path)
 	return true, writeAndAtomicRename(path, data, 0644)
 }
+
+func writeAndAtomicRename(path string, data []byte, perm os.FileMode) error {
+	tmpfile := filepath.Join(filepath.Dir(path), "."+filepath.Base(path))
+	if err := ioutil.WriteFile(tmpfile, data, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmpfile, path)
+}

--- a/pkg/checkpoint/pod.go
+++ b/pkg/checkpoint/pod.go
@@ -1,8 +1,6 @@
 package checkpoint
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -162,12 +160,4 @@ func podFullNameToInactiveCheckpointPath(id string) string {
 
 func podFullNameToActiveCheckpointPath(id string) string {
 	return filepath.Join(activeCheckpointPath, strings.Replace(id, "/", "-", -1)+".json")
-}
-
-func writeAndAtomicRename(path string, data []byte, perm os.FileMode) error {
-	tmpfile := filepath.Join(filepath.Dir(path), "."+filepath.Base(path))
-	if err := ioutil.WriteFile(tmpfile, data, perm); err != nil {
-		return err
-	}
-	return os.Rename(tmpfile, path)
 }

--- a/pkg/checkpoint/process_test.go
+++ b/pkg/checkpoint/process_test.go
@@ -1,14 +1,19 @@
 package checkpoint
 
 import (
+	"flag"
 	"reflect"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
 func TestProcess(t *testing.T) {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
 	type testCase struct {
 		desc                string
 		localRunning        map[string]*v1.Pod
@@ -19,6 +24,9 @@ func TestProcess(t *testing.T) {
 		expectStart         []string
 		expectStop          []string
 		expectRemove        []string
+		expectGraceStart    []string
+		expectGraceStop     []string
+		expectGraceRemove   []string
 		podName             string
 	}
 
@@ -37,7 +45,7 @@ func TestProcess(t *testing.T) {
 			desc:                "Inactive checkpoint and no api parent: should remove",
 			inactiveCheckpoints: map[string]*v1.Pod{"AA": {}},
 			apiParents:          map[string]*v1.Pod{"BB": {}},
-			expectRemove:        []string{"AA"},
+			expectGraceRemove:   []string{"AA"},
 		},
 		{
 			desc:                "Inactive checkpoint and both api & local running: no change",
@@ -67,10 +75,10 @@ func TestProcess(t *testing.T) {
 			apiParents:        map[string]*v1.Pod{"AA": {}},
 		},
 		{
-			desc:              "Active checkpoint and no api parent: remove",
+			desc:              "Active checkpoint and no api parent: should remove",
 			activeCheckpoints: map[string]*v1.Pod{"AA": {}},
 			apiParents:        map[string]*v1.Pod{"BB": {}},
-			expectRemove:      []string{"AA"},
+			expectGraceRemove: []string{"AA"},
 		},
 		{
 			desc:              "Active checkpoint with local running, and api parent: should stop",
@@ -84,14 +92,14 @@ func TestProcess(t *testing.T) {
 			activeCheckpoints: map[string]*v1.Pod{"AA": {}},
 			localParents:      map[string]*v1.Pod{"AA": {}},
 			apiParents:        map[string]*v1.Pod{"BB": {}},
-			expectRemove:      []string{"AA"},
+			expectGraceRemove: []string{"AA"},
 		},
 		{
 			desc:                "Both active and inactive checkpoints, with no api parent: remove both",
 			activeCheckpoints:   map[string]*v1.Pod{"AA": {}},
 			inactiveCheckpoints: map[string]*v1.Pod{"AA": {}},
 			apiParents:          map[string]*v1.Pod{"BB": {}},
-			expectRemove:        []string{"AA"}, // Only need single remove, we should clean up both active/inactive
+			expectGraceRemove:   []string{"AA"}, // Only need single remove, we should clean up both active/inactive
 		},
 		{
 			desc:                "Inactive checkpoint, local parent, local running, no api parent: no change", // Safety check - don't GC if local parent still exists (even if possibly stale)
@@ -108,7 +116,14 @@ func TestProcess(t *testing.T) {
 			desc:         "Inactive pod-checkpointer, local parent, local running, api parent: should start",
 			localRunning: map[string]*v1.Pod{"kube-system/pod-checkpointer": {}},
 			localParents: map[string]*v1.Pod{"kube-system/pod-checkpointer": {}},
-			apiParents:   map[string]*v1.Pod{"kube-system/pod-checkpointer": {}},
+			apiParents: map[string]*v1.Pod{
+				"kube-system/pod-checkpointer": {
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "kube-system",
+						Name:      "pod-checkpointer",
+					},
+				},
+			},
 			inactiveCheckpoints: map[string]*v1.Pod{
 				"kube-system/pod-checkpointer": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -117,11 +132,19 @@ func TestProcess(t *testing.T) {
 					},
 				},
 			},
-			expectStart: []string{"kube-system/pod-checkpointer"},
+			expectStart:      []string{"kube-system/pod-checkpointer"},
+			expectGraceStart: []string{"kube-system/pod-checkpointer"},
 		},
 		{
-			desc:         "Inactive pod-checkpointer, local parent, no local running, api not reachable: should start",
-			localParents: map[string]*v1.Pod{"kube-system/pod-checkpointer": {}},
+			desc: "Inactive pod-checkpointer, local parent, no local running, api not reachable: should start",
+			localParents: map[string]*v1.Pod{
+				"kube-system/pod-checkpointer": {
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "kube-system",
+						Name:      "pod-checkpointer",
+					},
+				},
+			},
 			inactiveCheckpoints: map[string]*v1.Pod{
 				"kube-system/pod-checkpointer": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -130,11 +153,12 @@ func TestProcess(t *testing.T) {
 					},
 				},
 			},
-			expectStart: []string{"kube-system/pod-checkpointer"},
+			expectStart:      []string{"kube-system/pod-checkpointer"},
+			expectGraceStart: []string{"kube-system/pod-checkpointer"},
 		},
 		{
 			desc:         "Inactive pod-checkpointer, no local parent, no api parent: should remove in the last",
-			localRunning: map[string]*v1.Pod{"kube-system/pod-checkpointer": {}, "AA": {}},
+			localRunning: map[string]*v1.Pod{"kube-system/pod-checkpointer": {}, "AA": {}, "BB": {}},
 			localParents: map[string]*v1.Pod{"BB": {}},
 			apiParents:   map[string]*v1.Pod{"BB": {}},
 			inactiveCheckpoints: map[string]*v1.Pod{
@@ -146,7 +170,8 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectRemove: []string{"AA", "kube-system/pod-checkpointer"},
+			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
+			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
 		},
 		{
 			desc:         "Inactive pod-checkpointer, no local parent, no api parent: should remove all",
@@ -162,7 +187,8 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectRemove: []string{"AA", "kube-system/pod-checkpointer"},
+			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
+			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
 		},
 		{
 			desc:         "Active pod-checkpointer, no local parent, no api parent: should remove all",
@@ -178,14 +204,22 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectRemove: []string{"AA", "kube-system/pod-checkpointer"},
+			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
+			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
 		},
 		{
 			desc:         "Running as an on-disk checkpointer: Inactive pod-checkpointer, local parent, local running, api parent: should start",
 			podName:      "pod-checkpointer-mynode",
 			localRunning: map[string]*v1.Pod{"kube-system/pod-checkpointer": {}},
 			localParents: map[string]*v1.Pod{"kube-system/pod-checkpointer": {}},
-			apiParents:   map[string]*v1.Pod{"kube-system/pod-checkpointer": {}},
+			apiParents: map[string]*v1.Pod{
+				"kube-system/pod-checkpointer": {
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "kube-system",
+						Name:      "pod-checkpointer",
+					},
+				},
+			},
 			inactiveCheckpoints: map[string]*v1.Pod{
 				"kube-system/pod-checkpointer": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -194,12 +228,20 @@ func TestProcess(t *testing.T) {
 					},
 				},
 			},
-			expectStart: []string{"kube-system/pod-checkpointer"},
+			expectStart:      []string{"kube-system/pod-checkpointer"},
+			expectGraceStart: []string{"kube-system/pod-checkpointer"},
 		},
 		{
-			desc:         "Running as an on-disk checkpointer: Inactive pod-checkpointer, local parent, no local running, api not reachable: should start",
-			podName:      "pod-checkpointer-mynode",
-			localParents: map[string]*v1.Pod{"kube-system/pod-checkpointer": {}},
+			desc:    "Running as an on-disk checkpointer: Inactive pod-checkpointer, local parent, no local running, api not reachable: should start",
+			podName: "pod-checkpointer-mynode",
+			localParents: map[string]*v1.Pod{
+				"kube-system/pod-checkpointer": {
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "kube-system",
+						Name:      "pod-checkpointer",
+					},
+				},
+			},
 			inactiveCheckpoints: map[string]*v1.Pod{
 				"kube-system/pod-checkpointer": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -208,7 +250,8 @@ func TestProcess(t *testing.T) {
 					},
 				},
 			},
-			expectStart: []string{"kube-system/pod-checkpointer"},
+			expectStart:      []string{"kube-system/pod-checkpointer"},
+			expectGraceStart: []string{"kube-system/pod-checkpointer"},
 		},
 		{
 			desc:         "Running as an on-disk checkpointer: Inactive pod-checkpointer, no local parent, no api parent: should remove in the last",
@@ -225,7 +268,8 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectRemove: []string{"AA", "kube-system/pod-checkpointer"},
+			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
+			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
 		},
 		{
 			desc:         "Running as an on-disk checkpointer: Inactive pod-checkpointer, no local parent, no api parent: should remove all",
@@ -242,7 +286,8 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectRemove: []string{"AA", "kube-system/pod-checkpointer"},
+			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
+			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
 		},
 		{
 			desc:         "Running as an on-disk checkpointer: Active pod-checkpointer, no local parent, no api parent: should remove all",
@@ -259,11 +304,13 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectRemove: []string{"AA", "kube-system/pod-checkpointer"},
+			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
+			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
 		},
 	}
 
 	for _, tc := range cases {
+		// Set up test state.
 		cp := CheckpointerPod{
 			NodeName:     "mynode",
 			PodName:      "pod-checkpointer",
@@ -272,12 +319,24 @@ func TestProcess(t *testing.T) {
 		if tc.podName != "" {
 			cp.PodName = tc.podName
 		}
-		gotStart, gotStop, gotRemove := process(tc.localRunning, tc.localParents, tc.apiParents, tc.activeCheckpoints, tc.inactiveCheckpoints, cp)
+		c := checkpoints{}
+
+		// Run test now.
+		now := time.Time{}
+		c.update(tc.localRunning, tc.localParents, tc.apiParents, tc.activeCheckpoints, tc.inactiveCheckpoints, cp)
+		gotStart, gotStop, gotRemove := c.process(now, tc.apiParents != nil, tc.localRunning, tc.localParents, tc.apiParents)
+
+		// Advance past grace period and test again.
+		now = now.Add(checkpointGracePeriod)
+		c.update(tc.localRunning, tc.localParents, tc.apiParents, tc.activeCheckpoints, tc.inactiveCheckpoints, cp)
+		gotGraceStart, gotGraceStop, gotGraceRemove := c.process(now, tc.apiParents != nil, tc.localRunning, tc.localParents, tc.apiParents)
 		if !reflect.DeepEqual(tc.expectStart, gotStart) ||
 			!reflect.DeepEqual(tc.expectStop, gotStop) ||
-			!reflect.DeepEqual(tc.expectRemove, gotRemove) {
-			t.Errorf("For test: %s\nExpected start: %s Got: %s\nExpected stop: %s Got: %s\nExpected remove: %s Got: %s\n",
-				tc.desc, tc.expectStart, gotStart, tc.expectStop, gotStop, tc.expectRemove, gotRemove)
+			!reflect.DeepEqual(tc.expectRemove, gotRemove) ||
+			!reflect.DeepEqual(tc.expectGraceStart, gotGraceStart) ||
+			!reflect.DeepEqual(tc.expectGraceStop, gotGraceStop) ||
+			!reflect.DeepEqual(tc.expectGraceRemove, gotGraceRemove) {
+			t.Errorf("For test: %s\nExpected start: %s Got: %s\nExpected stop: %s Got: %s\nExpected remove: %s Got: %s\nExpected grace period start: %s Got: %s\nExpected grace period stop: %s Got: %s\nExpected grace period remove: %s Got: %s\n", tc.desc, tc.expectStart, gotStart, tc.expectStop, gotStop, tc.expectRemove, gotRemove, tc.expectGraceStart, gotGraceStart, tc.expectGraceStop, gotGraceStop, tc.expectGraceRemove, gotGraceRemove)
 		}
 	}
 }

--- a/pkg/checkpoint/state.go
+++ b/pkg/checkpoint/state.go
@@ -1,0 +1,343 @@
+package checkpoint
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// apiCondition represents information returned from the various api endpoints for a given pod.
+type apiCondition struct {
+	// apiAvailable is true if the apiserver was reachable.
+	apiAvailable bool
+	// apiParent is true if the api parent pod exists.
+	apiParent bool
+	// localRunning is true if the CRI shim reports that the pod is running locally.
+	localRunning bool
+	// localParent is true if the kubelet parent pod exists.
+	localParent bool
+}
+
+// String() implements fmt.Stringer.String().
+func (a apiCondition) String() string {
+	return fmt.Sprintf("apiAvailable=%t, apiParent=%t, localRunning=%t, localParent=%t", a.apiAvailable, a.apiParent, a.localRunning, a.localParent)
+}
+
+// action represents the action to be taken based on the state of a checkpoint.
+type action int
+
+const (
+	// none is the default action of "do nothing".
+	none = iota
+	// start means that the checkpoint should be started.
+	start
+	// stop means that the checkpoint should be stopped.
+	stop
+	// remove means that the checkpoint should be garbage collected.
+	remove
+)
+
+// String() implements fmt.Stringer.String().
+func (a action) String() string {
+	switch a {
+	case none:
+		return "none"
+	case start:
+		return "start"
+	case stop:
+		return "stop"
+	case remove:
+		return "remove"
+	default:
+		return "[unknown action]"
+	}
+}
+
+// checkpointState represents the current state of a checkpoint.
+type checkpointState interface {
+	// transition computes the new state for the current time and information from various apis.
+	transition(time.Time, apiCondition) checkpointState
+	// action returns the action that should be taken for this state.
+	action() action
+}
+
+// stateSelfCheckpointActive represents a checkpoint of the checkpointer itself, which has special
+// behavior.
+//
+// stateSelfCheckpointActive can transition to stateInactiveGracePeriod.
+type stateSelfCheckpointActive struct{}
+
+// transition implements state.transition()
+func (s stateSelfCheckpointActive) transition(now time.Time, apis apiCondition) checkpointState {
+	if !apis.apiAvailable {
+		// If the apiserver is unavailable always stay in the selfCheckpoint state.
+		return s
+	}
+
+	if apis.apiParent {
+		// If the parent pod exists always stay in the selfCheckpoint state.
+		return s
+	}
+
+	// The apiserver parent pod is deleted, transition to stateInactiveGracePeriod.
+	// TODO(diegs): this is a little hacky, perhaps clean it up with a constructor.
+	return stateInactiveGracePeriod{gracePeriodEnd: now.Add(checkpointGracePeriod)}.checkGracePeriod(now, apis)
+}
+
+// action implements state.action()
+func (s stateSelfCheckpointActive) action() action {
+	// The self-checkpoint should always be started.
+	return start
+}
+
+// String() implements fmt.Stringer.String().
+func (s stateSelfCheckpointActive) String() string {
+	return "self-checkpoint"
+}
+
+// stateNone represents a new pod that has not been processed yet, so it has no checkpoint state.
+//
+// stateNone can transition to stateInactive, stateInactiveGracePeriod, or stateActive.
+type stateNone struct{}
+
+// transition implements state.transition()
+func (s stateNone) transition(now time.Time, apis apiCondition) checkpointState {
+	// Newly discovered pods are treated as mostly inactive, but only if there is either a local
+	// running pod or kubelet parent pod. In other words, if the new pod is only reflected in the
+	// apiserver we do not checkpoint it yet.
+	if apis.localRunning || apis.localParent {
+		return stateInactive{}.transition(now, apis)
+	}
+	return s
+}
+
+// action implements state.action()
+func (s stateNone) action() action {
+	return none
+}
+
+// String() implements fmt.Stringer.String().
+func (s stateNone) String() string {
+	return "none"
+}
+
+// stateInactive is a checkpoint that is currently sitting inactive on disk.
+//
+// stateInactive can transition to stateActive or stateInactiveGracePeriod.
+type stateInactive struct{}
+
+// transition implements state.transition()
+func (s stateInactive) transition(now time.Time, apis apiCondition) checkpointState {
+	if !apis.apiAvailable {
+		// The apiserver is unavailable but the local copy is running, remain in stateInactive.
+		if apis.localRunning {
+			return s
+		}
+
+		// The apiserver is unavailable and the local pod is not running, transition to stateActive.
+		return stateActive{}
+	}
+
+	if apis.apiParent {
+		// The parent pod exists and the kubelet is running it, remain in stateInactive.
+		if apis.localRunning {
+			return s
+		}
+
+		// The parent pod exists but the kubelet is not running it, transition to stateActive.
+		return stateActive{}
+	}
+
+	// The apiserver parent pod is deleted, transition to stateInactiveGracePeriod.
+	// TODO(diegs): this is a little hacky, perhaps clean it up with a constructor.
+	return stateInactiveGracePeriod{gracePeriodEnd: now.Add(checkpointGracePeriod)}.checkGracePeriod(now, apis)
+}
+
+// action implements state.action()
+func (s stateInactive) action() action {
+	return stop
+}
+
+// String() implements fmt.Stringer.String().
+func (s stateInactive) String() string {
+	return "inactive"
+}
+
+// stateInactiveGracePeriod is a checkpoint that is inactive but will be garbage collected after a
+// grace period.
+//
+// stateInactiveGracePeriod can transition to stateInactive, stateActive, or stateRemove.
+type stateInactiveGracePeriod struct {
+	// gracePeriodEnd is the time when the grace period for this checkpoint is over and it should be
+	// garbage collected.
+	gracePeriodEnd time.Time
+}
+
+// transition implements state.transition()
+func (s stateInactiveGracePeriod) transition(now time.Time, apis apiCondition) checkpointState {
+	if !apis.apiAvailable {
+		// The apiserver is unavailable but the local copy is running, remain in
+		// stateInactiveGracePeriod.
+		if apis.localRunning {
+			return s.checkGracePeriod(now, apis)
+		}
+
+		// The apiserver is unavailable and the local pod is not running, transition to stateActive.
+		return stateActive{}
+	}
+
+	if apis.apiParent {
+		// The parent pod exists and the kubelet is running it, remain in inactive.
+		if apis.localRunning {
+			return stateInactive{}
+		}
+
+		// The parent pod exists but the kubelet is not running it, transition to stateActive.
+		return stateActive{}
+	}
+
+	// The apiserver pod is still deleted, remain in stateInactiveGracePeriod.
+	return s.checkGracePeriod(now, apis)
+}
+
+func (s stateInactiveGracePeriod) checkGracePeriod(now time.Time, apis apiCondition) checkpointState {
+	// Override state to remove if the grace period has passed.
+	if now.Equal(s.gracePeriodEnd) || now.After(s.gracePeriodEnd) {
+		glog.Infof("Grace period exceeded for state %s", s)
+		return stateRemove{}
+	}
+	return s
+}
+
+// action implements state.action()
+func (s stateInactiveGracePeriod) action() action {
+	return stop
+}
+
+// String() implements fmt.Stringer.String().
+func (s stateInactiveGracePeriod) String() string {
+	return "inactive (grace period)"
+}
+
+// stateActive is a checkpoint that is currently activated.
+//
+// stateActive can transition to stateInactive or stateActiveGracePeriod.
+type stateActive struct{}
+
+// transition implements state.transition()
+func (s stateActive) transition(now time.Time, apis apiCondition) checkpointState {
+	if !apis.apiAvailable {
+		// The apiserver is unavailable but the local copy is running, transition to inactive.
+		if apis.localRunning {
+			return stateInactive{}
+		}
+
+		// The apiserver is unavailable and the local pod is not running, remain in stateActive.
+		return s
+	}
+
+	if apis.apiParent {
+		// The parent pod exists and the kubelet is running it, transition to inactive.
+		if apis.localRunning {
+			return stateInactive{}
+		}
+
+		// The parent pod exists but the kubelet is not running it, remain in stateActive.
+		return s
+	}
+
+	// The apiserver pod is deleted, transition to stateActiveGracePeriod.
+	// TODO(diegs): this is a little hacky, perhaps clean it up with a constructor.
+	return stateActiveGracePeriod{gracePeriodEnd: now.Add(checkpointGracePeriod)}.checkGracePeriod(now, apis)
+}
+
+// action implements state.action()
+func (s stateActive) action() action {
+	return start
+}
+
+// String() implements fmt.Stringer.String().
+func (s stateActive) String() string {
+	return "active"
+}
+
+// stateActiveGracePeriod is a checkpoint that is active but will be garbage collected after a grace
+// period.
+//
+// stateActiveGracePeriod can transition to stateActive or stateInactive.
+type stateActiveGracePeriod struct {
+	// gracePeriodEnd is the time when the grace period for this checkpoint is over and it should be
+	// garbage collected.
+	gracePeriodEnd time.Time
+}
+
+// transition implements state.transition()
+func (s stateActiveGracePeriod) transition(now time.Time, apis apiCondition) checkpointState {
+	if !apis.apiAvailable {
+		// The apiserver is unavailable but the local copy is running, transition to stateInactive.
+		if apis.localRunning {
+			return stateInactive{}
+		}
+
+		// The apiserver is unavailable and the local pod is not running, remain in
+		// stateActiveGracePeriod.
+		return s.checkGracePeriod(now, apis)
+	}
+
+	if apis.apiParent {
+		// The parent pod exists and the kubelet is running it, transition to stateInactive.
+		if apis.localRunning {
+			return stateInactive{}
+		}
+
+		// The parent pod exists but the kubelet is not running it, transition to stateActive.
+		return stateActive{}
+	}
+
+	// The apiserver pod is still deleted, remain in stateActiveGracePeriod.
+	return s.checkGracePeriod(now, apis)
+}
+
+func (s stateActiveGracePeriod) checkGracePeriod(now time.Time, apis apiCondition) checkpointState {
+	// Override state to stateInactiveGracePeriod.transition() as if the grace period has passed. This
+	// has the effect of either transitioning to stateInactive or stateRemove.
+	if now.Equal(s.gracePeriodEnd) || now.After(s.gracePeriodEnd) {
+		glog.Infof("Grace period exceeded for state %s", s)
+		return stateInactiveGracePeriod{gracePeriodEnd: now}.transition(now, apis)
+	}
+	return s
+}
+
+// action implements state.action()
+func (s stateActiveGracePeriod) action() action {
+	return start
+}
+
+// String() implements fmt.Stringer.String().
+func (s stateActiveGracePeriod) String() string {
+	return "active (grace period)"
+}
+
+// stateRemove is a checkpoint that is being garbage collected.
+//
+// It is a terminal state that can never transition to other states; checkpoints in this state are
+// removed as part of the update loop.
+type stateRemove struct{}
+
+// transition implements state.transition()
+func (s stateRemove) transition(now time.Time, apis apiCondition) checkpointState {
+	// Remove is a terminal state. This should never actually be called.
+	glog.Errorf("Unexpected call to transition() for state %s", s)
+	return s
+}
+
+// action implements state.action()
+func (s stateRemove) action() action {
+	return remove
+}
+
+// String() implements fmt.Stringer.String().
+func (s stateRemove) String() string {
+	return "remove"
+}

--- a/pkg/checkpoint/state_test.go
+++ b/pkg/checkpoint/state_test.go
@@ -1,0 +1,69 @@
+package checkpoint
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+var (
+	allAPIConditions []apiCondition
+)
+
+func init() {
+	bools := []bool{true, false}
+	for _, apiAvailable := range bools {
+		for _, apiParent := range bools {
+			for _, localRunning := range bools {
+				for _, localParent := range bools {
+					allAPIConditions = append(allAPIConditions, apiCondition{
+						apiAvailable, apiParent, localRunning, localParent,
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestAllowedStateTransitions(t *testing.T) {
+	for _, tc := range []struct {
+		state checkpointState
+		want  []checkpointState
+	}{{
+		state: stateSelfCheckpointActive{},
+		want:  []checkpointState{stateSelfCheckpointActive{}, stateInactiveGracePeriod{}},
+	}, {
+		state: stateNone{},
+		want:  []checkpointState{stateNone{}, stateInactive{}, stateInactiveGracePeriod{}, stateActive{}},
+	}, {
+		state: stateInactive{},
+		want:  []checkpointState{stateInactive{}, stateInactiveGracePeriod{}, stateActive{}},
+	}, {
+		state: stateInactiveGracePeriod{},
+		want:  []checkpointState{stateInactive{}, stateInactiveGracePeriod{}, stateActive{}, stateRemove{}},
+	}, {
+		state: stateActive{},
+		want:  []checkpointState{stateActive{}, stateActiveGracePeriod{}, stateInactive{}},
+	}, {
+		state: stateActiveGracePeriod{},
+		want:  []checkpointState{stateActiveGracePeriod{}, stateActive{}, stateInactive{}, stateRemove{}},
+	}, {
+		state: stateRemove{},
+		want:  []checkpointState{stateRemove{}},
+	}} {
+		for _, apis := range allAPIConditions {
+			now := time.Time{}
+			got := tc.state.transition(time.Time{}, apis)
+			allowed := false
+			for _, want := range tc.want {
+				if reflect.TypeOf(got) == reflect.TypeOf(want) {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				t.Errorf("%s.transition(%s, %s) = %s, want: %s", tc.state, now.Format("04:05"), apis, got, tc.want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This implements an explicit state machine to capture the various states
a checkpoint can be in. It recovers those states from disk upon startup
(if applicable) and then reconciles them with the states that are
fetched from the various apiservers.

It also adds 2 new states to attempt to workaround issues with
kubernetes 1.8 in which daemonset pods are deleted before being
recreated. For single-master clusters this can lead to a total outage
during apiserver upgrades since the checkpointer will aggressively
retire the checkpoint for the deleted apiserver pod before it has
a chance to schedule the new one.