### PR TITLE
images: update pod-checkpointer.

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -13,5 +13,5 @@ var DefaultImages = ImageVersions{
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5",
 	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5",
 	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5",
-	PodCheckpointer: "quay.io/coreos/pod-checkpointer:ec22bec63334befacc2b237ab73b1a8b95b0a654",
+	PodCheckpointer: "quay.io/coreos/pod-checkpointer:e22cc0e3714378de92f45326474874eb602ca0ac",
 }

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -390,7 +390,6 @@ spec:
         image: {{ .Images.PodCheckpointer }}
         command:
         - /checkpoint
-        - --v=4
         - --lock-file=/var/run/lock/pod-checkpointer.lock
         env:
         - name: NODE_NAME


### PR DESCRIPTION
Updates checkpointer to e22cc0e3714378de92f45326474874eb602ca0ac.

Also removes `-v=4` from the manifest by default because it's
unnecessarily noisy.