### PR TITLE
*/kubelet: remove deprecated flag

### DIFF
--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -39,8 +39,7 @@ coreos:
           --network-plugin=cni \
           --node-labels=node-role.kubernetes.io/master \
           --pod-manifest-path=/etc/kubernetes/manifests \
-          --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-          --require-kubeconfig
+          --register-with-taints=node-role.kubernetes.io/master=:NoSchedule
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=5

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -32,8 +32,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --network-plugin=cni \
   --node-labels=node-role.kubernetes.io/master \
   --pod-manifest-path=/etc/kubernetes/manifests \
-  --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-  --require-kubeconfig
+  --register-with-taints=node-role.kubernetes.io/master=:NoSchedule
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
 Restart=always
 RestartSec=5

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -38,8 +38,7 @@ coreos:
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
           --node-labels=node-role.kubernetes.io/master \
-          --pod-manifest-path=/etc/kubernetes/manifests \
-          --require-kubeconfig
+          --pod-manifest-path=/etc/kubernetes/manifests
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=5

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -69,7 +69,6 @@ spec:
         - --lock-file=/var/run/lock/kubelet.lock
         - --network-plugin=cni
         - --pod-manifest-path=/etc/kubernetes/manifests
-        - --require-kubeconfig
         env:
           - name: NODE_NAME
             valueFrom:


### PR DESCRIPTION
As of 1.8 (https://issues.k8s.io/40050) this flag is deprecated and does
nothing.