### PR TITLE
checkpointer: two fixes (now that checkpointer tests work again)

### DIFF
--- a/pkg/checkpoint/pod.go
+++ b/pkg/checkpoint/pod.go
@@ -28,8 +28,13 @@ var (
 	)
 )
 
-func sanitizeCheckpointPod(cp *v1.Pod) (*v1.Pod, error) {
+func sanitizeCheckpointPod(cp *v1.Pod) *v1.Pod {
 	trueVar := true
+
+	// Check if this is already sanitized, i.e. it was read back from a checkpoint on disk.
+	if _, ok := cp.Annotations[checkpointParentAnnotation]; ok {
+		return cp
+	}
 
 	// Keep same name, namespace, and labels as parent.
 	cp.ObjectMeta = metav1.ObjectMeta{
@@ -73,7 +78,7 @@ func sanitizeCheckpointPod(cp *v1.Pod) (*v1.Pod, error) {
 	// Clear pod status
 	cp.Status.Reset()
 
-	return cp, nil
+	return cp
 }
 
 // isPodCheckpointer returns true if the manifest is the pod checkpointer (has the same name as the parent).

--- a/pkg/checkpoint/pod_test.go
+++ b/pkg/checkpoint/pod_test.go
@@ -139,13 +139,41 @@ func TestSanitizeCheckpointPod(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "Pod is already sanitized.",
+			pod: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "podname",
+					Namespace:   "podnamespace",
+					Annotations: map[string]string{checkpointParentAnnotation: "podname"},
+					OwnerReferences: []metav1.OwnerReference{
+						{APIVersion: "v1", Kind: "Pod", Name: "podname", UID: "pod-uid", Controller: &trueVar},
+					},
+				},
+			},
+			expected: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "podname",
+					Namespace:   "podnamespace",
+					Annotations: map[string]string{checkpointParentAnnotation: "podname"},
+					OwnerReferences: []metav1.OwnerReference{
+						{APIVersion: "v1", Kind: "Pod", Name: "podname", UID: "pod-uid", Controller: &trueVar},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
-		got, err := sanitizeCheckpointPod(tc.pod)
-		if err != nil {
-			t.Errorf("\nUnexpected error: %v\n", err)
-		}
+		got := sanitizeCheckpointPod(tc.pod)
 		if !apiequality.Semantic.DeepEqual(tc.expected, got) {
 			t.Errorf("\nFor Test: %s\n\nExpected:\n%#v\nGot:\n%#v\n", tc.desc, tc.expected, got)
 		}

--- a/pkg/checkpoint/process.go
+++ b/pkg/checkpoint/process.go
@@ -43,7 +43,8 @@ func (cs *checkpoints) update(localRunningPods, localParentPods, apiParentPods, 
 		cs.checkpoints[cs.selfCheckpoint.name] = cs.selfCheckpoint
 	}
 
-	// Make sure all on-disk checkpoints are represented in memory, i.e. if we are restarting from a crash.
+	// Make sure all on-disk checkpoints are represented in memory, i.e. if we are restarting from a
+	// crash.
 	for name, pod := range activeCheckpoints {
 		if _, ok := cs.checkpoints[name]; !ok {
 			cs.checkpoints[name] = &checkpoint{
@@ -224,11 +225,7 @@ func (c *checkpointer) createCheckpointsForValidParents() {
 			continue
 		}
 
-		cp, err = sanitizeCheckpointPod(cp)
-		if err != nil {
-			glog.Errorf("Failed to sanitize manifest for %s: %v", id, err)
-			continue
-		}
+		cp = sanitizeCheckpointPod(cp)
 
 		podChanged, err := writeCheckpointManifest(cp)
 		if err != nil {

--- a/pkg/checkpoint/process.go
+++ b/pkg/checkpoint/process.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/golang/glog"
@@ -143,6 +144,7 @@ func (cs *checkpoints) process(now time.Time, apiAvailable bool, localRunningPod
 					stops = append(stops, name)
 				}
 			}
+			sort.Strings(stops) // Ensure stable ordering.
 			stops = append(stops, cs.selfCheckpoint.name)
 			return starts, stops, removes
 		case remove:
@@ -154,6 +156,7 @@ func (cs *checkpoints) process(now time.Time, apiAvailable bool, localRunningPod
 					delete(cs.checkpoints, name)
 				}
 			}
+			sort.Strings(removes) // Ensure stable ordering.
 			removes = append(removes, cs.selfCheckpoint.name)
 			delete(cs.checkpoints, cs.selfCheckpoint.name)
 			cs.selfCheckpoint = nil

--- a/pkg/checkpoint/process_test.go
+++ b/pkg/checkpoint/process_test.go
@@ -1,7 +1,6 @@
 package checkpoint
 
 import (
-	"flag"
 	"reflect"
 	"testing"
 	"time"
@@ -11,9 +10,6 @@ import (
 )
 
 func TestProcess(t *testing.T) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
 	type testCase struct {
 		desc                string
 		localRunning        map[string]*v1.Pod

--- a/pkg/checkpoint/process_test.go
+++ b/pkg/checkpoint/process_test.go
@@ -56,6 +56,13 @@ func TestProcess(t *testing.T) {
 			expectStart:         []string{"AA"},
 		},
 		{
+			desc:                "Inactive checkpoint and only api and kubelet parents: should start",
+			inactiveCheckpoints: map[string]*v1.Pod{"AA": {}},
+			apiParents:          map[string]*v1.Pod{"AA": {}},
+			localParents:        map[string]*v1.Pod{"AA": {}},
+			expectStart:         []string{"AA"},
+		},
+		{
 			desc:              "Active checkpoint and no local running: no change",
 			activeCheckpoints: map[string]*v1.Pod{"AA": {}},
 		},

--- a/pkg/checkpoint/process_test.go
+++ b/pkg/checkpoint/process_test.go
@@ -166,8 +166,9 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
-			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
+			expectStart:       []string{"kube-system/pod-checkpointer"},
+			expectStop:        []string{"BB"},
+			expectGraceRemove: []string{"AA", "BB", "kube-system/pod-checkpointer"},
 		},
 		{
 			desc:         "Inactive pod-checkpointer, no local parent, no api parent: should remove all",
@@ -183,7 +184,7 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
+			expectStart:       []string{"kube-system/pod-checkpointer"},
 			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
 		},
 		{
@@ -200,7 +201,8 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
+			expectStart:       []string{"kube-system/pod-checkpointer"},
+			expectStop:        []string{"AA"},
 			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
 		},
 		{
@@ -264,8 +266,8 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
-			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
+			expectStart:       []string{"kube-system/pod-checkpointer", "BB"},
+			expectGraceRemove: []string{"AA", "BB", "kube-system/pod-checkpointer"},
 		},
 		{
 			desc:         "Running as an on-disk checkpointer: Inactive pod-checkpointer, no local parent, no api parent: should remove all",
@@ -282,7 +284,7 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
+			expectStart:       []string{"kube-system/pod-checkpointer"},
 			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
 		},
 		{
@@ -300,7 +302,8 @@ func TestProcess(t *testing.T) {
 				},
 				"AA": {},
 			},
-			expectStop:        []string{"AA", "kube-system/pod-checkpointer"},
+			expectStart:       []string{"kube-system/pod-checkpointer"},
+			expectStop:        []string{"AA"},
 			expectGraceRemove: []string{"AA", "kube-system/pod-checkpointer"},
 		},
 	}

--- a/pkg/checkpoint/state.go
+++ b/pkg/checkpoint/state.go
@@ -65,7 +65,7 @@ type checkpointState interface {
 // stateSelfCheckpointActive represents a checkpoint of the checkpointer itself, which has special
 // behavior.
 //
-// stateSelfCheckpointActive can transition to stateInactiveGracePeriod.
+// stateSelfCheckpointActive can transition to stateActiveGracePeriod.
 type stateSelfCheckpointActive struct{}
 
 // transition implements state.transition()
@@ -80,9 +80,9 @@ func (s stateSelfCheckpointActive) transition(now time.Time, apis apiCondition) 
 		return s
 	}
 
-	// The apiserver parent pod is deleted, transition to stateInactiveGracePeriod.
+	// The apiserver parent pod is deleted, transition to stateActiveGracePeriod.
 	// TODO(diegs): this is a little hacky, perhaps clean it up with a constructor.
-	return stateInactiveGracePeriod{gracePeriodEnd: now.Add(checkpointGracePeriod)}.checkGracePeriod(now, apis)
+	return stateActiveGracePeriod{gracePeriodEnd: now.Add(checkpointGracePeriod)}.checkGracePeriod(now, apis)
 }
 
 // action implements state.action()

--- a/pkg/checkpoint/state_test.go
+++ b/pkg/checkpoint/state_test.go
@@ -31,7 +31,7 @@ func TestAllowedStateTransitions(t *testing.T) {
 		want  []checkpointState
 	}{{
 		state: stateSelfCheckpointActive{},
-		want:  []checkpointState{stateSelfCheckpointActive{}, stateInactiveGracePeriod{}},
+		want:  []checkpointState{stateSelfCheckpointActive{}, stateActiveGracePeriod{}},
 	}, {
 		state: stateNone{},
 		want:  []checkpointState{stateNone{}, stateInactive{}, stateInactiveGracePeriod{}, stateActive{}},


### PR DESCRIPTION
checkpointer: make sanitize function idempotent.

The new behavior reads back checkpoints from disk when the checkpointer
restarts, e.g. on node reboot. It was then round-tripping those
checkpoints through the sanitize() function which was not idempotent.
This changes that function to be idempotent.

checkpointer: don't move checkpointer to inactive.

It should move to activeGracePeriod after it is removed. Then it will
clean itself up after the grace period ends.

If it moves to inactive then it will simply get terminated while leaving
garbage around.

cc @thorfour 