### PR TITLE
pkg/asset: Disable Calico termination grace period

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -1293,7 +1293,7 @@ spec:
             - name: CALICO_IPV4POOL_CIDR
               value: "{{ .PodCIDR }}"
             - name: CALICO_IPV4POOL_IPIP
-              value: "always"
+              value: "Always"
             - name: FELIX_IPINIPENABLED
               value: "true"
             - name: NODENAME
@@ -1350,6 +1350,7 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+      terminationGracePeriodSeconds: 0
       volumes:
         - name: lib-modules
           hostPath:
@@ -1417,7 +1418,7 @@ spec:
             - name: CALICO_IPV4POOL_CIDR
               value: "{{ .PodCIDR }}"
             - name: CALICO_IPV4POOL_IPIP
-              value: "always"
+              value: "Always"
             - name: NODENAME
               valueFrom:
                 fieldRef:
@@ -1472,6 +1473,7 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+      terminationGracePeriodSeconds: 0
       volumes:
         - name: lib-modules
           hostPath:


### PR DESCRIPTION
* Disable termination grace period to account for Kubernetes v1.8 changes to DaemonSet behavior that can cause rolls to be slow. See https://github.com/projectcalico/calico/pull/1293
* Fix IPIP mode casing https://github.com/projectcalico/calico/pull/1233