### PR TITLE
checkpoint: only watch pods in kube-system

### DIFF
--- a/pkg/checkpoint/apiserver.go
+++ b/pkg/checkpoint/apiserver.go
@@ -15,7 +15,7 @@ func (c *checkpointer) getAPIParentPods(nodeName string) (bool, map[string]*v1.P
 		FieldSelector: fields.OneTermEqualSelector(api.PodHostField, nodeName).String(),
 	}
 
-	podList, err := c.apiserver.CoreV1().Pods(api.NamespaceAll).List(opts)
+	podList, err := c.apiserver.CoreV1().Pods(c.checkpointerPod.PodNamespace).List(opts)
 	if err != nil {
 		glog.Warningf("Unable to contact APIServer, skipping garbage collection: %v", err)
 		return false, nil


### PR DESCRIPTION
This is so we can drop the checkpoint's ClusterRole to a Role. See discussion https://github.com/kubernetes-incubator/bootkube/pull/767#pullrequestreview-76901940