### PR TITLE
checkpointer: update image and drop permissions from ClusterRole to Role

### DIFF
--- a/cmd/checkpoint/README.md
+++ b/cmd/checkpoint/README.md
@@ -88,14 +88,15 @@ Once it reaches the API server and finds out that it's no longer being scheduled
 ### RBAC Requirements
 
 By default, the pod checkpoint runs with service account credentials, checkpointing its own
-service account secret for reboots. That service account must be bound to a ClusterRole that
-lets the pod checkpoint watch for Pods with the checkpoint annotation, then save ConfigMaps and
-Secrets referenced by those Pods.
+service account secret for reboots. That service account must be bound to a Role that lets the
+pod checkpoint watch for Pods with the checkpoint annotation, then save ConfigMaps and Secrets
+referenced by those Pods.
 
 ```yaml
-kind: ClusterRole
+kind: Role
 metadata:
   name: pod-checkpointer
+  namespace: kube-system
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
@@ -104,6 +105,3 @@ rules:
   resources: ["secrets", "configmaps"]
   verbs: ["get"]
 ```
-
-Currently the pod checkpoint watches all pods in all namespaces, and requires a ClusterRole and
-ClusterRoleBinding. In the future the pod checkpoint may be restricted to `kube-system`.

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -13,5 +13,5 @@ var DefaultImages = ImageVersions{
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5",
 	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5",
 	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5",
-	PodCheckpointer: "quay.io/coreos/pod-checkpointer:e22cc0e3714378de92f45326474874eb602ca0ac",
+	PodCheckpointer: "quay.io/coreos/pod-checkpointer:08fa021813231323e121ecca7383cc64c4afe888",
 }

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -444,13 +444,11 @@ metadata:
   name: pod-checkpointer
 `)
 
-// TODO: Drop checkpointer RBAC resources to a Role and RoleBinding if
-// the checkpoint switches to only watching kube-system.
-
 var CheckpointerRole = []byte(`apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: pod-checkpointer
+  namespace: kube-system
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
@@ -461,12 +459,13 @@ rules:
 `)
 
 var CheckpointerRoleBinding = []byte(`apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: pod-checkpointer
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: pod-checkpointer
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
The checkpointer now only watches pods in kube-system (#774), so it
doesn't need cluster wide permissions.

/assign @dghubble 