### PR TITLE
e2e: make checkpointer tests more robust.

### DIFF
--- a/cmd/checkpoint/README.md
+++ b/cmd/checkpoint/README.md
@@ -88,14 +88,15 @@ Once it reaches the API server and finds out that it's no longer being scheduled
 ### RBAC Requirements
 
 By default, the pod checkpoint runs with service account credentials, checkpointing its own
-service account secret for reboots. That service account must be bound to a ClusterRole that
-lets the pod checkpoint watch for Pods with the checkpoint annotation, then save ConfigMaps and
-Secrets referenced by those Pods.
+service account secret for reboots. That service account must be bound to a Role that lets the
+pod checkpoint watch for Pods with the checkpoint annotation, then save ConfigMaps and Secrets
+referenced by those Pods.
 
 ```yaml
-kind: ClusterRole
+kind: Role
 metadata:
   name: pod-checkpointer
+  namespace: kube-system
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
@@ -104,6 +105,3 @@ rules:
   resources: ["secrets", "configmaps"]
   verbs: ["get"]
 ```
-
-Currently the pod checkpoint watches all pods in all namespaces, and requires a ClusterRole and
-ClusterRoleBinding. In the future the pod checkpoint may be restricted to `kube-system`.

--- a/e2e/checkpointer_test.go
+++ b/e2e/checkpointer_test.go
@@ -8,31 +8,264 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	rbac "k8s.io/client-go/pkg/apis/rbac/v1beta1"
+
+	"github.com/kubernetes-incubator/bootkube/pkg/asset"
 )
 
-var nginxDS = []byte(`apiVersion: extensions/v1beta1
-kind: DaemonSet
-metadata:
-  name: nginx-daemonset
-spec:
-  template:
-    metadata:
-      labels:
-        app: nginx-checkpoint-test
-      annotations:
-        checkpointer.alpha.coreos.com/checkpoint: "true"
-    spec:
-      hostNetwork: true
-      containers:
-        - name: nginx
-          image: nginx`)
+const (
+	retryAttempts = 60
+	retryInterval = 5 * time.Second
+)
+
+func TestCheckpointer(t *testing.T) {
+	t.Run("UnscheduleCheckpointer", testCheckpointerUnscheduleCheckpointer)
+	t.Run("UnscheduleParent", testCheckpointerUnscheduleParent)
+}
+
+// 1. Schedule a pod checkpointer on worker node.
+// 2. Schedule a test pod on worker node.
+// 3. Reboot the worker without starting the kubelet.
+// 4. Delete the checkpointer on API server.
+// 5. Reboot the masters without starting the kubelet.
+// 6. Start the worker kubelet, verify the checkpointer and the pod are still running as static pods.
+// 7. Start the master kubelets, verify the checkpointer is removed but the pod is still running.
+func testCheckpointerUnscheduleCheckpointer(t *testing.T) {
+	// Get the cluster
+	c := waitCluster(t)
+
+	testNS := makeNamespace(t.Name())
+	if _, err := createNamespace(client, testNS); err != nil {
+		t.Fatalf("Failed to create namespace: %v", err)
+	}
+	defer deleteNamespace(client, testNS)
+
+	// Deploy the pod checkpointer and test nginx.
+	if err := setupTestCheckpointerRole(testNS); err != nil {
+		t.Fatalf("Failed to create test-checkpointer role: %v", err)
+	}
+	if err := createDaemonSet(testNS, []byte(fmt.Sprintf(checkpointerDS, asset.DefaultImages.PodCheckpointer)), c); err != nil {
+		t.Fatalf("Failed to create pod-checkpointer daemonset: %v", err)
+	}
+	if err := createDaemonSet(testNS, nginxDS, c); err != nil {
+		t.Fatalf("Failed to create nginx daemonset: %v", err)
+	}
+
+	// Verify the checkpoints are created.
+	if err := verifyCheckpoint(c, testNS, "test-checkpointer", true, true); err != nil {
+		t.Fatalf("Failed to verify checkpoint: %v", err)
+	}
+	if err := verifyCheckpoint(c, testNS, "test-nginx", true, false); err != nil {
+		t.Fatalf("Failed to verify checkpoint: %v", err)
+	}
+
+	// Disable the kubelet and reboot the worker.
+	if stdout, stderr, err := c.Workers[0].SSH("sudo systemctl disable kubelet"); err != nil {
+		t.Fatalf("Failed to disable kubelet on worker %q: %v\nstdout: %s\nstderr: %s", c.Workers[0].Name, err, stdout, stderr)
+	}
+	if err := c.Workers[0].Reboot(); err != nil {
+		t.Fatalf("Failed to reboot worker: %v", err)
+	}
+
+	// Delete the pod checkpointer.
+	deletePropagationForeground := metav1.DeletePropagationForeground
+	if err := client.ExtensionsV1beta1().DaemonSets(testNS).Delete("test-checkpointer", &metav1.DeleteOptions{PropagationPolicy: &deletePropagationForeground}); err != nil {
+		t.Fatalf("Failed to delete checkpointer: %v", err)
+	}
+
+	// Disable the kubelet and reboot the masters.
+	var rebootGroup sync.WaitGroup
+	for i := range c.Masters {
+		rebootGroup.Add(1)
+		go func(i int) {
+			defer rebootGroup.Done()
+			if stdout, stderr, err := c.Masters[i].SSH("sudo systemctl disable kubelet"); err != nil {
+				t.Fatalf("Failed to disable kubelet on master %q: %v\nstdout: %s\nstderr: %s", c.Masters[i].Name, err, stdout, stderr)
+			}
+			if err := c.Masters[i].Reboot(); err != nil {
+				t.Fatalf("Failed to reboot master: %v", err)
+			}
+		}(i)
+	}
+	rebootGroup.Wait()
+
+	// Start the worker kubelet.
+	if stdout, stderr, err := c.Workers[0].SSH("sudo systemctl enable kubelet && sudo systemctl start kubelet"); err != nil {
+		t.Fatalf("Failed to start kubelet on worker %q: %v\nstdout: %s\nstderr: %s", c.Workers[0].Name, err, stdout, stderr)
+	}
+
+	// Verify that the checkpoints are still running.
+	if err := verifyPod(c, "test-checkpointer", true); err != nil {
+		t.Fatalf("Failed to verifyPod: %s", err)
+	}
+	if err := verifyPod(c, "test-nginx", true); err != nil {
+		t.Fatalf("Failed to verifyPod: %s", err)
+	}
+
+	// Start the master kubelet.
+	var enableGroup sync.WaitGroup
+	for i := range c.Masters {
+		enableGroup.Add(1)
+		go func(i int) {
+			defer enableGroup.Done()
+			if stdout, stderr, err := c.Masters[i].SSH("sudo systemctl enable kubelet && sudo systemctl start kubelet"); err != nil {
+				t.Fatalf("Failed to start kubelet on master %q: %v\nstdout: %s\nstderr: %s", c.Masters[i].Name, err, stdout, stderr)
+			}
+		}(i)
+	}
+	enableGroup.Wait()
+
+	// Verify that the test-checkpointer is cleaned up but the daemonset is still running.
+	if err := verifyPod(c, "test-checkpointer", false); err != nil {
+		t.Fatalf("Failed to verifyPod: %s", err)
+	}
+	if err := verifyPod(c, "test-nginx", true); err != nil {
+		t.Fatalf("Failed to verifyPod: %s", err)
+	}
+	if err := verifyCheckpoint(c, testNS, "test-checkpointer", false, false); err != nil {
+		t.Fatalf("Failed to verifyCheckpoint: %s", err)
+	}
+	if err := verifyCheckpoint(c, testNS, "test-nginx", false, false); err != nil {
+		t.Fatalf("Failed to verifyCheckpoint: %s", err)
+	}
+}
+
+// 1. Schedule a pod checkpointer on worker node.
+// 2. Schedule a test pod on worker node.
+// 3. Reboot the worker without starting the kubelet.
+// 4. Delete the test pod on API server.
+// 5. Reboot the masters without starting the kubelet.
+// 6. Start the worker kubelet, verify the checkpointer and the pod are still running as static pods.
+// 7. Start the master kubelets, verify the test pod is removed, but not the checkpointer.
+func testCheckpointerUnscheduleParent(t *testing.T) {
+	// Get the cluster
+	c := waitCluster(t)
+
+	testNS := makeNamespace(t.Name())
+	if _, err := createNamespace(client, testNS); err != nil {
+		t.Fatalf("Failed to create namespace: %v", err)
+	}
+	defer deleteNamespace(client, testNS)
+
+	// Deploy the pod checkpointer and test nginx.
+	if err := setupTestCheckpointerRole(testNS); err != nil {
+		t.Fatalf("Failed to create test-checkpointer role: %v", err)
+	}
+	if err := createDaemonSet(testNS, []byte(fmt.Sprintf(checkpointerDS, asset.DefaultImages.PodCheckpointer)), c); err != nil {
+		t.Fatalf("Failed to create pod-checkpointer daemonset: %v", err)
+	}
+	if err := createDaemonSet(testNS, nginxDS, c); err != nil {
+		t.Fatalf("Failed to create nginx daemonset: %v", err)
+	}
+
+	// Verify the checkpoints are created.
+	if err := verifyCheckpoint(c, testNS, "test-checkpointer", true, true); err != nil {
+		t.Fatalf("verifyCheckpoint: %s", err)
+	}
+	if err := verifyCheckpoint(c, testNS, "test-nginx", true, false); err != nil {
+		t.Fatalf("verifyCheckpoint: %s", err)
+	}
+
+	// Disable the kubelet and reboot the worker.
+	if stdout, stderr, err := c.Workers[0].SSH("sudo systemctl disable kubelet"); err != nil {
+		t.Fatalf("Failed to disable kubelet on worker %q: %v\nstdout: %s\nstderr: %s", c.Workers[0].Name, err, stdout, stderr)
+	}
+	if err := c.Workers[0].Reboot(); err != nil {
+		t.Fatalf("Failed to reboot worker: %v", err)
+	}
+
+	// Delete test pod on the workers.
+	patch := `{"spec":{"template":{"spec":{"nodeSelector":{"node-role.kubernetes.io/master":""}}}}}`
+	if _, err := client.ExtensionsV1beta1().DaemonSets(testNS).Patch("test-nginx", types.MergePatchType, []byte(patch)); err != nil {
+		t.Fatalf("unable to patch daemonset: %v", err)
+	}
+
+	// Disable the kubelet and reboot the masters.
+	var rebootGroup sync.WaitGroup
+	for i := range c.Masters {
+		rebootGroup.Add(1)
+		go func(i int) {
+			defer rebootGroup.Done()
+			if stdout, stderr, err := c.Masters[i].SSH("sudo systemctl disable kubelet"); err != nil {
+				t.Fatalf("Failed to disable kubelet on master %q: %v\nstdout: %s\nstderr: %s", c.Masters[i].Name, err, stdout, stderr)
+			}
+			if err := c.Masters[i].Reboot(); err != nil {
+				t.Fatalf("Failed to reboot master: %v", err)
+			}
+		}(i)
+	}
+	rebootGroup.Wait()
+
+	// Start the worker kubelet.
+	if stdout, stderr, err := c.Workers[0].SSH("sudo systemctl enable kubelet && sudo systemctl start kubelet"); err != nil {
+		t.Fatalf("unable to start kubelet on worker %q: %v\nstdout: %s\nstderr: %s", c.Workers[0].Name, err, stdout, stderr)
+	}
+
+	// Verify that the checkpoints are running.
+	if err := verifyPod(c, "pod-checkpointer", true); err != nil {
+		t.Fatalf("verifyPod: %s", err)
+	}
+	if err := verifyPod(c, "test-nginx", true); err != nil {
+		t.Fatalf("verifyPod: %s", err)
+	}
+
+	// Start the master kubelets.
+	var enableGroup sync.WaitGroup
+	for i := range c.Masters {
+		enableGroup.Add(1)
+		go func(i int) {
+			defer enableGroup.Done()
+			if stdout, stderr, err := c.Masters[i].SSH("sudo systemctl enable kubelet && sudo systemctl start kubelet"); err != nil {
+				t.Fatalf("unable to start kubelet on master %q: %v\nstdout: %s\nstderr: %s", c.Masters[i].Name, err, stdout, stderr)
+			}
+		}(i)
+	}
+	enableGroup.Wait()
+
+	// Verify that checkpoint is cleaned up and not running, but the pod checkpointer should still be running.
+	if err := verifyPod(c, "test-checkpointer", true); err != nil {
+		t.Fatalf("verifyPod: %s", err)
+	}
+	if err := verifyPod(c, "test-nginx", false); err != nil {
+		t.Fatalf("verifyPod: %s", err)
+	}
+	if err := verifyCheckpoint(c, testNS, "test-checkpointer", true, true); err != nil {
+		t.Fatalf("verifyCheckpoint: %s", err)
+	}
+	if err := verifyCheckpoint(c, testNS, "test-nginx", false, false); err != nil {
+		t.Fatalf("verifyCheckpoint: %s", err)
+	}
+}
+
+func makeNamespace(testName string) string {
+	return strings.ToLower(fmt.Sprintf("%s-%s", namespace, strings.Split(testName, "/")[1]))
+}
+
+func createDaemonSet(namespace string, manifest []byte, c *Cluster) error {
+	obj, _, err := api.Codecs.UniversalDecoder().Decode(manifest, nil, &v1beta1.DaemonSet{})
+	if err != nil {
+		return fmt.Errorf("unable to decode manifest: %v", err)
+	}
+	ds, ok := obj.(*v1beta1.DaemonSet)
+	if !ok {
+		return fmt.Errorf("expected manifest to decode into *api.Daemonset, got %T", ds)
+	}
+	if _, err := client.ExtensionsV1beta1().DaemonSets(namespace).Create(ds); err != nil {
+		return fmt.Errorf("failed to create the checkpoint parent: %v", err)
+	}
+	if err := verifyPod(c, ds.ObjectMeta.Name, true); err != nil {
+		return fmt.Errorf("failed to verifyPod: %s", err)
+	}
+	return nil
+}
 
 func verifyCheckpoint(c *Cluster, namespace, daemonsetName string, shouldExist, shouldBeActive bool) error {
-	checkpointed := func() error {
+	return retry(retryAttempts, retryInterval, func() error {
 		dirs := []string{
 			"/etc/kubernetes/inactive-manifests/",
 			"/etc/kubernetes/checkpoint-secrets/" + namespace,
@@ -71,12 +304,11 @@ func verifyCheckpoint(c *Cluster, namespace, daemonsetName string, shouldExist, 
 		}
 
 		return nil
-	}
-	return retry(60, 10*time.Second, checkpointed)
+	})
 }
 
 func verifyPod(c *Cluster, daemonsetName string, shouldRun bool) error {
-	checkpointsRunning := func() error {
+	return retry(retryAttempts, retryInterval, func() error {
 		stdout, stderr, err := c.Workers[0].SSH("docker ps")
 		if err != nil {
 			return fmt.Errorf("unable to docker ps, error: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
@@ -89,8 +321,7 @@ func verifyPod(c *Cluster, daemonsetName string, shouldRun bool) error {
 			return fmt.Errorf("should not find running checkpoints %q, error: %v, output: %q", daemonsetName, err, stdout)
 		}
 		return nil
-	}
-	return retry(60, 10*time.Second, checkpointsRunning)
+	})
 }
 
 func isNodeReady(n *Node) bool {
@@ -107,7 +338,7 @@ func waitCluster(t *testing.T) *Cluster {
 	var c *Cluster
 	var err error
 
-	f := func() error {
+	if err := retry(retryAttempts, retryInterval, func() error {
 		c, err = GetCluster()
 		if err != nil {
 			t.Fatalf("Failed to get cluster")
@@ -129,293 +360,149 @@ func waitCluster(t *testing.T) *Cluster {
 			}
 		}
 		return nil
-	}
-
-	if err := retry(60, 10*time.Second, f); err != nil {
+	}); err != nil {
 		t.Fatalf("Failed to wait cluster: %v", err)
 	}
 	return c
 }
 
-// waitForCheckpointDeactivation waits for checkpointed pods to be replaced by the
-// apiserver-managed ones.
-// TODO(diegs): do something more scientific, like talking to docker.
-func waitForCheckpointDeactivation(t *testing.T) {
-	t.Log("Waiting 120 seconds for checkpoints to deactivate.")
-	time.Sleep(120 * time.Second)
-	successes := 0
-	if err := retry(60, 3*time.Second, func() error {
-		_, err := client.Discovery().ServerVersion()
-		if err != nil {
-			successes = 0
-			return fmt.Errorf("request failed, starting over: %v", err)
-		}
-		successes++
-		if successes < 5 {
-			return fmt.Errorf("request success %d of %d", successes, 5)
-		}
-		return nil
+func setupTestCheckpointerRole(namespace string) error {
+	// Copy special kubeconfig-in-cluster secret from kube-system namespace.
+	kc, err := client.CoreV1().Secrets(metav1.NamespaceSystem).Get("kubeconfig-in-cluster", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	kc.ObjectMeta = metav1.ObjectMeta{
+		Name:      kc.ObjectMeta.Name,
+		Namespace: namespace,
+	}
+	if _, err := client.CoreV1().Secrets(namespace).Create(kc); err != nil {
+		return err
+	}
+
+	if _, err := client.CoreV1().ServiceAccounts(namespace).Create(&v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-checkpointer",
+			Namespace: namespace,
+		},
 	}); err != nil {
-		t.Fatalf("non-checkpoint apiserver did not come back: %v", err)
+		return err
 	}
+	if _, err := client.RbacV1beta1().Roles(namespace).Create(&rbac.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-checkpointer",
+			Namespace: namespace,
+		},
+		Rules: []rbac.PolicyRule{{
+			APIGroups: []string{""}, // "" indicates the core API group
+			Resources: []string{"pods"},
+			Verbs:     []string{"get", "watch", "list"},
+		}, {
+			APIGroups: []string{""}, // "" indicates the core API group
+			Resources: []string{"secrets", "configmaps"},
+			Verbs:     []string{"get"},
+		}},
+	}); err != nil {
+		return err
+	}
+	if _, err := client.RbacV1beta1().RoleBindings(namespace).Create(&rbac.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-checkpointer",
+			Namespace: namespace,
+		},
+		Subjects: []rbac.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      "test-checkpointer",
+			Namespace: namespace,
+		}},
+		RoleRef: rbac.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "test-checkpointer",
+		},
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
-// 1. Schedule a pod checkpointer on worker node.
-// 2. Schedule a test pod on worker node.
-// 3. Reboot the worker without starting the kubelet.
-// 4. Delete the checkpointer on API server.
-// 5. Reboot the masters without starting the kubelet.
-// 6. Start the worker kubelet, verify the checkpointer and the pod are still running as static pods.
-// 7. Start the master kubelets, verify the checkpointer is removed but the pod is still running.
-func TestCheckpointerUnscheduleCheckpointer(t *testing.T) {
-	// Get the cluster
-	c := waitCluster(t)
+const checkpointerDS = `apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: test-checkpointer
+  labels:
+    app: test-checkpointer
+spec:
+  selector:
+    matchLabels:
+      app: test-checkpointer
+  template:
+    metadata:
+      labels:
+        app: test-checkpointer
+      annotations:
+        checkpointer.alpha.coreos.com/checkpoint: "true"
+    spec:
+      containers:
+      - name: test-checkpointer
+        image: %s
+        command:
+        - /checkpoint
+        - --lock-file=/var/run/lock/test-checkpointer.lock
+        - --kubeconfig=/etc/checkpointer/kubeconfig
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        imagePullPolicy: Always
+        volumeMounts:
+        - mountPath: /etc/checkpointer
+          name: kubeconfig
+        - mountPath: /etc/kubernetes
+          name: etc-kubernetes
+        - mountPath: /var/run
+          name: var-run
+      serviceAccountName: test-checkpointer
+      hostNetwork: true
+      restartPolicy: Always
+      volumes:
+      - name: kubeconfig
+        secret:
+          secretName: kubeconfig-in-cluster
+      - name: etc-kubernetes
+        hostPath:
+          path: /etc/kubernetes
+      - name: var-run
+        hostPath:
+          path: /var/run
+`
 
-	testNS := strings.ToLower(fmt.Sprintf("%s-%s", namespace, t.Name()))
-	if _, err := createNamespace(client, testNS); err != nil {
-		t.Fatalf("Failed to create namespace: %v", err)
-	}
-	defer deleteNamespace(client, testNS)
-
-	// Run the pod checkpointer on worker nodes as well.
-	patch := `[{"op": "replace", "path": "/spec/template/spec/nodeSelector", "value": {}}]`
-	_, err := client.ExtensionsV1beta1().DaemonSets("kube-system").Patch("pod-checkpointer", types.JSONPatchType, []byte(patch))
-	if err != nil {
-		t.Fatalf("Failed to patch checkpointer: %v", err)
-	}
-	if err := verifyPod(c, "pod-checkpointer", true); err != nil {
-		t.Fatalf("Failed to verifyPod: %s", err)
-	}
-
-	// Create test pod.
-	obj, _, err := api.Codecs.UniversalDecoder().Decode(nginxDS, nil, &v1beta1.DaemonSet{})
-	if err != nil {
-		t.Fatalf("Unable to decode manifest: %v", err)
-	}
-	ds, ok := obj.(*v1beta1.DaemonSet)
-	if !ok {
-		t.Fatalf("Expected manifest to decode into *api.Daemonset, got %T", ds)
-	}
-	_, err = client.ExtensionsV1beta1().DaemonSets(testNS).Create(ds)
-	if err != nil {
-		t.Fatalf("Failed to create the checkpoint parent: %v", err)
-	}
-	if err := verifyPod(c, "nginx-daemonset", true); err != nil {
-		t.Fatalf("Failed to verifyPod: %s", err)
-	}
-
-	// Verify the checkpoints are created.
-	if err := verifyCheckpoint(c, "kube-system", "pod-checkpointer", true, true); err != nil {
-		t.Fatalf("Failed to verify checkpoint: %v", err)
-	}
-	if err := verifyCheckpoint(c, testNS, "nginx-daemonset", true, false); err != nil {
-		t.Fatalf("Failed to verify checkpoint: %v", err)
-	}
-
-	// Disable the kubelet and reboot the worker.
-	stdout, stderr, err := c.Workers[0].SSH("sudo systemctl disable kubelet")
-	if err != nil {
-		t.Fatalf("Failed to disable kubelet on worker %q: %v\nstdout: %s\nstderr: %s", c.Workers[0].Name, err, stdout, stderr)
-	}
-	if err := c.Workers[0].Reboot(); err != nil {
-		t.Fatalf("Failed to reboot worker: %v", err)
-	}
-
-	// Delete the pod checkpointer on the worker node by updating the daemonset.
-	patch = `{"spec":{"template":{"spec":{"nodeSelector":{"node-role.kubernetes.io/master":""}}}}}`
-	_, err = client.ExtensionsV1beta1().DaemonSets("kube-system").Patch("pod-checkpointer", types.MergePatchType, []byte(patch))
-	if err != nil {
-		t.Fatalf("Failed to patch checkpointer: %v", err)
-	}
-
-	// Disable the kubelet and reboot the masters.
-	var rebootGroup sync.WaitGroup
-	for i := range c.Masters {
-		rebootGroup.Add(1)
-		go func(i int) {
-			defer rebootGroup.Done()
-			stdout, stderr, err = c.Masters[i].SSH("sudo systemctl disable kubelet")
-			if err != nil {
-				t.Fatalf("Failed to disable kubelet on master %q: %v\nstdout: %s\nstderr: %s", c.Masters[i].Name, err, stdout, stderr)
-			}
-			if err := c.Masters[i].Reboot(); err != nil {
-				t.Fatalf("Failed to reboot master: %v", err)
-			}
-		}(i)
-	}
-	rebootGroup.Wait()
-
-	// Start the worker kubelet.
-	stdout, stderr, err = c.Workers[0].SSH("sudo systemctl enable kubelet && sudo systemctl start kubelet")
-	if err != nil {
-		t.Fatalf("Failed to start kubelet on worker %q: %v\nstdout: %s\nstderr: %s", c.Workers[0].Name, err, stdout, stderr)
-	}
-
-	// Verify that the checkpoints are still running.
-	if err := verifyPod(c, "pod-checkpointer", true); err != nil {
-		t.Fatalf("Failed to verifyPod: %s", err)
-	}
-	if err := verifyPod(c, "nginx-daemonset", true); err != nil {
-		t.Fatalf("Failed to verifyPod: %s", err)
-	}
-
-	// Start the master kubelet.
-	var enableGroup sync.WaitGroup
-	for i := range c.Masters {
-		enableGroup.Add(1)
-		go func(i int) {
-			defer enableGroup.Done()
-			stdout, stderr, err = c.Masters[i].SSH("sudo systemctl enable kubelet && sudo systemctl start kubelet")
-			if err != nil {
-				t.Fatalf("Failed to start kubelet on master %q: %v\nstdout: %s\nstderr: %s", c.Masters[i].Name, err, stdout, stderr)
-			}
-		}(i)
-	}
-	enableGroup.Wait()
-
-	// Verify that the pod-checkpointer is cleaned up but the daemonset is still running.
-	if err := verifyPod(c, "pod-checkpointer", false); err != nil {
-		t.Fatalf("Failed to verifyPod: %s", err)
-	}
-	if err := verifyPod(c, "nginx-daemonset", true); err != nil {
-		t.Fatalf("Failed to verifyPod: %s", err)
-	}
-	if err := verifyCheckpoint(c, "kube-system", "pod-checkpointer", false, false); err != nil {
-		t.Fatalf("Failed to verifyCheckpoint: %s", err)
-	}
-	if err := verifyCheckpoint(c, testNS, "nginx-daemonset", false, false); err != nil {
-		t.Fatalf("Failed to verifyCheckpoint: %s", err)
-	}
-
-	waitForCheckpointDeactivation(t)
-}
-
-// 1. Schedule a pod checkpointer on worker node.
-// 2. Schedule a test pod on worker node.
-// 3. Reboot the worker without starting the kubelet.
-// 4. Delete the test pod on API server.
-// 5. Reboot the masters without starting the kubelet.
-// 6. Start the worker kubelet, verify the checkpointer and the pod are still running as static pods.
-// 7. Start the master kubelets, verify the test pod is removed, but not the checkpointer.
-func TestCheckpointerUnscheduleParent(t *testing.T) {
-	// Get the cluster
-	c := waitCluster(t)
-
-	testNS := strings.ToLower(fmt.Sprintf("%s-%s", namespace, t.Name()))
-	if _, err := createNamespace(client, testNS); err != nil {
-		t.Fatalf("Failed to create namespace: %v", err)
-	}
-	defer deleteNamespace(client, testNS)
-
-	// Run the pod checkpointer on worker nodes as well.
-	patch := `[{"op": "replace", "path": "/spec/template/spec/nodeSelector", "value": {}}]`
-	_, err := client.ExtensionsV1beta1().DaemonSets("kube-system").Patch("pod-checkpointer", types.JSONPatchType, []byte(patch))
-	if err != nil {
-		t.Fatalf("Failed to patch checkpointer: %v", err)
-	}
-	if err := verifyPod(c, "pod-checkpointer", true); err != nil {
-		t.Fatalf("verifyPod: %s", err)
-	}
-
-	// Create test pod.
-	obj, _, err := api.Codecs.UniversalDecoder().Decode(nginxDS, nil, &v1beta1.DaemonSet{})
-	if err != nil {
-		t.Fatalf("Unable to decode manifest: %v", err)
-	}
-	ds, ok := obj.(*v1beta1.DaemonSet)
-	if !ok {
-		t.Fatalf("Expected manifest to decode into *api.Daemonset, got %T", ds)
-	}
-	_, err = client.ExtensionsV1beta1().DaemonSets(testNS).Create(ds)
-	if err != nil {
-		t.Fatalf("Failed to create the checkpoint parent: %v", err)
-	}
-	if err := verifyPod(c, "nginx-daemonset", true); err != nil {
-		t.Fatalf("verifyPod: %s", err)
-	}
-
-	// Verify the checkpoints are created.
-	if err := verifyCheckpoint(c, "kube-system", "pod-checkpointer", true, true); err != nil {
-		t.Fatalf("verifyCheckpoint: %s", err)
-	}
-	if err := verifyCheckpoint(c, testNS, "nginx-daemonset", true, false); err != nil {
-		t.Fatalf("verifyCheckpoint: %s", err)
-	}
-
-	// Disable the kubelet and reboot the worker.
-	stdout, stderr, err := c.Workers[0].SSH("sudo systemctl disable kubelet")
-	if err != nil {
-		t.Fatalf("Failed to disable kubelet on worker %q: %v\nstdout: %s\nstderr: %s", c.Workers[0].Name, err, stdout, stderr)
-	}
-	if err := c.Workers[0].Reboot(); err != nil {
-		t.Fatalf("Failed to reboot worker: %v", err)
-	}
-
-	// Delete test pod on the workers.
-	patch = `{"spec":{"template":{"spec":{"nodeSelector":{"node-role.kubernetes.io/master":""}}}}}`
-	_, err = client.ExtensionsV1beta1().DaemonSets(testNS).Patch("nginx-daemonset", types.MergePatchType, []byte(patch))
-	if err != nil {
-		t.Fatalf("unable to patch daemonset: %v", err)
-	}
-
-	// Disable the kubelet and reboot the masters.
-	var rebootGroup sync.WaitGroup
-	for i := range c.Masters {
-		rebootGroup.Add(1)
-		go func(i int) {
-			defer rebootGroup.Done()
-			stdout, stderr, err = c.Masters[i].SSH("sudo systemctl disable kubelet")
-			if err != nil {
-				t.Fatalf("Failed to disable kubelet on master %q: %v\nstdout: %s\nstderr: %s", c.Masters[i].Name, err, stdout, stderr)
-			}
-			if err := c.Masters[i].Reboot(); err != nil {
-				t.Fatalf("Failed to reboot master: %v", err)
-			}
-		}(i)
-	}
-	rebootGroup.Wait()
-
-	// Start the worker kubelet.
-	stdout, stderr, err = c.Workers[0].SSH("sudo systemctl enable kubelet && sudo systemctl start kubelet")
-	if err != nil {
-		t.Fatalf("unable to start kubelet on worker %q: %v\nstdout: %s\nstderr: %s", c.Workers[0].Name, err, stdout, stderr)
-	}
-
-	// Verify that the checkpoints are running.
-	if err := verifyPod(c, "pod-checkpointer", true); err != nil {
-		t.Fatalf("verifyPod: %s", err)
-	}
-	if err := verifyPod(c, "nginx-daemonset", true); err != nil {
-		t.Fatalf("verifyPod: %s", err)
-	}
-
-	// Start the master kubelets.
-	var enableGroup sync.WaitGroup
-	for i := range c.Masters {
-		enableGroup.Add(1)
-		go func(i int) {
-			defer enableGroup.Done()
-			stdout, stderr, err = c.Masters[i].SSH("sudo systemctl enable kubelet && sudo systemctl start kubelet")
-			if err != nil {
-				t.Fatalf("unable to start kubelet on master %q: %v\nstdout: %s\nstderr: %s", c.Masters[i].Name, err, stdout, stderr)
-			}
-		}(i)
-	}
-	enableGroup.Wait()
-
-	// Verify that checkpoint is cleaned up and not running, but the pod checkpointer should still be running.
-	if err := verifyPod(c, "pod-checkpointer", true); err != nil {
-		t.Fatalf("verifyPod: %s", err)
-	}
-	if err := verifyPod(c, "nginx-daemonset", false); err != nil {
-		t.Fatalf("verifyPod: %s", err)
-	}
-	if err := verifyCheckpoint(c, "kube-system", "pod-checkpointer", true, true); err != nil {
-		t.Fatalf("verifyCheckpoint: %s", err)
-	}
-	if err := verifyCheckpoint(c, testNS, "nginx-daemonset", false, false); err != nil {
-		t.Fatalf("verifyCheckpoint: %s", err)
-	}
-
-	waitForCheckpointDeactivation(t)
-}
+var nginxDS = []byte(`apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: test-nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx-checkpoint-test
+  template:
+    metadata:
+      labels:
+        app: nginx-checkpoint-test
+      annotations:
+        checkpointer.alpha.coreos.com/checkpoint: "true"
+    spec:
+      hostNetwork: true
+      containers:
+        - name: nginx
+          image: nginx
+`)

--- a/e2e/deleteapi_test.go
+++ b/e2e/deleteapi_test.go
@@ -59,6 +59,4 @@ func TestDeleteAPI(t *testing.T) {
 	if err := retry(30, 10*time.Second, waitAPI); err != nil {
 		t.Fatal(err)
 	}
-
-	waitForCheckpointDeactivation(t)
 }

--- a/e2e/reboot_test.go
+++ b/e2e/reboot_test.go
@@ -36,8 +36,6 @@ func TestReboot(t *testing.T) {
 	if err := nodesReady(client, nodeList, t); err != nil {
 		t.Fatalf("some or all nodes did not recover from reboot: %v", err)
 	}
-
-	waitForCheckpointDeactivation(t)
 }
 
 // nodesReady blocks until all nodes in list are ready based on Name. Safe

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	"github.com/coreos/ktestutil/testworkload"
 )
@@ -13,7 +14,7 @@ func TestSmoke(t *testing.T) {
 	}
 	defer nginx.Delete()
 
-	if err := nginx.IsReachable(); err != nil {
+	if err := retry(60, 5*time.Second, nginx.IsReachable); err != nil {
 		t.Errorf("%s is not reachable: %v", nginx.Name, err)
 	}
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 54ffbe6f19acdc20ffc1579a461dc6d8c08b98b3fd5c8ac9b13d1068bd3e6dc2
-updated: 2017-10-17T13:42:25.833130872-07:00
+hash: 646974c81f38fdb9299622dfea3233f62b2485ba5eb8054a816769f9e1c246e9
+updated: 2017-12-06T13:53:37.400943197-06:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -77,7 +77,7 @@ imports:
   - journal
   - util
 - name: github.com/coreos/ktestutil
-  version: e715fca7103c954b24fa636de412ac043efe6c49
+  version: b8e4e68fe1c1c47b132cf007deb8dd620431948a
   subpackages:
   - log-collector
   - log-collector/pkg/fluentd

--- a/glide.yaml
+++ b/glide.yaml
@@ -47,7 +47,7 @@ import:
   - ssh/agent
   - curve25519
 - package: github.com/coreos/ktestutil
-  version: e715fca7103c954b24fa636de412ac043efe6c49
+  version: b8e4e68fe1c1c47b132cf007deb8dd620431948a
 - package: github.com/pkg/sftp
   version: 98203f5a8333288eb3163b7c667d4260fe1333e9
 - package: k8s.io/metrics
@@ -58,4 +58,6 @@ import:
   - pkg/client/clientset_generated/clientset
   - pkg/client/clientset_generated/clientset/scheme
   - pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1
+- package: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -13,5 +13,5 @@ var DefaultImages = ImageVersions{
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5",
 	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5",
 	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5",
-	PodCheckpointer: "quay.io/coreos/pod-checkpointer:e22cc0e3714378de92f45326474874eb602ca0ac",
+	PodCheckpointer: "quay.io/coreos/pod-checkpointer:08fa021813231323e121ecca7383cc64c4afe888",
 }

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -332,13 +332,11 @@ metadata:
   name: pod-checkpointer
 `)
 
-// TODO: Drop checkpointer RBAC resources to a Role and RoleBinding if
-// the checkpoint switches to only watching kube-system.
-
 var CheckpointerRole = []byte(`apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: pod-checkpointer
+  namespace: kube-system
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
@@ -349,12 +347,13 @@ rules:
 `)
 
 var CheckpointerRoleBinding = []byte(`apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: pod-checkpointer
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: pod-checkpointer
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
Instead of extending the existing checkpointer daemonset to run on
worker nodes, start a new checkpointer daemonset instead. This makes
sure that the existing checkpointer (on the apiserver) is not disturbed.

Furthermore, this allows the checkpointer tests to work with the new
checkpointer that is only allowed to look at its own namespace.