### PR TITLE
apiserver: run as non-root user.

### DIFF
--- a/Documentation/network-requirements.md
+++ b/Documentation/network-requirements.md
@@ -8,7 +8,7 @@ The information below describes a minimum set of port allocations used by Kubern
 
 | Protocol | Port Range | Source                                    | Purpose                |
 -----------|------------|-------------------------------------------|------------------------|
-| TCP      | 443        | Worker Nodes, API Requests, and End-Users | Kubernetes API server. |
+| TCP      | 6443       | Worker Nodes, API Requests, and End-Users | Kubernetes API server. |
 | UDP      | 8472       | Master & Worker Nodes                     | flannel overlay network - *vxlan backend* |
 
 ### etcd node(s) ingress

--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -65,7 +65,7 @@ func init() {
 	cmdRender.Flags().StringVar(&renderOpts.etcdCertificatePath, "etcd-certificate-path", "", "Path to an existing certificate that will be used for TLS-enabled communication between the apiserver and etcd. Must be used in conjunction with --etcd-ca-path and --etcd-private-key-path, and must have etcd configured to use TLS with matching secrets.")
 	cmdRender.Flags().StringVar(&renderOpts.etcdPrivateKeyPath, "etcd-private-key-path", "", "Path to an existing private key that will be used for TLS-enabled communication between the apiserver and etcd. Must be used in conjunction with --etcd-ca-path and --etcd-certificate-path, and must have etcd configured to use TLS with matching secrets.")
 	cmdRender.Flags().StringVar(&renderOpts.etcdServers, "etcd-servers", defaultEtcdServers, "List of etcd servers URLs including host:port, comma separated")
-	cmdRender.Flags().StringVar(&renderOpts.apiServers, "api-servers", "https://127.0.0.1:443", "List of API server URLs including host:port, commma seprated")
+	cmdRender.Flags().StringVar(&renderOpts.apiServers, "api-servers", "https://127.0.0.1:6443", "List of API server URLs including host:port, commma seprated")
 	cmdRender.Flags().StringVar(&renderOpts.altNames, "api-server-alt-names", "", "List of SANs to use in api-server certificate. Example: 'IP=127.0.0.1,IP=127.0.0.2,DNS=localhost'. If empty, SANs will be extracted from the --api-servers flag.")
 	cmdRender.Flags().StringVar(&renderOpts.podCIDR, "pod-cidr", "10.2.0.0/16", "The CIDR range of cluster pods.")
 	cmdRender.Flags().StringVar(&renderOpts.serviceCIDR, "service-cidr", "10.3.0.0/24", "The CIDR range of cluster services.")

--- a/e2e/checkpointer_test.go
+++ b/e2e/checkpointer_test.go
@@ -448,6 +448,7 @@ spec:
         image: %s
         command:
         - /checkpoint
+        - --checkpoint-grace-period=5s
         - --lock-file=/var/run/lock/test-checkpointer.lock
         - --kubeconfig=/etc/checkpointer/kubeconfig
         env:

--- a/hack/multi-node/bootkube-up
+++ b/hack/multi-node/bootkube-up
@@ -28,7 +28,7 @@ fi
 
 # Render assets
 if [ ! -d "cluster" ]; then
-  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.101:443 ${etcd_render_flags} ${cnp_render_flags}
+  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.101:6443 ${etcd_render_flags} ${cnp_render_flags}
   cp user-data.sample cluster/user-data-worker
   cp user-data.sample cluster/user-data-controller
   sed -i -e '/node-role.kubernetes.io\/master/d' cluster/user-data-worker

--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -69,7 +69,7 @@ function init_master_node() {
 
     # Render cluster assets
     /home/${REMOTE_USER}/bootkube render --asset-dir=/home/${REMOTE_USER}/assets ${etcd_render_flags} ${network_provider_flags} \
-      --api-servers=https://${COREOS_PUBLIC_IPV4}:443,https://${COREOS_PRIVATE_IPV4}:443
+      --api-servers=https://${COREOS_PUBLIC_IPV4}:6443,https://${COREOS_PRIVATE_IPV4}:6443
 
     # Move the local kubeconfig into expected location
     chown -R ${REMOTE_USER}:${REMOTE_USER} /home/${REMOTE_USER}/assets

--- a/hack/quickstart/quickstart-aws.md
+++ b/hack/quickstart/quickstart-aws.md
@@ -21,7 +21,7 @@ Next, create the security group rules.
 
 ```
 $ aws ec2 authorize-security-group-ingress --region us-west-2 --group-name ${CLUSTER_PREFIX}-sg --protocol tcp --port 22 --cidr 0.0.0.0/0
-$ aws ec2 authorize-security-group-ingress --region us-west-2 --group-name ${CLUSTER_PREFIX}-sg --protocol tcp --port 443 --cidr 0.0.0.0/0
+$ aws ec2 authorize-security-group-ingress --region us-west-2 --group-name ${CLUSTER_PREFIX}-sg --protocol tcp --port 6443 --cidr 0.0.0.0/0
 $ aws ec2 authorize-security-group-ingress --region us-west-2 --group-name ${CLUSTER_PREFIX}-sg --protocol tcp --port 0-65535 --source-group ${CLUSTER_PREFIX}-sg
 ```
 

--- a/hack/quickstart/quickstart-gce.md
+++ b/hack/quickstart/quickstart-gce.md
@@ -16,11 +16,11 @@ Launch nodes:
 gcloud compute instances create ${CLUSTER_PREFIX}-core1 --image-project coreos-cloud --image-family coreos-stable --zone us-central1-a --machine-type n1-standard-1
 ```
 
-Tag the first node as an apiserver node, and allow traffic to 443 on that node.
+Tag the first node as an apiserver node, and allow traffic to 6443 on that node.
 
 ```
 gcloud compute instances add-tags ${CLUSTER_PREFIX}-core1 --tags ${CLUSTER_PREFIX}-apiserver --zone us-central1-a
-gcloud compute firewall-rules create ${CLUSTER_PREFIX}-443 --target-tags=${CLUSTER_PREFIX}-apiserver --allow tcp:443
+gcloud compute firewall-rules create ${CLUSTER_PREFIX}-6443 --target-tags=${CLUSTER_PREFIX}-apiserver --allow tcp:6443
 ```
 
 ### Bootstrap Master

--- a/hack/single-node/bootkube-up
+++ b/hack/single-node/bootkube-up
@@ -27,7 +27,7 @@ fi
 
 # Render assets
 if [ ! -d "cluster" ]; then
-  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.100:443 ${etcd_render_flags} ${cnp_render_flags}
+  ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.100:6443 ${etcd_render_flags} ${cnp_render_flags}
   cp user-data.sample cluster/user-data
 	if [ ${SELF_HOST_ETCD} = "false" ]; then
 		cat user-data-etcd.sample >> cluster/user-data

--- a/hack/tests/conformance-gce.sh
+++ b/hack/tests/conformance-gce.sh
@@ -35,7 +35,7 @@ GCE_PROJECT=${GCE_PROJECT:-coreos-gce-testing}
 
 function cleanup {
     gcloud compute instances delete --quiet --zone us-central1-a ${GCE_PREFIX}-m1 || true
-    gcloud compute firewall-rules delete --quiet ${GCE_PREFIX}-api-443 || true
+    gcloud compute firewall-rules delete --quiet ${GCE_PREFIX}-api-6443 || true
     for i in $(seq 1 ${WORKER_COUNT}); do
         gcloud compute instances delete --quiet --zone us-central1-a ${GCE_PREFIX}-w${i} || true
     done
@@ -60,7 +60,7 @@ function add_master {
         --image-project coreos-cloud --image-family ${COREOS_CHANNEL} --zone us-central1-a --machine-type n1-standard-4 --boot-disk-size=30GB
 
     gcloud compute instances add-tags --zone us-central1-a ${GCE_PREFIX}-m1 --tags ${GCE_PREFIX}-apiserver
-    gcloud compute firewall-rules create ${GCE_PREFIX}-api-443 --target-tags=${GCE_PREFIX}-apiserver --allow tcp:443
+    gcloud compute firewall-rules create ${GCE_PREFIX}-api-6443 --target-tags=${GCE_PREFIX}-apiserver --allow tcp:6443
 
     gcloud compute instances add-metadata ${GCE_PREFIX}-m1 --zone us-central1-a --metadata-from-file ssh-keys=/root/.ssh/gce-format.pub
 

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -13,5 +13,5 @@ var DefaultImages = ImageVersions{
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5",
 	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5",
 	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5",
-	PodCheckpointer: "quay.io/coreos/pod-checkpointer:08fa021813231323e121ecca7383cc64c4afe888",
+	PodCheckpointer: "quay.io/coreos/pod-checkpointer:3cd08279c564e95c8b42a0b97c073522d4a6b965",
 }

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -97,9 +97,6 @@ spec:
         - mountPath: /etc/kubernetes/secrets
           name: secrets
           readOnly: true
-        - mountPath: /var/lock
-          name: var-lock
-          readOnly: false
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -114,9 +111,9 @@ spec:
       - name: secrets
         secret:
           secretName: kube-apiserver
-      - name: var-lock
-        hostPath:
-          path: /var/lock
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -171,9 +168,6 @@ spec:
     - mountPath: /etc/kubernetes/secrets
       name: secrets
       readOnly: true
-    - mountPath: /var/lock
-      name: var-lock
-      readOnly: false
   hostNetwork: true
   volumes:
   - name: secrets
@@ -182,9 +176,6 @@ spec:
   - name: ssl-certs-host
     hostPath:
       path: /usr/share/ca-certificates
-  - name: var-lock
-    hostPath:
-      path: /var/lock
 `)
 
 var KencTemplate = []byte(`apiVersion: apps/v1beta2
@@ -1332,7 +1323,7 @@ spec:
               name: var-run-calico
               readOnly: false
         - name: install-cni
-          image: {{ .Images.CalicoCNI }} 
+          image: {{ .Images.CalicoCNI }}
           command: ["/install-cni.sh"]
           env:
             - name: CNI_CONF_NAME

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -445,7 +445,6 @@ spec:
       dnsPolicy: Default # Don't use cluster DNS.
 `)
 
-
 var ControllerManagerServiceAccount = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/recovery/recover_test.go
+++ b/pkg/recovery/recover_test.go
@@ -41,7 +41,7 @@ var (
 							Containers: []v1.Container{{
 								Name:    "kube-apiserver",
 								Image:   "quay.io/coreos/hyperkube:v1.6.4_coreos.0",
-								Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
+								Command: []string{"/hyperkube", "apiserver", "--secure-port=6443"},
 								VolumeMounts: []v1.VolumeMount{{
 									Name:      "ssl-certs-host",
 									MountPath: "/etc/ssl/certs",
@@ -114,7 +114,7 @@ func TestExtractBootstrapPods(t *testing.T) {
 			Containers: []v1.Container{{
 				Name:    "kube-apiserver",
 				Image:   "quay.io/coreos/hyperkube:v1.6.4_coreos.0",
-				Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
+				Command: []string{"/hyperkube", "apiserver", "--secure-port=6443"},
 				VolumeMounts: []v1.VolumeMount{{
 					Name:      "ssl-certs-host",
 					MountPath: "/etc/ssl/certs",
@@ -171,7 +171,7 @@ func TestFixUpBootstrapPods(t *testing.T) {
 			Containers: []v1.Container{{
 				Name:    "kube-apiserver",
 				Image:   "quay.io/coreos/hyperkube:v1.6.4_coreos.0",
-				Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
+				Command: []string{"/hyperkube", "apiserver", "--secure-port=6443"},
 				VolumeMounts: []v1.VolumeMount{{
 					Name:      "ssl-certs-host",
 					MountPath: "/etc/ssl/certs",
@@ -228,7 +228,7 @@ func TestFixUpBootstrapPods(t *testing.T) {
 			Containers: []v1.Container{{
 				Name:    "kube-apiserver",
 				Image:   "quay.io/coreos/hyperkube:v1.6.4_coreos.0",
-				Command: []string{"/usr/bin/flock", "/hyperkube", "apiserver", "--secure-port=443"},
+				Command: []string{"/hyperkube", "apiserver", "--secure-port=6443"},
 				VolumeMounts: []v1.VolumeMount{{
 					Name:      "ssl-certs-host",
 					MountPath: "/etc/ssl/certs",


### PR DESCRIPTION
Changes the apiserver defaults to listen on port 6443 and use a non-root
user. The port matches the upstream default and reflects best practices.

Production users can put the apiserver behind a load-balancer to forward
443 to 6443.