### PR TITLE
hack: restore multi-node.

### DIFF
--- a/hack/multi-node/bootkube-up
+++ b/hack/multi-node/bootkube-up
@@ -31,7 +31,7 @@ if [ ! -d "cluster" ]; then
   ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.101:443 ${etcd_render_flags} ${cnp_render_flags}
   cp user-data.sample cluster/user-data-worker
   cp user-data.sample cluster/user-data-controller
-  sed -i.bak -e '/node-role.kubernetes.io\/master/d' cluster/user-data-worker
+  sed -i -e '/node-role.kubernetes.io\/master/d' cluster/user-data-worker
 fi
 
 # Start the VM

--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -39,7 +39,8 @@ coreos:
           --network-plugin=cni \
           --node-labels=node-role.kubernetes.io/master \
           --pod-manifest-path=/etc/kubernetes/manifests \
-          --register-with-taints=node-role.kubernetes.io/master=:NoSchedule
+          --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+          # do not delete this comment: the line above is deleted for workers.
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=5


### PR DESCRIPTION
The multi-node worker kubelet wrapper was broken by
929e04f2316876b2fc0f67ccd771dd067dbf1083. This fixes it.