### PR TITLE
Make kubecofig-in-cluster use certificate provided by apiserver

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -699,7 +699,7 @@ stringData:
     - name: local
       cluster:
         server: {{ .Server }}
-        certificate-authority-data: {{ .CACert }}
+        certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     users:
     - name: service-account
       user:


### PR DESCRIPTION
Make it tiny bit cert rotation friendlier