### PR TITLE
Pass ServiceCIDR to controller-manager

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -407,6 +407,7 @@ spec:
         - --allocate-node-cidrs=true
         - --cloud-provider={{ .CloudProvider }}
         - --cluster-cidr={{ .PodCIDR }}
+        - --service-cluster-ip-range={{ .ServiceCIDR }}
         - --configure-cloud-routes=false
         - --leader-elect=true
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
@@ -457,6 +458,7 @@ spec:
     - controller-manager
     - --allocate-node-cidrs=true
     - --cluster-cidr={{ .PodCIDR }}
+    - --service-cluster-ip-range={{ .ServiceCIDR }}
     - --cloud-provider={{ .CloudProvider }}
     - --configure-cloud-routes=false
     - --kubeconfig=/etc/kubernetes/kubeconfig


### PR DESCRIPTION
In theory PodCIDR and ServiceCIDR can overlap, letting controller-manager
know service cidr allows it to behave correctly in that case