### PR TITLE
quickstart/kubelet.worker: remove deprecated flag

### DIFF
--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -28,8 +28,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --lock-file=/var/run/lock/kubelet.lock \
   --minimum-container-ttl-duration=3m0s \
   --network-plugin=cni \
-  --pod-manifest-path=/etc/kubernetes/manifests \
-  --require-kubeconfig
+  --pod-manifest-path=/etc/kubernetes/manifests
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
 Restart=always
 RestartSec=5


### PR DESCRIPTION
This was forgotten in 929e04f2316876b2fc0f67ccd771dd067dbf1083