### PR TITLE
hack/quickstart: enable setting kubelet cloud provider separately from controller manager

### DIFF
--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -9,6 +9,7 @@ IDENT=${IDENT:-${HOME}/.ssh/id_rsa}
 SSH_OPTS=${SSH_OPTS:-}
 SELF_HOST_ETCD=${SELF_HOST_ETCD:-false}
 CLOUD_PROVIDER=${CLOUD_PROVIDER:-}
+CLOUD_PROVIDER_KUBELET=${CLOUD_PROVIDER_KUBELET:-${CLOUD_PROVIDER}}
 NETWORK_PROVIDER=${NETWORK_PROVIDER:-flannel}
 
 function usage() {
@@ -85,7 +86,7 @@ function init_master_node() {
     fi
 
     # Set cloud provider
-    sed -i "s/cloud-provider=/cloud-provider=$CLOUD_PROVIDER/" /etc/systemd/system/kubelet.service
+    sed -i "s/cloud-provider=/cloud-provider=$CLOUD_PROVIDER_KUBELET/" /etc/systemd/system/kubelet.service
 
     # Start the kubelet
     systemctl enable kubelet; sudo systemctl start kubelet
@@ -123,7 +124,7 @@ if [ "${REMOTE_HOST}" != "local" ]; then
     fi
     # Copy self to remote host so script can be executed in "local" mode
     scp -i ${IDENT} -P ${REMOTE_PORT} ${SSH_OPTS} ${BASH_SOURCE[0]} ${REMOTE_USER}@${REMOTE_HOST}:/home/${REMOTE_USER}/init-master.sh
-    ssh -i ${IDENT} -p ${REMOTE_PORT} ${SSH_OPTS} ${REMOTE_USER}@${REMOTE_HOST} "sudo REMOTE_USER=${REMOTE_USER} CLOUD_PROVIDER=${CLOUD_PROVIDER} SELF_HOST_ETCD=${SELF_HOST_ETCD} NETWORK_PROVIDER=${NETWORK_PROVIDER} /home/${REMOTE_USER}/init-master.sh local"
+    ssh -i ${IDENT} -p ${REMOTE_PORT} ${SSH_OPTS} ${REMOTE_USER}@${REMOTE_HOST} "sudo REMOTE_USER=${REMOTE_USER} CLOUD_PROVIDER=${CLOUD_PROVIDER} CLOUD_PROVIDER_KUBELET=${CLOUD_PROVIDER_KUBELET} SELF_HOST_ETCD=${SELF_HOST_ETCD} NETWORK_PROVIDER=${NETWORK_PROVIDER} /home/${REMOTE_USER}/init-master.sh local"
 
     # Copy assets from remote host to a local directory. These can be used to launch additional nodes & contain TLS assets
     mkdir ${CLUSTER_DIR}


### PR DESCRIPTION
Running a cloud-controller-manager require kubelet to be started
with `--cloud-provider=external` and `kube-apiserver` and
`kube-controller-manager` without the `--cloud-provider` flag or a
empty string [1].
This commit make it possible to specific `--cloud-provider` for
`kubelet` without specifying a cloud-provider for `kube-apiserver`
and `kube-controller-manager` with the new env option
CLOUD_PROVIDER_KUBELET, the option use CLOUD_PROVIDER as fallback
if not set.

[1] https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager

---

Not tested yet.


As this is the future, I think it make sense to add a extra option.