### PR TITLE
vendor: bump ktestutil for timestamp fix

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 646974c81f38fdb9299622dfea3233f62b2485ba5eb8054a816769f9e1c246e9
-updated: 2017-12-06T13:53:37.400943197-06:00
+hash: 8101910d30b14ec13e4e48613c0937623d4fad6ae6f4ae9eb6a968bfdb6d12ed
+updated: 2017-12-13T15:51:15.75522624-06:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -77,7 +77,7 @@ imports:
   - journal
   - util
 - name: github.com/coreos/ktestutil
-  version: b8e4e68fe1c1c47b132cf007deb8dd620431948a
+  version: 47edf51e9cdb1955e93e56e6c84ed944fdda4789
   subpackages:
   - log-collector
   - log-collector/pkg/fluentd

--- a/glide.yaml
+++ b/glide.yaml
@@ -47,7 +47,7 @@ import:
   - ssh/agent
   - curve25519
 - package: github.com/coreos/ktestutil
-  version: b8e4e68fe1c1c47b132cf007deb8dd620431948a
+  version: 47edf51e9cdb1955e93e56e6c84ed944fdda4789
 - package: github.com/pkg/sftp
   version: 98203f5a8333288eb3163b7c667d4260fe1333e9
 - package: k8s.io/metrics

--- a/vendor/github.com/coreos/ktestutil/log-collector/pkg/fluentd/master.go
+++ b/vendor/github.com/coreos/ktestutil/log-collector/pkg/fluentd/master.go
@@ -113,6 +113,7 @@ data:
         time_slice_format %Y%m%d
         path /var/log/log-collector/container.${tag_parts[1]}.${tag_parts[0]}.*.log
         format json
+        include_time_key true
         append true
         flush_interval 10s
         flush_at_shutdown true
@@ -127,6 +128,7 @@ data:
         time_slice_format %Y%m%d
         path /var/log/log-collector/service.${tag_parts[1]}.${tag_parts[0]}.*.log
         format json
+        include_time_key true
         append true    
         flush_interval 10s
         flush_at_shutdown true

--- a/vendor/github.com/coreos/ktestutil/log-collector/pkg/fluentd/workers.go
+++ b/vendor/github.com/coreos/ktestutil/log-collector/pkg/fluentd/workers.go
@@ -91,6 +91,7 @@ data:
       path /var/log/containers/*.log
       pos_file /var/log/fluentd-containers.log.pos
       time_format %Y-%m-%dT%H:%M:%S.%NZ
+      keep_time_key true
       tag reform.*
       format json
       read_from_head true
@@ -110,6 +111,13 @@ data:
       enable_ruby true
       tag "raw.kubernetes.${tag_suffix[4].split('-')[0..-2].join('-')}.#{Socket.gethostname}"
     </match>
+
+    <filter>
+      @type record_transformer
+      <record>
+        hostname ${hostname}
+      </record>
+    </filter>
 
     <match raw.kubernetes.**>
       @type copy


### PR DESCRIPTION
bumps ktestutil to pull in the fluentd fixes for timestamps and hostnames.