### PR TITLE
checkpointer: make grace period a flag.

### DIFF
--- a/cmd/checkpoint/main.go
+++ b/cmd/checkpoint/main.go
@@ -20,6 +20,7 @@ const (
 
 	defaultRuntimeEndpoint       = "unix:///var/run/dockershim.sock"
 	defaultRuntimeRequestTimeout = 2 * time.Minute
+	defaultCheckpointGracePeriod = 1 * time.Minute
 )
 
 var (
@@ -27,6 +28,7 @@ var (
 	kubeconfigPath        string
 	remoteRuntimeEndpoint string
 	runtimeRequestTimeout time.Duration
+	checkpointGracePeriod time.Duration
 )
 
 func init() {
@@ -35,6 +37,7 @@ func init() {
 	flag.Set("logtostderr", "true")
 	flag.StringVar(&remoteRuntimeEndpoint, "container-runtime-endpoint", defaultRuntimeEndpoint, "[Experimental] The endpoint of remote runtime service. Currently unix socket is supported on Linux, and tcp is supported on windows.  Examples:'unix:///var/run/dockershim.sock', 'tcp://localhost:3735'")
 	flag.DurationVar(&runtimeRequestTimeout, "runtime-request-timeout", defaultRuntimeRequestTimeout, "Timeout of all runtime requests except long running request - pull, logs, exec and attach. When timeout exceeded, kubelet will cancel the request, throw out an error and retry later.")
+	flag.DurationVar(&checkpointGracePeriod, "checkpoint-grace-period", defaultCheckpointGracePeriod, "Grace period for cleaning up checkpoints when the parent pod is deleted. Non-zero values are helpful for accommodating control plane eventual consistency.")
 }
 
 func main() {
@@ -69,6 +72,7 @@ func main() {
 		KubeConfig:            kubeConfig,
 		RemoteRuntimeEndpoint: remoteRuntimeEndpoint,
 		RuntimeRequestTimeout: runtimeRequestTimeout,
+		CheckpointGracePeriod: checkpointGracePeriod,
 	}); err != nil {
 		glog.Fatalf("Error starting checkpointer: %v", err)
 	}

--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -25,14 +25,13 @@ const (
 	shouldCheckpoint = "true"
 	podSourceFile    = "file"
 
-	defaultPollingFrequency      = 5 * time.Second
-	defaultCheckpointTimeout     = 1 * time.Minute
-	defaultCheckpointGracePeriod = 1 * time.Minute
+	defaultPollingFrequency  = 5 * time.Second
+	defaultCheckpointTimeout = 1 * time.Minute
 )
 
 var (
 	lastCheckpoint        time.Time
-	checkpointGracePeriod = defaultCheckpointGracePeriod
+	checkpointGracePeriod time.Duration
 )
 
 // Options defines the parameters that are required to start the checkpointer.
@@ -45,6 +44,9 @@ type Options struct {
 	RemoteRuntimeEndpoint string
 	// RuntimeRequestTimeout is the timeout that is used for requests to the RemoteRuntimeEndpoint.
 	RuntimeRequestTimeout time.Duration
+	// CheckpointGracePeriod is the timeout that is used for cleaning up checkpoints when the parent
+	// pod is deleted.
+	CheckpointGracePeriod time.Duration
 }
 
 // CheckpointerPod holds information about this checkpointer pod.
@@ -81,6 +83,8 @@ func Run(opts Options) error {
 	if err != nil {
 		return fmt.Errorf("failed to connect to CRI server: %v", err)
 	}
+
+	checkpointGracePeriod = opts.CheckpointGracePeriod
 
 	cp := &checkpointer{
 		apiserver:       apiserver,

--- a/pkg/checkpoint/state_test.go
+++ b/pkg/checkpoint/state_test.go
@@ -11,6 +11,8 @@ var (
 )
 
 func init() {
+	checkpointGracePeriod = time.Second
+
 	bools := []bool{true, false}
 	for _, apiAvailable := range bools {
 		for _, apiParent := range bools {


### PR DESCRIPTION
This allows users to configure the checkpoint removal grace period
parameter as a flag. This may be useful for tests, among other things.