### PR TITLE
checkpointer: write secrets and configmaps with uid.

### DIFF
--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -27,6 +27,9 @@ const (
 
 	defaultPollingFrequency  = 5 * time.Second
 	defaultCheckpointTimeout = 1 * time.Minute
+
+	rootUID = 0
+	rootGID = 0
 )
 
 var (

--- a/pkg/checkpoint/config_map.go
+++ b/pkg/checkpoint/config_map.go
@@ -12,13 +12,18 @@ import (
 
 // checkpointConfigMapVolumes ensures that all pod configMaps are checkpointed locally, then converts the configMap volume to a hostpath.
 func (c *checkpointer) checkpointConfigMapVolumes(pod *v1.Pod) (*v1.Pod, error) {
+	uid, gid, err := podUserAndGroup(pod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to checkpoint configMap for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+	}
+
 	for i := range pod.Spec.Volumes {
 		v := &pod.Spec.Volumes[i]
 		if v.ConfigMap == nil {
 			continue
 		}
 
-		_, err := c.checkpointConfigMap(pod.Namespace, pod.Name, v.ConfigMap.Name)
+		_, err := c.checkpointConfigMap(pod.Namespace, pod.Name, v.ConfigMap.Name, uid, gid)
 		if err != nil {
 			return nil, fmt.Errorf("failed to checkpoint configMap for pod %s/%s: %v", pod.Namespace, pod.Name, err)
 		}
@@ -29,7 +34,7 @@ func (c *checkpointer) checkpointConfigMapVolumes(pod *v1.Pod) (*v1.Pod, error) 
 // checkpointConfigMap will locally store configMap data.
 // The path to the configMap data becomes: checkpointConfigMapPath/namespace/podname/configMapName/configMap.file
 // Where each "configMap.file" is a key from the configMap.Data field.
-func (c *checkpointer) checkpointConfigMap(namespace, podName, configMapName string) (string, error) {
+func (c *checkpointer) checkpointConfigMap(namespace, podName, configMapName string, uid, gid int) (string, error) {
 	configMap, err := c.apiserver.Core().ConfigMaps(namespace).Get(configMapName, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve configMap %s/%s: %v", namespace, configMapName, err)
@@ -39,9 +44,13 @@ func (c *checkpointer) checkpointConfigMap(namespace, podName, configMapName str
 	if err := os.MkdirAll(basePath, 0700); err != nil {
 		return "", fmt.Errorf("failed to create configMap checkpoint path %s: %v", basePath, err)
 	}
+	if err := os.Chown(basePath, uid, gid); err != nil {
+		return "", fmt.Errorf("failed to chown configMap checkpoint path %s: %v", basePath, err)
+	}
+
 	// TODO(aaron): No need to store if already exists
 	for f, d := range configMap.Data {
-		if err := writeAndAtomicRename(filepath.Join(basePath, f), []byte(d), 0600); err != nil {
+		if err := writeAndAtomicRename(filepath.Join(basePath, f), []byte(d), uid, gid, 0600); err != nil {
 			return "", fmt.Errorf("failed to write configMap %s: %v", configMap.Name, err)
 		}
 	}


### PR DESCRIPTION
This reads the uid from the security context and uses it when
checkpointing secrets and configmaps.

If there is a conflict between containers or the outer pod security it
returns an error for now. In the future we could make multiple copies,
one with each uid.