### PR TITLE
pkg/asset: Update Calico from v2.6.3 to v2.6.4

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -6,7 +6,7 @@ var DefaultImages = ImageVersions{
 	EtcdOperator:    "quay.io/coreos/etcd-operator:v0.5.0",
 	Flannel:         "quay.io/coreos/flannel:v0.9.1-amd64",
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
-	Calico:          "quay.io/calico/node:v2.6.3",
+	Calico:          "quay.io/calico/node:v2.6.4",
 	CalicoCNI:       "quay.io/calico/cni:v1.11.1",
 	Hyperkube:       "gcr.io/google_containers/hyperkube:v1.8.5",
 	Kenc:            "quay.io/coreos/kenc:0.0.2",


### PR DESCRIPTION
Calico v2.6.4 contains some bug fixes and a new compatability option `CNI_OLD_CONFIG_NAME` we've been wanting to allow migrations between CNI configs. It basically just means the sidecar can cleanup an old CNI config file on hosts if that variable is set (calico is a damonset). The sidecar already lays down a new CNI config on each host as part of startup. This allows migrations and unblocks #711

https://github.com/projectcalico/calico/releases/tag/v2.6.4