### PR TITLE
pkg/asset: Update calico/cni to v1.11.2

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -7,7 +7,7 @@ var DefaultImages = ImageVersions{
 	Flannel:         "quay.io/coreos/flannel:v0.9.1-amd64",
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
 	Calico:          "quay.io/calico/node:v2.6.4",
-	CalicoCNI:       "quay.io/calico/cni:v1.11.1",
+	CalicoCNI:       "quay.io/calico/cni:v1.11.2",
 	Hyperkube:       "gcr.io/google_containers/hyperkube:v1.8.5",
 	Kenc:            "quay.io/coreos/kenc:0.0.2",
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5",


### PR DESCRIPTION
Meant to include this with #818, we bump the calico and sidecar image together.