### PR TITLE
checkpointer: bump default checkpointer version.

### DIFF
--- a/e2e/checkpointer_test.go
+++ b/e2e/checkpointer_test.go
@@ -448,6 +448,7 @@ spec:
         image: %s
         command:
         - /checkpoint
+        - --checkpoint-grace-period=5s
         - --lock-file=/var/run/lock/test-checkpointer.lock
         - --kubeconfig=/etc/checkpointer/kubeconfig
         env:

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -13,5 +13,5 @@ var DefaultImages = ImageVersions{
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5",
 	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5",
 	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5",
-	PodCheckpointer: "quay.io/coreos/pod-checkpointer:08fa021813231323e121ecca7383cc64c4afe888",
+	PodCheckpointer: "quay.io/coreos/pod-checkpointer:3cd08279c564e95c8b42a0b97c073522d4a6b965",
 }

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -445,7 +445,6 @@ spec:
       dnsPolicy: Default # Don't use cluster DNS.
 `)
 
-
 var ControllerManagerServiceAccount = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Also use new flag (in this checkpointer version) to vastly shorten the
grace period in the checkpoint tests.