### PR TITLE
Update kube-dns and switch sidecar to probe SRV records

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -9,8 +9,8 @@ var DefaultImages = ImageVersions{
 	Calico:          "quay.io/calico/node:v2.6.6",
 	CalicoCNI:       "quay.io/calico/cni:v1.11.2",
 	Hyperkube:       "gcr.io/google_containers/hyperkube:v1.9.2",
-	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5",
-	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5",
-	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5",
+	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.8",
+	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8",
+	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8",
 	PodCheckpointer: "quay.io/coreos/pod-checkpointer:3cd08279c564e95c8b42a0b97c073522d4a6b965",
 }

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -898,8 +898,8 @@ spec:
         args:
         - --v=2
         - --logtostderr
-        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,A
-        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,A
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,SRV
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,SRV
         ports:
         - containerPort: 10054
           name: metrics


### PR DESCRIPTION
* Update kube-dns from v1.14.5 to v1.14.8
* Switch kube-dns sidecar to probe for SRV records (recommended for 1.9)
  * https://github.com/kubernetes/kubernetes/pull/51378