### PR TITLE
hack: rearrange log messages, use correct kubeconfig

### DIFF
--- a/hack/quickstart/init-node.sh
+++ b/hack/quickstart/init-node.sh
@@ -59,9 +59,7 @@ if [ "${REMOTE_HOST}" != "local" ]; then
     ssh -i ${IDENT} -p ${REMOTE_PORT} ${SSH_OPTS} ${REMOTE_USER}@${REMOTE_HOST} "rm /home/${REMOTE_USER}/{init-node.sh,kubeconfig}"
 
     echo
-    echo "Node bootstrap complete. It may take a few minutes for the node to become ready. Access your kubernetes cluster using:"
-    echo "kubectl --kubeconfig=${KUBECONFIG} get nodes"
-    echo
+    echo "Node (${REMOTE_HOST}) bootstrap complete. It may take a few minutes for the node to become ready."
 
 # Execute this script locally on the machine, assumes a kubelet.service file has already been placed on host.
 elif [ "$1" == "local" ]; then

--- a/hack/terraform-quickstart/start-cluster.sh
+++ b/hack/terraform-quickstart/start-cluster.sh
@@ -31,3 +31,6 @@ for IP in $MASTER_IPS
 do
   TAG_MASTER=true ./init-node.sh $IP cluster/auth/kubeconfig-kubelet
 done
+
+echo "Cluster bootstrap is complete. Access your kubernetes cluster using:"
+echo "kubectl --kubeconfig=cluster/auth/kubeconfig get nodes"


### PR DESCRIPTION
This prevents users from incorrectly being instructed to use the `kubeconfig-kubelet` file to authenticate to the cluster. That is no longer appropriate with TLS bootstrapping, and there is a plain `kubeconfig` file that should be used instead.