### PR TITLE
hack: Update conformance tests to use Go 1.9.2

### DIFF
--- a/hack/tests/conformance-gce.sh
+++ b/hack/tests/conformance-gce.sh
@@ -115,6 +115,6 @@ else
 
     #TODO(pb): See if there is a way to make the --inherit-env option replace
     #passing all the variables manually. 
-    sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.8.4 --exec /bin/bash -- -c \
+    sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.9.2 --exec /bin/bash -- -c \
         "IN_CONTAINER=true COREOS_CHANNEL=${COREOS_CHANNEL} GCE_PREFIX=${GCE_PREFIX} GCE_SERVICE_ACCOUNT=${GCE_SERVICE_ACCOUNT} GCE_PROJECT=${GCE_PROJECT} SELF_HOST_ETCD=${SELF_HOST_ETCD} /build/bootkube/hack/tests/$(basename $0)"
 fi

--- a/hack/tests/conformance-test.sh
+++ b/hack/tests/conformance-test.sh
@@ -44,5 +44,5 @@ CONFORMANCE="\
  KUBECONFIG=/kubeconfig KUBERNETES_CONFORMANCE_TEST=Y go run hack/e2e.go \
  -- -v --test --check-version-skew=false --provider=skeleton --test_args='--ginkgo.focus=\[Conformance\]'"
 
-CMD="sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.8.4 --exec /bin/bash -- -c \"${INIT} && ${BUILD} && ${CONFORMANCE}\""
+CMD="sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.9.2 --exec /bin/bash -- -c \"${INIT} && ${BUILD} && ${CONFORMANCE}\""
 ssh -q  -o UserKnownHostsFile=/dev/null -o stricthostkeychecking=no -i ${ssh_key} -p ${ssh_port} core@${ssh_host} "${CMD}"


### PR DESCRIPTION
Conformance tests for Kubernetes 1.9 need to be run with Go v1.9.

```
[710876.901729] golang[6]: [  607.394616] golang[6]: Detected go version: go version go1.8.4 linux/amd64.
[710876.902320] golang[6]: [  607.395062] golang[6]: Kubernetes requires go1.9.1 or greater.
[710876.902548] golang[6]: [  607.395288] golang[6]: Please install go1.9.1 or later.
[710876.904858] golang[6]: [  607.398040] golang[6]: !!! [0118 12:07:34] Call tree:
[710876.906480] golang[6]: [  607.399712] golang[6]: !!! [0118 12:07:34]  1: ./hack/run-in-gopath.sh:30 kube::golang::setup_env(...)
```

Triggered in bootkube-dev job 68.