### PR TITLE
pkg/asset: Update Calico from 2.6.4 to 2.6.6

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -6,7 +6,7 @@ var DefaultImages = ImageVersions{
 	EtcdOperator:    "quay.io/coreos/etcd-operator:v0.5.0",
 	Flannel:         "quay.io/coreos/flannel:v0.9.1-amd64",
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
-	Calico:          "quay.io/calico/node:v2.6.4",
+	Calico:          "quay.io/calico/node:v2.6.6",
 	CalicoCNI:       "quay.io/calico/cni:v1.11.2",
 	Hyperkube:       "gcr.io/google_containers/hyperkube:v1.9.2",
 	Kenc:            "quay.io/coreos/kenc:0.0.2",


### PR DESCRIPTION
Minor bug fixes:
https://github.com/projectcalico/calico/releases/tag/v2.6.6
https://github.com/projectcalico/calico/releases/tag/v2.6.5