### PR TITLE
gitignore: ignore hack/e2e litter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ hack/*/ssh_config
 hack/*/.terraform*
 hack/*/terraform.tfstate*
 hack/*/terraform.tfvars
+
+# e2e tests touch these
+hack/terraform-quickstart/terraform
+hack/terraform*tar.gz
+e2e/logs


### PR DESCRIPTION
Ignore more artifacts of running e2e/hack scripts.

Hopefully this will prevent me from `git add -A`-ing and pushing a bunch of random log files and binaries into Git and/or an open PR.