### PR TITLE
Fail release build on gofmt diffs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ release: \
 	_output/release/bootkube.tar.gz \
 
 check:
-	@find . -name vendor -prune -o -name '*.go' -exec gofmt -s -d {} +
+	@gofmt -l -s $(GOFILES) | read; if [ $$? == 0 ]; then gofmt -s -d $(GOFILES); exit 1; fi
 	@go vet $(shell go list ./... | grep -v '/vendor/')
 	@go test -v $(shell go list ./... | grep -v '/vendor/\|/e2e')
 

--- a/e2e/reboot_test.go
+++ b/e2e/reboot_test.go
@@ -97,12 +97,12 @@ func controlPlaneReady(c kubernetes.Interface, attempts int, backoff time.Durati
 		// list of pods that are checkpoint pods, not the real pods.
 		var (
 			waitablePods []string
-			regularPods    []string
+			regularPods  []string
 		)
-		
+
 		// only wait on Pods that have lack a parent, or have a non-runnning parent
 		for _, pod := range pods.Items {
-			if checkpointedPodName, ok := pod.Annotations[checkpointAnnotation]; ok {				
+			if checkpointedPodName, ok := pod.Annotations[checkpointAnnotation]; ok {
 				foundParent := false
 				for _, possibleParentPod := range pods.Items {
 					if possibleParentPod.Name == checkpointedPodName {


### PR DESCRIPTION
The current Makefile doesn't fail builds on `gofmt` errors. This changes causes it to fail.