### PR TITLE
use bash for the makefile shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ export GO15VENDOREXPERIMENT:=1
 export CGO_ENABLED:=0
 export GOARCH:=amd64
 
+SHELL:=$(shell which bash)
 LOCAL_OS:=$(shell uname | tr A-Z a-z)
 GOFILES:=$(shell find . -name '*.go' | grep -v -E '(./vendor)')
 GOPATH_BIN:=$(shell echo ${GOPATH} | awk 'BEGIN { FS = ":" }; { print $1 }')/bin


### PR DESCRIPTION
make is using `sh` on Jenkins by default. This tweak sets the shell to bash to fix the following error on `make check`:

```
05:22:18 [1650506.967906] golang[6]: /bin/sh: 1: read: arg count
05:22:18 [1650507.054205] golang[6]: /bin/sh: 1: [: 2: unexpected operator
```