### PR TITLE
[WIP] heptio-authenticator-aws side car with apiserver

### DIFF
--- a/hack/quickstart/aws-authenticator-config.yaml
+++ b/hack/quickstart/aws-authenticator-config.yaml
@@ -1,0 +1,42 @@
+# a unique-per-cluster identifier to prevent replay attacks (see above)
+clusterID: bootkube-cluster
+server:
+  # state directory for generated TLS certificate and private keys
+  stateDir: /var/aws-authenticator
+  generateKubeconfig: /var/aws-authenticator/kubeconfig.yaml
+  # each mapRoles entry maps an IAM role to a username and set of groups
+  # Each username and group can optionally contain template parameters:
+  #  1) "{{AccountID}}" is the 12 digit AWS ID.
+  #  2) "{{SessionName}}" is the role session name.
+  mapRoles:
+  # statically map arn:aws:iam::000000000000:role/KubernetesAdmin to cluster admin
+  #- roleARN: arn:aws:iam::000000000000:role/KubernetesAdmin
+  #  username: kubernetes-admin
+  #  groups:
+  #  - system:masters
+  # map EC2 instances in my "KubernetesNode" role to users like
+  # "aws:000000000000:instance:i-0123456789abcdef0". Only use this if you
+  # trust that the role can only be assumed by EC2 instances. If an IAM user
+  # can assume this role directly (with sts:AssumeRole) they can control
+  # SessionName.
+  #- roleARN: arn:aws:iam::000000000000:role/KubernetesNode
+  #  username: aws:{{AccountID}}:instance:{{SessionName}}
+  #  groups:
+  #  - system:bootstrappers
+  #  - aws:instances
+  # map federated users in my "KubernetesAdmin" role to users like
+  # "admin:alice-example.com". The SessionName is an arbitrary role name
+  # like an e-mail address passed by the identity provider. Note that if this
+  # role is assumed directly by an IAM User (not via federation), the user
+  # can control the SessionName.
+  #- roleARN: arn:aws:iam::000000000000:role/KubernetesAdmin
+  #  username: admin:{{SessionName}}
+  #  groups:
+  #  - system:masters
+  # each mapUsers entry maps an IAM role to a static username and set of groups
+  mapUsers:
+  # map user IAM user Alice in 000000000000 to user "alice" in group "system:masters"
+  #- userARN: arn:aws:iam::000000000000:user/Alice
+  #  username: alice
+  #  groups:
+  #  - system:masters

--- a/hack/terraform-quickstart/main.tf
+++ b/hack/terraform-quickstart/main.tf
@@ -16,9 +16,10 @@ resource "aws_instance" "bootstrap_node" {
   associate_public_ip_address = true
   depends_on                  = ["aws_internet_gateway.main"]
 
-  tags {
-    Name = "${var.resource_owner}"
-  }
+  tags = "${map(
+    "Name", "${var.resource_owner}",
+    "kubernetes.io/cluster/${var.resource_owner}", "owned"
+  )}"
 
   root_block_device {
     volume_type = "gp2"
@@ -26,7 +27,7 @@ resource "aws_instance" "bootstrap_node" {
   }
 
   provisioner "file" {
-    source = "environment_${var.environment}.txt"
+    source      = "environment_${var.environment}.txt"
     destination = "/tmp/environment"
 
     connection {
@@ -38,7 +39,7 @@ resource "aws_instance" "bootstrap_node" {
     # coreos manages /etc/environment, so append to the file
     inline = [
       "sudo bash -c 'cat /tmp/environment >> /etc/environment'",
-      "sudo rm -f /tmp/environment"
+      "sudo rm -f /tmp/environment",
     ]
 
     connection {
@@ -59,9 +60,10 @@ resource "aws_instance" "worker_node" {
   associate_public_ip_address = true
   depends_on                  = ["aws_internet_gateway.main"]
 
-  tags {
-    Name = "${var.resource_owner}"
-  }
+  tags = "${map(
+    "Name", "${var.resource_owner}",
+    "kubernetes.io/cluster/${var.resource_owner}", "owned"
+  )}"
 
   root_block_device {
     volume_type = "gp2"
@@ -69,7 +71,7 @@ resource "aws_instance" "worker_node" {
   }
 
   provisioner "file" {
-    source = "environment_${var.environment}.txt"
+    source      = "environment_${var.environment}.txt"
     destination = "/tmp/environment"
 
     connection {
@@ -81,7 +83,7 @@ resource "aws_instance" "worker_node" {
     # coreos manages /etc/environment, so append to the file
     inline = [
       "sudo bash -c 'cat /tmp/environment >> /etc/environment'",
-      "sudo rm -f /tmp/environment"
+      "sudo rm -f /tmp/environment",
     ]
 
     connection {
@@ -102,9 +104,10 @@ resource "aws_instance" "master_node" {
   associate_public_ip_address = true
   depends_on                  = ["aws_internet_gateway.main"]
 
-  tags {
-    Name = "${var.resource_owner}"
-  }
+  tags = "${map(
+    "Name", "${var.resource_owner}",
+    "kubernetes.io/cluster/${var.resource_owner}", "owned"
+  )}"
 
   root_block_device {
     volume_type = "gp2"
@@ -112,7 +115,7 @@ resource "aws_instance" "master_node" {
   }
 
   provisioner "file" {
-    source = "environment_${var.environment}.txt"
+    source      = "environment_${var.environment}.txt"
     destination = "/tmp/environment"
 
     connection {
@@ -124,7 +127,7 @@ resource "aws_instance" "master_node" {
     # coreos manages /etc/environment, so append to the file
     inline = [
       "sudo bash -c 'cat /tmp/environment >> /etc/environment'",
-      "sudo rm -f /tmp/environment"
+      "sudo rm -f /tmp/environment",
     ]
 
     connection {

--- a/hack/terraform-quickstart/network.tf
+++ b/hack/terraform-quickstart/network.tf
@@ -67,29 +67,3 @@ resource "aws_security_group" "allow_all" {
     Name = "${var.resource_owner}"
   }
 }
-
-resource "aws_network_acl" "all" {
-  vpc_id = "${aws_vpc.main.id}"
-
-  egress {
-    protocol   = "-1"
-    rule_no    = 2
-    action     = "allow"
-    cidr_block = "0.0.0.0/0"
-    from_port  = 0
-    to_port    = 0
-  }
-
-  ingress {
-    protocol   = "-1"
-    rule_no    = 1
-    action     = "allow"
-    cidr_block = "0.0.0.0/0"
-    from_port  = 0
-    to_port    = 0
-  }
-
-  tags {
-    Name = "${var.resource_owner}"
-  }
-}

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -119,18 +119,19 @@ type Config struct {
 
 // ImageVersions holds all the images (and their versions) that are rendered into the templates.
 type ImageVersions struct {
-	Etcd            string
-	EtcdOperator    string
-	Flannel         string
-	FlannelCNI      string
-	Calico          string
-	CalicoCNI       string
-	Hyperkube       string
-	Kenc            string
-	KubeDNS         string
-	KubeDNSMasq     string
-	KubeDNSSidecar  string
-	PodCheckpointer string
+	Etcd             string
+	EtcdOperator     string
+	Flannel          string
+	FlannelCNI       string
+	Calico           string
+	CalicoCNI        string
+	Hyperkube        string
+	Kenc             string
+	KubeDNS          string
+	KubeDNSMasq      string
+	KubeDNSSidecar   string
+	PodCheckpointer  string
+	AWSAuthenticator string
 }
 
 // NewDefaultAssets returns a list of default assets, optionally

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -2,14 +2,15 @@ package asset
 
 // DefaultImages are the defualt images bootkube components use.
 var DefaultImages = ImageVersions{
-	Etcd:            "quay.io/coreos/etcd:v3.1.8",
-	Flannel:         "quay.io/coreos/flannel:v0.10.0-amd64",
-	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
-	Calico:          "quay.io/calico/node:v2.6.6",
-	CalicoCNI:       "quay.io/calico/cni:v1.11.2",
-	Hyperkube:       "gcr.io/google_containers/hyperkube:v1.9.2",
-	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.8",
-	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8",
-	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8",
-	PodCheckpointer: "quay.io/coreos/pod-checkpointer:3cd08279c564e95c8b42a0b97c073522d4a6b965",
+	Etcd:             "quay.io/coreos/etcd:v3.1.8",
+	Flannel:          "quay.io/coreos/flannel:v0.10.0-amd64",
+	FlannelCNI:       "quay.io/coreos/flannel-cni:v0.3.0",
+	Calico:           "quay.io/calico/node:v2.6.6",
+	CalicoCNI:        "quay.io/calico/cni:v1.11.2",
+	Hyperkube:        "gcr.io/google_containers/hyperkube:v1.9.2",
+	KubeDNS:          "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.8",
+	KubeDNSMasq:      "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8",
+	KubeDNSSidecar:   "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8",
+	PodCheckpointer:  "quay.io/coreos/pod-checkpointer:3cd08279c564e95c8b42a0b97c073522d4a6b965",
+	AWSAuthenticator: "quay.io/abhinavdahiya/aws-authenticator:dev",
 }


### PR DESCRIPTION
This adds https://github.com/heptio/authenticator as a side car with the kube-apiserver. This will allow users to use their aws credentials.

- `aws-authenticator-config.yaml` file configures the authenticator with required AWS resource names to kubernetes group,username

/cc: @ericchiang 