### PR TITLE
add terraform fmt validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: go
+before_script:
+  - wget https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_linux_amd64.zip
+  - unzip terraform_0.11.3_linux_amd64.zip
+  - export PATH=$PWD:$PATH
 go:
   - 1.8.x
   - 1.9.x

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 export GO15VENDOREXPERIMENT:=1
 export CGO_ENABLED:=0
 export GOARCH:=amd64
+export PATH:=$(PATH):$(PWD)
 
 SHELL:=$(shell which bash)
 LOCAL_OS:=$(shell uname | tr A-Z a-z)
@@ -30,6 +31,7 @@ release: \
 
 check:
 	@gofmt -l -s $(GOFILES) | read; if [ $$? == 0 ]; then gofmt -s -d $(GOFILES); exit 1; fi
+	@terraform fmt -check ; if [ ! $$? -eq 0 ]; then exit 1; fi
 	@go vet $(shell go list ./... | grep -v '/vendor/')
 	@./scripts/verify-gopkg.sh
 	@go test -v $(shell go list ./... | grep -v '/vendor/\|/e2e')

--- a/hack/terraform-quickstart/main.tf
+++ b/hack/terraform-quickstart/main.tf
@@ -26,7 +26,7 @@ resource "aws_instance" "bootstrap_node" {
   }
 
   provisioner "file" {
-    source = "environment_${var.environment}.txt"
+    source      = "environment_${var.environment}.txt"
     destination = "/tmp/environment"
 
     connection {
@@ -38,7 +38,7 @@ resource "aws_instance" "bootstrap_node" {
     # coreos manages /etc/environment, so append to the file
     inline = [
       "sudo bash -c 'cat /tmp/environment >> /etc/environment'",
-      "sudo rm -f /tmp/environment"
+      "sudo rm -f /tmp/environment",
     ]
 
     connection {
@@ -69,7 +69,7 @@ resource "aws_instance" "worker_node" {
   }
 
   provisioner "file" {
-    source = "environment_${var.environment}.txt"
+    source      = "environment_${var.environment}.txt"
     destination = "/tmp/environment"
 
     connection {
@@ -81,7 +81,7 @@ resource "aws_instance" "worker_node" {
     # coreos manages /etc/environment, so append to the file
     inline = [
       "sudo bash -c 'cat /tmp/environment >> /etc/environment'",
-      "sudo rm -f /tmp/environment"
+      "sudo rm -f /tmp/environment",
     ]
 
     connection {
@@ -112,7 +112,7 @@ resource "aws_instance" "master_node" {
   }
 
   provisioner "file" {
-    source = "environment_${var.environment}.txt"
+    source      = "environment_${var.environment}.txt"
     destination = "/tmp/environment"
 
     connection {
@@ -124,7 +124,7 @@ resource "aws_instance" "master_node" {
     # coreos manages /etc/environment, so append to the file
     inline = [
       "sudo bash -c 'cat /tmp/environment >> /etc/environment'",
-      "sudo rm -f /tmp/environment"
+      "sudo rm -f /tmp/environment",
     ]
 
     connection {


### PR DESCRIPTION
fails `make check` if terraform files are not formatted correctly.