### PR TITLE
wait for the controlPlane to be restored

### DIFF
--- a/e2e/deleteapi_test.go
+++ b/e2e/deleteapi_test.go
@@ -48,16 +48,8 @@ func TestDeleteAPI(t *testing.T) {
 	}
 
 	// wait until api server is back up
-	waitAPI := func() error {
-		// only checking for presence of api returning, specific function not important
-		_, err := client.Discovery().ServerVersion()
-		if err != nil {
-			return fmt.Errorf("waiting for apiserver to return: %v", err)
-		}
-		return nil
-	}
-	if err := retry(30, 10*time.Second, waitAPI); err != nil {
-		t.Fatal(err)
+	if err := controlPlaneReady(client, 120, 5*time.Second); err != nil {
+		t.Fatalf("waiting for control plane: %v", err)
 	}
 
 	waitForCheckpointDeactivation(t)


### PR DESCRIPTION
The control plane can take in excess of 60 seconds to be restored. In my testing, I have seen the control plane take anywhere from 40 seconds to 1 minute 40 seconds to be fully functional again. The TestDeleteAPI test simply ignores the restoration of the control plane and continues without verifying the control plane so the next unit test can run.