### PR TITLE
pkg/bootkube: remove global variable

### DIFF
--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -12,8 +12,6 @@ import (
 
 const assetTimeout = 20 * time.Minute
 
-var kubeConfig clientcmd.ClientConfig
-
 var requiredPods = []string{
 	"pod-checkpointer",
 	"kube-apiserver",
@@ -41,7 +39,7 @@ func NewBootkube(config Config) (*bootkube, error) {
 func (b *bootkube) Run() error {
 	// TODO(diegs): create and share a single client rather than the kubeconfig once all uses of it
 	// are migrated to client-go.
-	kubeConfig = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath.Join(b.assetDir, asset.AssetPathAdminKubeConfig)},
 		&clientcmd.ConfigOverrides{})
 
@@ -66,11 +64,11 @@ func (b *bootkube) Run() error {
 		return err
 	}
 
-	if err = CreateAssets(filepath.Join(b.assetDir, asset.AssetPathManifests), assetTimeout); err != nil {
+	if err = CreateAssets(kubeConfig, filepath.Join(b.assetDir, asset.AssetPathManifests), assetTimeout); err != nil {
 		return err
 	}
 
-	if err = WaitUntilPodsRunning(requiredPods, assetTimeout); err != nil {
+	if err = WaitUntilPodsRunning(kubeConfig, requiredPods, assetTimeout); err != nil {
 		return err
 	}
 

--- a/pkg/bootkube/status.go
+++ b/pkg/bootkube/status.go
@@ -16,14 +16,15 @@ import (
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
 	doesNotExist = "DoesNotExist"
 )
 
-func WaitUntilPodsRunning(pods []string, timeout time.Duration) error {
-	sc, err := NewStatusController(pods)
+func WaitUntilPodsRunning(c clientcmd.ClientConfig, pods []string, timeout time.Duration) error {
+	sc, err := NewStatusController(c, pods)
 	if err != nil {
 		return err
 	}
@@ -44,8 +45,8 @@ type statusController struct {
 	lastPodPhases map[string]v1.PodPhase
 }
 
-func NewStatusController(pods []string) (*statusController, error) {
-	config, err := kubeConfig.ClientConfig()
+func NewStatusController(c clientcmd.ClientConfig, pods []string) (*statusController, error) {
+	config, err := c.ClientConfig()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Am removing some kubectl code and this is a good cleanup that can go in on its own.