### PR TITLE
jenkins: add e2e script

### DIFF
--- a/hack/.gitignore
+++ b/hack/.gitignore
@@ -1,0 +1,1 @@
+_clusters/

--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -109,11 +109,6 @@ function init_master_node() {
 
 [ "$#" == 1 ] || usage
 
-[ -d "${CLUSTER_DIR}" ] && {
-    echo "Error: CLUSTER_DIR=${CLUSTER_DIR} already exists"
-    exit 1
-}
-
 # This script can execute on a remote host by copying itself + bootkube binary + kubelet service unit to remote host.
 # After assets are available on the remote host, the script will execute itself in "local" mode.
 if [ "${REMOTE_HOST}" != "local" ]; then
@@ -143,7 +138,7 @@ if [ "${REMOTE_HOST}" != "local" ]; then
     ssh -i ${IDENT} -p ${REMOTE_PORT} ${SSH_OPTS} ${REMOTE_USER}@${REMOTE_HOST} "sudo REMOTE_USER=${REMOTE_USER} CLOUD_PROVIDER=${CLOUD_PROVIDER} NETWORK_PROVIDER=${NETWORK_PROVIDER} /home/${REMOTE_USER}/init-master.sh local"
 
     # Copy assets from remote host to a local directory. These can be used to launch additional nodes & contain TLS assets
-    mkdir ${CLUSTER_DIR}
+    mkdir -p ${CLUSTER_DIR}
     scp -q -i ${IDENT} -P ${REMOTE_PORT} ${SSH_OPTS} -r ${REMOTE_USER}@${REMOTE_HOST}:/home/${REMOTE_USER}/assets/* ${CLUSTER_DIR}
 
     # Cleanup

--- a/hack/terraform-quickstart/e2e.sh
+++ b/hack/terraform-quickstart/e2e.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -x
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+#export CLUSTER_NAME="${CLUSTER_NAME:-"bootkube$(printf '0x%x' $(date +%s))"}"
+export CLUSTER_NAME="${CLUSTER_NAME:-"default"}"
+export CLUSTER_DIR="${CLUSTER_DIR:-"${DIR}/../_clusters/${CLUSTER_NAME}"}"
+mkdir -p "${CLUSTER_DIR}"
+
+export NUM_WORKERS=${NUM_WORKERS:-1}
+export REGION="${REGION:-"us-west-2"}"
+
+export TERRAFORM_VERSION="0.11.3"
+
+# variables from ../quickstart/init-*.sh
+#REMOTE_HOST=$1
+#REMOTE_PORT=${REMOTE_PORT:-22}
+#REMOTE_USER=${REMOTE_USER:-core}
+#CLUSTER_DIR=${CLUSTER_DIR:-cluster}
+#IDENT=${IDENT:-${HOME}/.ssh/id_rsa}
+#SSH_OPTS=${SSH_OPTS:-}
+#CLOUD_PROVIDER=${CLOUD_PROVIDER:-}
+#NETWORK_PROVIDER=${NETWORK_PROVIDER:-flannel}
+
+# generate ssh-key
+ssh-keygen -t rsa -f "${CLUSTER_DIR}/id_rsa" -q -N ""
+if [ -z "${SSH_AUTH_SOCK:-}" ] ; then
+  ssh-agent -s > "${CLUSTER_DIR}/sshagent.env"
+  source "${CLUSTER_DIR}/sshagent.env"
+  ssh-add "${CLUSTER_DIR}/id_rsa"
+fi
+
+if [[ -f "../../_output/bin/linux/bootkube" ]]; then
+    echo "Build already exists. Skipping (re)build."
+else
+    ../../build/build-release.sh
+fi
+
+# install terraform
+if [[ ! -f "${DIR}/bin/terraform" ]]; then
+    (
+        mkdir -p "${DIR}/bin/"
+        cd "${DIR}/bin/";
+        curl -L -O "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+        unzip "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+        rm "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+    )
+fi
+export TERRAFORM="${DIR}/bin/terraform"
+
+cd ../terraform-quickstart
+
+export TF_VAR_access_key_id="${ACCESS_KEY_ID}"
+export TF_VAR_access_key="${ACCESS_KEY_SECRET}"
+#export TF_VAR_instance_tags="${CLUSTER_NAME}" # unused??
+export TF_VAR_resource_owner="${CLUSTER_NAME}"
+export TF_VAR_ssh_public_key="$(cat ${CLUSTER_DIR}/id_rsa.pub)"
+export TF_VAR_ssh_key="jenkins-core-services"
+export TF_VAR_additional_masters=0
+export TF_VAR_num_workers=${NUM_WORKERS}
+export TF_VAR_region="${REGION}"
+
+export TERRAFORM_STATE_FILE="${CLUSTER_DIR}/terraform.tfstate"
+
+# bring up compute
+terraform init
+"${TERRAFORM}" apply --auto-approve --state "${TERRAFORM_STATE_FILE}"
+
+# sleep so ssh works with start-cluster
+sleep 30
+
+#avoid some IPs being blank bootkube/issues/552
+"${TERRAFORM}" refresh --state "${TERRAFORM_STATE_FILE}"
+
+#launch bootkube via quickstart scripts
+./start-cluster.sh
+
+if [[ "${RUN_E2E:-}" == "y" ]]; then
+    #run tests -- mount /tmp for access to ssh agent 
+    BOOTKUBE_ROOT=$(git rev-parse --show-toplevel)
+    sudo rkt run \
+        --volume bk,kind=host,source=${BOOTKUBE_ROOT} \
+        --mount volume=bk,target=/go/src/github.com/kubernetes-incubator/bootkube \
+        --volume tmp,kind=host,source=/tmp \
+        --mount volume=tmp,target=/tmp \
+        --set-env SSH_AUTH_SOCK=$SSH_AUTH_SOCK \
+        --insecure-options=image docker://golang:1.8.3 --exec /bin/bash -- -c \
+        "cd /go/src/github.com/kubernetes-incubator/bootkube/e2e && \
+        go test -v -timeout 45m \
+        --kubeconfig=../hack/quickstart/cluster/auth/kubeconfig \
+        --expectedmasters=1 \
+        ./e2e/"
+fi

--- a/hack/terraform-quickstart/main.tf
+++ b/hack/terraform-quickstart/main.tf
@@ -5,10 +5,15 @@ provider "aws" {
   version    = "1.8"
 }
 
+resource "aws_key_pair" "core" {
+  key_name   = "${var.resource_owner}"
+  public_key = "${var.ssh_public_key}"
+}
+
 resource "aws_instance" "bootstrap_node" {
   ami                  = "${data.aws_ami.coreos_ami.image_id}"
   instance_type        = "${var.instance_type}"
-  key_name             = "${var.ssh_key}"
+  key_name             = "${aws_key_pair.core.key_name}"
   iam_instance_profile = "${aws_iam_instance_profile.bk_profile.id}"
 
   vpc_security_group_ids      = ["${aws_security_group.allow_all.id}"]
@@ -50,7 +55,7 @@ resource "aws_instance" "bootstrap_node" {
 resource "aws_instance" "worker_node" {
   ami                  = "${data.aws_ami.coreos_ami.image_id}"
   instance_type        = "${var.instance_type}"
-  key_name             = "${var.ssh_key}"
+  key_name             = "${aws_key_pair.core.key_name}"
   count                = "${var.num_workers}"
   iam_instance_profile = "${aws_iam_instance_profile.bk_profile.id}"
 
@@ -93,7 +98,7 @@ resource "aws_instance" "worker_node" {
 resource "aws_instance" "master_node" {
   ami                  = "${data.aws_ami.coreos_ami.image_id}"
   instance_type        = "${var.instance_type}"
-  key_name             = "${var.ssh_key}"
+  key_name             = "${aws_key_pair.core.key_name}"
   count                = "${var.additional_masters}"
   iam_instance_profile = "${aws_iam_instance_profile.bk_profile.id}"
 

--- a/hack/terraform-quickstart/start-cluster.sh
+++ b/hack/terraform-quickstart/start-cluster.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export BOOTSTRAP_IP=`terraform output bootstrap_node_ip`
-export WORKER_IPS=`terraform output -json worker_ips | jq -r '.value[]'`
-export MASTER_IPS=`terraform output -json master_ips | jq -r '.value[]'`
+export TERRAFORM_STATE_FILE="${TERRAFORM_STATE_FILE:-"terraform.tfstate"}"
+
+export BOOTSTRAP_IP=`terraform output -state "${TERRAFORM_STATE_FILE}" bootstrap_node_ip`
+export WORKER_IPS=`terraform output -state "${TERRAFORM_STATE_FILE}"  -json worker_ips | jq -r '.value[]'`
+export MASTER_IPS=`terraform output -state "${TERRAFORM_STATE_FILE}"  -json master_ips | jq -r '.value[]'`
 export SSH_OPTS=${SSH_OPTS:-}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 export CLOUD_PROVIDER=${CLOUD_PROVIDER:-aws}
-export NETWORK_PROVIDER=`terraform output network_provider`
+export NETWORK_PROVIDER=`terraform output -state "${TERRAFORM_STATE_FILE}"  network_provider`
 
 # Normally we want to default to aws here since that is all terraform
 # supports and it is required for the e2e tests. However because of an

--- a/hack/terraform-quickstart/variables.tf
+++ b/hack/terraform-quickstart/variables.tf
@@ -6,8 +6,8 @@ variable "access_key" {
   type = "string"
 }
 
-variable "ssh_key" {
-  description = "aws ssh key"
+variable "ssh_public_key" {
+  description = "SSH Public Key"
   type        = "string"
 }
 
@@ -18,7 +18,7 @@ variable "resource_owner" {
 }
 
 variable "instance_type" {
-  description = "Name all instances behind a single tag based on who/what is running terraform"
+  description = "Instance type"
   type        = "string"
   default     = "m3.medium"
 }


### PR DESCRIPTION
This is the script from Jenkins with modifications to support multiple clusters side-by-side.

The TF state and a per-cluster SSH key are saved into a cluster directory. This is instead of relying on the user having a specially named ssh key already active in their AWS subscription.

cc: @ericchiang @rphillips 