### PR TITLE
bootkube: remove duplicate error messages

### DIFF
--- a/cmd/bootkube/main.go
+++ b/cmd/bootkube/main.go
@@ -36,7 +36,6 @@ func main() {
 
 	cmdRoot.AddCommand(cmdVersion)
 	if err := cmdRoot.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
error messages are duplicated on exit. This patch removes the extra fmt.Println

```
core@ip-10-0-42-175 ~ $ sudo ./bootkube recover --etcd-ca-path /etc/ssl/etcd/ca.crt --etcd-certificate-path /etc/ssl/etcd/client.crt  --recovery-dir recovery --etcd-servers=https://127.0.0.1:2379 --kubeconfig ./kubeconfig
Error: you must specify both --etcd-certificate-path, and --etcd-private-key-path
you must specify both --etcd-certificate-path, and --etcd-private-key-path
```