### PR TITLE
jenkins: add initial bootkube-e2e jobs

### DIFF
--- a/hack/jenkins/README.md
+++ b/hack/jenkins/README.md
@@ -1,0 +1,60 @@
+# hack/jenkins
+
+Job configurations, pipelines, scripts, and docker images used for `bootkube` validation.
+
+### Overvew
+
+This contains all specifications for `bootkube` Jenkins jobs. No changes are made to these jobs
+after they are deployed. They are re-deployed each time Jenkins is restarted. The goal is for
+Jenkins and its job configurations to be as fungible as possible.
+
+### Jenkins Quick Information
+
+-   Declarative, Verison-Controlled Jenkins Jobs
+    -   (via [Job DSL Plugin](https://github.com/jenkinsci/job-dsl-plugin))
+    -   It defines a groovy DSL for specifying Jenkins job in a declarative-looking imperative syntax that emits Jenkins job xml.
+    -   It provides a "Build Action" that is used in a "Seed Job" (defined in a separate repo) to instantiate jobs.
+    -   Jobs for this repo are defined in `./jobs/`.
+-   Jenkinsfile / Jenkins Pipelines
+    -   (built-in to Jenkins)
+    -   Jenkins has pipelines for defining workflows for jobs in a version-control friendly manner (as opposed to the non-friendly XML files that it uses internally)
+    -   Confusingly, they come in two variants - [Declarative Pipelines](https://jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline) and [Scripted Pipelines](https://jenkins.io/doc/book/pipeline/syntax/#scripted-pipeline).
+        Be sure you are reading the docs for the right kind. They have slightly different steps, and even they have same-named steps, they can have behavioral differences.
+    -   This repository favors "Declarative Pipelines" where possible.
+        -   It seems to be where Jenkins is trending and trying to push people toward.
+        -   The syntax is more convincingly declarative.
+        -   It has an escape hatch that allows you to enter a scripting block and use the full scripting syntax.
+    -   Pipelines for this repo are defined in `./pipelines/`.
+-   Kubernetes Plugin
+    -   (via [Kubernetes Plugin](https://github.com/jenkinsci/kubernetes-plugin))
+    -   Allows using a Kubernetes cluster as a Jenkins "Cloud" (resource from which worker Agents can be spawned).
+    -   _Note:_ All jobs here are expected to run on the default `kubernetes` cloud.
+
+### Structure
+
+-   `images`: Contains `Dockerfile`s for any images used in validation. (_Note:_ images used for CI are not considered or supported as part of any bootkube release.)
+-   `jobs`: Contains top-level groovy scripts containing the Job DSL configurations. (these are recommeneded to be (but are not necessarily) Pipeline Jobs.)
+-   `pipelines`: Contains `Jenkinsfile` pipelines used as part of pipeline jobs.
+-   `scripts`: Contains scripts that are used in Pipelines, or in Jobs directly. (May or may not be usable outside of Jenkins. Only supported as part of CI.)
+
+This shows an example directory structure, added as part of the `bootkube-e2e-*` jobs:
+
+    hack/jenkins
+    ├── images
+    │   └── bootkube-e2e
+    │       └── Dockerfile
+    ├── jobs
+    │   └── bootkube_e2e.groovy
+    ├── pipelines
+    │   └── bootkube-e2e
+    │       └── Jenkinsfile
+    └── scripts
+        ├── e2e.sh
+        ├── tqs-down.sh
+        └── tqs-up.sh
+
+### Currently Defined Jobs
+
+-   bootkube-e2e-\*
+    -   calico: tests a standard multi-master bootkube cluster with calico
+    -   flannel: tests a standard multi-master bootkube cluster with flannel

--- a/hack/jenkins/images/bootkube-e2e/Dockerfile
+++ b/hack/jenkins/images/bootkube-e2e/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y unzip wget curl git make jq openssh-client && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget https://godeb.s3.amazonaws.com/godeb-amd64.tar.gz && \
+    tar xvzf godeb-amd64.tar.gz && \
+    ./godeb install 1.10 && \
+    rm -rf godeb* *.deb
+
+ENV TERRAFORM_VERSION 0.11.3
+RUN curl -L -O "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
+    unzip "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
+    mv terraform /usr/local/bin/ && \
+    rm "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+

--- a/hack/jenkins/jobs/bootkube_e2e.groovy
+++ b/hack/jenkins/jobs/bootkube_e2e.groovy
@@ -1,0 +1,60 @@
+// META
+job_dir = 'bootkube'
+
+// CONFIG
+fork_to_use = 'kubernetes-incubator'
+job_admins = ['colemickens', 'ericchiang', 'rithujohn191', 'rphillips']
+user_whitelist = job_admins
+org_whitelist = ['coreos', 'coreos-inc']
+
+// JOBS
+network_providers = ['flannel', 'calico']
+network_providers.each { np ->
+  // Note: the "tku-" prefix is to differentiate "team-kube-upstream" jenkins job
+  // statuses and triggers from the legacy jobs and triggers.
+  job_name = "tku-bootkube-e2e-${np}"
+
+  pipelineJob(job_name) {
+    parameters {
+      stringParam('sha1', 'origin/master', 'git reference to build')
+    }
+    definition {
+      triggers {
+        githubPullRequest {
+          admins(job_admins)
+          userWhitelist(user_whitelist)
+          orgWhitelist(org_whitelist)
+          useGitHubHooks(true)
+          onlyTriggerPhrase(false)
+          triggerPhrase("coreosbot run ${job_name}")
+
+          extensions {
+            commitStatus {
+              context(job_name)
+              triggeredStatus('e2e triggered')
+              startedStatus('e2e started')
+              completedStatus('SUCCESS', 'e2e succeeded')
+              completedStatus('FAILURE', 'e2e failed. Investigate!')
+              completedStatus('PENDING', 'e2e queued')
+              completedStatus('ERROR', 'e2e internal error. Investigate!')
+            }
+          }
+        }
+      }
+
+      cpsScm {
+        scm {
+          git {
+            remote {
+              github("${fork_to_use}/bootkube")
+              refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+              credentials('github_userpass')
+            }
+            branch('${sha1}')
+          }
+        }
+        scriptPath('hack/jenkins/pipelines/bootkube-e2e/Jenkinsfile')
+      }
+    }
+  }
+}

--- a/hack/jenkins/pipelines/bootkube-e2e/Jenkinsfile
+++ b/hack/jenkins/pipelines/bootkube-e2e/Jenkinsfile
@@ -1,0 +1,76 @@
+// Declarative Pipeline (used by `bootkube-e2e-*` jobs)
+
+pipeline {
+  agent {
+    kubernetes {
+      cloud 'kubernetes'
+      label "${JOB_NAME}-${BUILD_NUMBER}"
+      containerTemplate {
+        name 'default'
+        image 'colemickens/bootkube-e2e:1520055055'
+        ttyEnabled true
+        command 'cat'
+      }
+    }
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    ansiColor('xterm')
+    timestamps()
+    skipDefaultCheckout(true)
+  }
+  environment {
+    CLUSTER_NAME="${JOB_NAME}-${BUILD_NUMBER}"
+    GOPATH = "${WORKSPACE}"
+    WORKDIR = "${WORKSPACE}/src/github.com/kubernetes-incubator/bootkube"
+    KUBECONFIG = "${WORKSPACE}/src/github.com/kubernetes-incubator/bootkube/hack/quickstart/cluster/auth/kubeconfig"
+    IDENT = "${WORKSPACE}/src/github.com/kubernetes-incubator/bootkube/hack/quickstart/cluster/auth/id_rsa"
+
+    AWS_CRED = credentials('aws')
+    ACCESS_KEY_ID = "${AWS_CRED_USR}"
+    ACCESS_KEY_SECRET = "${AWS_CRED_PSW}"
+  }
+  stages {
+    stage('checkout') {
+      steps {
+        // jnlp slave runs as "jenkins" user, use the escape hatch. (https://hub.docker.com/r/jenkins/slave/~/dockerfile/)
+        sh "chmod -R go+rw /home/jenkins"
+        dir("${WORKDIR}") {
+          checkout scm
+        }
+      }
+    }
+    stage('build') {
+      steps {
+        dir("${WORKDIR}") {
+          sh "make release"
+        }
+      }
+    }
+    stage('deploy') {
+      steps {
+        dir("${WORKDIR}") {
+          sh "./hack/jenkins/scripts/tqs-up.sh"
+        }
+      }
+    }
+    stage('e2e') {
+      steps {
+        dir("${WORKDIR}") {
+          sh "./hack/jenkins/scripts/e2e.sh"
+        }
+      }
+    }
+  }
+  post {
+    always {
+      script { // break the seal so that we can put cleanup in a stage
+        stage('cleanup') {
+          dir("${WORKDIR}") {
+            sh "./hack/jenkins/scripts/tqs-down.sh"
+          }
+        }
+      }
+    }
+  }
+}

--- a/hack/jenkins/scripts/e2e.sh
+++ b/hack/jenkins/scripts/e2e.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+set -x
+set -euo pipefail
+
+cd "${DIR}/../../../e2e"
+
+export KUBECONFIG="${KUBECONFIG:-"${DIR}/../../quickstart/cluster/auth/kubeconfig"}"
+
+go test -v -timeout 45m \
+  --kubeconfig="${KUBECONFIG}" \
+  --keypath="${IDENT}" \
+  --expectedmasters=1 \
+  ./e2e/

--- a/hack/jenkins/scripts/tqs-down.sh
+++ b/hack/jenkins/scripts/tqs-down.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+set -x
+set -euo pipefail
+
+export TERRAFORM="terraform"
+export NUM_WORKERS=${NUM_WORKERS:-1}
+export ADDITIONAL_MASTERS=${ADDITIONAL_MASTER:-0}
+export REGION="${REGION:-"us-west-2"}"
+export CLUSTER_NAME="${CLUSTER_NAME:-"default"}"
+export IDENT="${IDENT:-"${HOME}/.ssh/id_rsa"}"
+
+cd "${DIR}/../../terraform-quickstart"
+
+export TF_VAR_access_key_id="${ACCESS_KEY_ID}"
+export TF_VAR_access_key="${ACCESS_KEY_SECRET}"
+export TF_VAR_resource_owner="${CLUSTER_NAME}"
+export TF_VAR_ssh_public_key="$(cat "${IDENT}.pub")"
+export TF_VAR_additional_masters="${ADDITIONAL_MASTERS}"
+export TF_VAR_num_workers=${NUM_WORKERS}
+export TF_VAR_region="${REGION}"
+
+# early exit if there's no state file. we probably failed before we even got to terraform
+if [[ ! -f "./terraform.tfstate" ]]; then exit 0; fi
+
+for i in 1 2 3 4 5; do
+    "${TERRAFORM}" destroy --force && break || sleep 15;
+done
+
+# TODO: remove if unnecessary
+# if additional resources are destroyed in subsequent calls, the "cleanup" stage will painlessly fail
+# giving us an indicator we need this. if we don't, let's remove it.
+destroyed_extra=""
+for i in 1 2 3; do
+    #sleep 30
+    output="$("${TERRAFORM}" destroy --force | tail -1)"
+    count="$(echo "$output" | sed 's/.*\([0-9]\+\) destroyed.*/\1/')"
+    if (( count > 0 )); then
+        destroyed_extra="y"
+    fi
+done
+
+if [[ ! -z "${destroyed_extra:-}" ]]; then
+    echo "Terraform required multiple 'destroy' runs to cleanup everything!"
+    exit -1
+fi

--- a/hack/jenkins/scripts/tqs-up.sh
+++ b/hack/jenkins/scripts/tqs-up.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+set -x
+set -euo pipefail
+
+export TERRAFORM="terraform"
+export NUM_WORKERS=${NUM_WORKERS:-1}
+export ADDITIONAL_MASTERS=${ADDITIONAL_MASTER:-0}
+export REGION="${REGION:-"us-west-2"}"
+export CLUSTER_NAME="${CLUSTER_NAME:-"default"}"
+export IDENT="${IDENT:-"${HOME}/.ssh/id_rsa"}"
+
+cd "${DIR}/../../terraform-quickstart"
+
+if [[ ! -f "${IDENT}" ]]; then
+  mkdir -p "$(dirname "${IDENT}")"
+  ssh-keygen -t rsa -f "${IDENT}" -q -N ""
+fi
+
+if [ -z "${SSH_AUTH_SOCK:-}" ] ; then
+  ssh-agent -s > "/tmp/bootkube-tqs-sshagent.env"
+  source "/tmp/bootkube-tqs-sshagent.env"
+  ssh-add "${IDENT}"
+fi
+
+export TF_VAR_access_key_id="${ACCESS_KEY_ID}"
+export TF_VAR_access_key="${ACCESS_KEY_SECRET}"
+export TF_VAR_resource_owner="${CLUSTER_NAME}"
+export TF_VAR_ssh_public_key="$(cat "${IDENT}.pub")"
+export TF_VAR_additional_masters="${ADDITIONAL_MASTERS}"
+export TF_VAR_num_workers=${NUM_WORKERS}
+export TF_VAR_region="${REGION}"
+
+# bring up compute
+"${TERRAFORM}" init
+"${TERRAFORM}" apply --auto-approve
+
+# sleep so ssh works with start-cluster
+sleep 30
+
+#avoid some IPs being blank bootkube/issues/552
+"${TERRAFORM}" refresh
+
+#launch bootkube via quickstart scripts
+./start-cluster.sh

--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -x
 
 REMOTE_HOST=$1
 REMOTE_PORT=${REMOTE_PORT:-22}
@@ -109,11 +110,6 @@ function init_master_node() {
 
 [ "$#" == 1 ] || usage
 
-[ -d "${CLUSTER_DIR}" ] && {
-    echo "Error: CLUSTER_DIR=${CLUSTER_DIR} already exists"
-    exit 1
-}
-
 # This script can execute on a remote host by copying itself + bootkube binary + kubelet service unit to remote host.
 # After assets are available on the remote host, the script will execute itself in "local" mode.
 if [ "${REMOTE_HOST}" != "local" ]; then
@@ -143,7 +139,7 @@ if [ "${REMOTE_HOST}" != "local" ]; then
     ssh -i ${IDENT} -p ${REMOTE_PORT} ${SSH_OPTS} ${REMOTE_USER}@${REMOTE_HOST} "sudo REMOTE_USER=${REMOTE_USER} CLOUD_PROVIDER=${CLOUD_PROVIDER} NETWORK_PROVIDER=${NETWORK_PROVIDER} /home/${REMOTE_USER}/init-master.sh local"
 
     # Copy assets from remote host to a local directory. These can be used to launch additional nodes & contain TLS assets
-    mkdir ${CLUSTER_DIR}
+    mkdir -p ${CLUSTER_DIR}
     scp -q -i ${IDENT} -P ${REMOTE_PORT} ${SSH_OPTS} -r ${REMOTE_USER}@${REMOTE_HOST}:/home/${REMOTE_USER}/assets/* ${CLUSTER_DIR}
 
     # Cleanup

--- a/hack/terraform-quickstart/main.tf
+++ b/hack/terraform-quickstart/main.tf
@@ -5,10 +5,15 @@ provider "aws" {
   version    = "1.8"
 }
 
+resource "aws_key_pair" "core" {
+  key_name   = "${var.resource_owner}"
+  public_key = "${var.ssh_public_key}"
+}
+
 resource "aws_instance" "bootstrap_node" {
   ami                  = "${data.aws_ami.coreos_ami.image_id}"
   instance_type        = "${var.instance_type}"
-  key_name             = "${var.ssh_key}"
+  key_name             = "${aws_key_pair.core.key_name}"
   iam_instance_profile = "${aws_iam_instance_profile.bk_profile.id}"
 
   vpc_security_group_ids      = ["${aws_security_group.allow_all.id}"]
@@ -50,7 +55,7 @@ resource "aws_instance" "bootstrap_node" {
 resource "aws_instance" "worker_node" {
   ami                  = "${data.aws_ami.coreos_ami.image_id}"
   instance_type        = "${var.instance_type}"
-  key_name             = "${var.ssh_key}"
+  key_name             = "${aws_key_pair.core.key_name}"
   count                = "${var.num_workers}"
   iam_instance_profile = "${aws_iam_instance_profile.bk_profile.id}"
 
@@ -93,7 +98,7 @@ resource "aws_instance" "worker_node" {
 resource "aws_instance" "master_node" {
   ami                  = "${data.aws_ami.coreos_ami.image_id}"
   instance_type        = "${var.instance_type}"
-  key_name             = "${var.ssh_key}"
+  key_name             = "${aws_key_pair.core.key_name}"
   count                = "${var.additional_masters}"
   iam_instance_profile = "${aws_iam_instance_profile.bk_profile.id}"
 

--- a/hack/terraform-quickstart/variables.tf
+++ b/hack/terraform-quickstart/variables.tf
@@ -6,8 +6,8 @@ variable "access_key" {
   type = "string"
 }
 
-variable "ssh_key" {
-  description = "aws ssh key"
+variable "ssh_public_key" {
+  description = "SSH Public Key"
   type        = "string"
 }
 
@@ -18,7 +18,7 @@ variable "resource_owner" {
 }
 
 variable "instance_type" {
-  description = "Name all instances behind a single tag based on who/what is running terraform"
+  description = "Instance type"
   type        = "string"
   default     = "m3.medium"
 }


### PR DESCRIPTION
Adds a new tree `hack/jenkins` to the tree:

```
hack/jenkins
├── images
│   └── bootkube-e2e
│       └── Dockerfile
├── jobs
│   └── bootkube_e2e.groovy
├── pipelines
│   └── bootkube-e2e
│       └── Jenkinsfile
└── scripts
    ├── e2e.sh
    ├── tqs-down.sh
    └── tqs-up.sh
```

This holds the majority of the configuration for all bootkube jobs. (Somethings are captured in our Jenkins configuration repo, instead of here, because they are "global" settings. With rare exception, all job-specific config is and belongs here.)

The jobs added here, `bootkube-e2e-{calico,flannel}` will execute on Kubernetes agents. This was chosen to minimize the amount of special care needed on the hosts. Even for a fairly self-contained project like `bootkube`, there is value in having a container with known-good versions of tools in place. Fortunately, if we need docker or something, we have a number of options, including provisioning "physical" agents, but I'd strongly prefer to avoid this.

This change will also enable easier testing to changes in our tests. Rarely should changes ever need to be made to the initial job Job DSL description, as most of the test logic is fully encoded in the Jenksfile or shell scripts. Thus a PR can modify them and the modifications will be tested as part of the test run. One could radically re-organize the hack/terraform/quickstart configs, for example, and still get test passes without needing manual merges or modifications to the Jenkins instance.

There's just a couple TODOs in here: changing the repo/bot accounts (will be done in a followup), as well as one last enhancement I'd like to make to `tqs-up.sh` to fully remove the `ssh-agent` stuff.