### PR TITLE
jenkins: update development readme with trigger information

### DIFF
--- a/Documentation/development.md
+++ b/Documentation/development.md
@@ -46,7 +46,20 @@ make conformance-single
 make conformance-multi
 ```
 
+
 ## Running PR Tests
+
+The basic test suite should run automatically on PRs, but can also be triggered manually.
+
+Jobs prefixed with `tku-` are running on the new Jenkins instance.
+
+Commenting on the PR:
+
+-   `ok to test`: whitelists an external contributor's PR as safe to test.
+-   `coreosbot run [job_name]`: re-runs the named job. The job name is always the same as the build context reported to GitHub. So if there is a failed build for `tku-bootkube-e2e-calico`, you can re-trigger it by commenting, `coreosbot run tku-bootkube-e2e-calico`.
+
+
+## Running PR Tests (legacy Jenkins)
 
 The basic test suite should run automatically on PRs, but can also be triggered manually.
 

--- a/hack/jenkins/README.md
+++ b/hack/jenkins/README.md
@@ -56,5 +56,5 @@ This shows an example directory structure, added as part of the `bootkube-e2e-*`
 ### Currently Defined Jobs
 
 -   bootkube-e2e-\*
-    -   calico: tests a standard multi-master bootkube cluster with calico
-    -   flannel: tests a standard multi-master bootkube cluster with flannel
+    -   calico: tests a standard single-master bootkube cluster with calico
+    -   flannel: tests a standard single-master bootkube cluster with flannel


### PR DESCRIPTION
Update:
* `Documentation/development.md` - mention the commands for new jobs
* `hack/jenkins/README.md` - correct bootkube-e2e-* job descriptions