### PR TITLE
jenkins: allow user to override repo_url

### DIFF
--- a/hack/jenkins/jobs/bootkube_e2e.groovy
+++ b/hack/jenkins/jobs/bootkube_e2e.groovy
@@ -1,11 +1,10 @@
 // META
-job_dir = 'bootkube'
+default_repo = "kubernetes-incubator/bootkube"
 
 // CONFIG
-fork_to_use = 'kubernetes-incubator'
+org_whitelist = ['coreos', 'coreos-inc']
 job_admins = ['colemickens', 'ericchiang', 'rithujohn191', 'rphillips']
 user_whitelist = job_admins
-org_whitelist = ['coreos', 'coreos-inc']
 
 // JOBS
 network_providers = ['flannel', 'calico']
@@ -17,6 +16,7 @@ network_providers.each { np ->
   pipelineJob(job_name) {
     parameters {
       stringParam('sha1', 'origin/master', 'git reference to build')
+      stringParam('repo', default_repo,    'git repo url to pull from')
     }
     definition {
       triggers {
@@ -46,8 +46,8 @@ network_providers.each { np ->
         scm {
           git {
             remote {
-              github("${fork_to_use}/bootkube")
-              refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+              github('${repo}')
+              refspec('+refs/heads/*:refs/remotes/origin/*')
               credentials('github_userpass')
             }
             branch('${sha1}')


### PR DESCRIPTION
This is just a bit of additional flexibility, but this will enable privileged users to queue jobs with their own repositories, so they can test before sending PRs.

Demo, for those that have access: https://jenkins-kube-upstream.prod.coreos.systems/job/tku-bootkube-e2e-calico/parambuild?sha1=origin/psp&repo_url=https%3A%2F%2Fgithub.com%2Fericchiang%2Fbootkube.git