### PR TITLE
Jenkins: Collect e2e logs & archive in public S3 bucket

### DIFF
--- a/hack/jenkins/jobs/bootkube_e2e.groovy
+++ b/hack/jenkins/jobs/bootkube_e2e.groovy
@@ -30,6 +30,8 @@ network_providers.each { np ->
 
           extensions {
             commitStatus {
+              // TODO: this is dependent on this merging, or using my fork: https://github.com/awslabs/aws-js-s3-explorer/pull/16
+              statusUrl('https://bootkube-pr-logs.s3-us-west-2.amazonaws.com/index.html#pr/${JOB_NAME}-${BUILD_NUMBER}/')
               context(job_name)
               triggeredStatus('e2e triggered')
               startedStatus('e2e started')

--- a/hack/jenkins/pipelines/bootkube-e2e/Jenkinsfile
+++ b/hack/jenkins/pipelines/bootkube-e2e/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
   environment {
     CLUSTER_NAME="${JOB_NAME}-${BUILD_NUMBER}"
     ARTIFACT_DIR="${WORKSPACE}/artifacts"
+    REGION = "us-west-2"
     GOPATH = "${WORKSPACE}"
     WORKDIR = "${WORKSPACE}/src/github.com/kubernetes-incubator/bootkube"
     KUBECONFIG = "${WORKSPACE}/src/github.com/kubernetes-incubator/bootkube/hack/quickstart/cluster/auth/kubeconfig"
@@ -45,25 +46,29 @@ pipeline {
     stage('build') {
       steps {
         dir("${WORKDIR}") {
-          sh "make release"
+          sh "make release |& tee -a ${ARTIFACT_DIR}/build.log"
         }
       }
     }
     stage('deploy') {
       steps {
         dir("${WORKDIR}") {
-          sh "./hack/jenkins/scripts/tqs-up.sh"
+          sh "./hack/jenkins/scripts/tqs-up.sh |& tee -a ${ARTIFACT_DIR}/deploy.log"
         }
       }
     }
     stage('e2e') {
       steps {
         dir("${WORKDIR}") {
-          sh "./hack/jenkins/scripts/e2e.sh"
+          sh "./hack/jenkins/scripts/e2e.sh |& tee -a ${ARTIFACT_DIR}/e2e.log"
         }
       }
     }
   }
+  // Notes about the post/always stage(s):
+  // We are breaking the seal and using a script{} block for better management of "stages"
+  // and so that additional actions are available. There is "<cmd> || true" used below, so
+  // that a script failure doesn't prevent teardown/cleanup/log-upload/etc as much as possible.
   post {
     always {
       script {
@@ -77,6 +82,13 @@ pipeline {
         stage('archive-logs') {
           dir("${ARTIFACT_DIR}") {
             archiveArtifacts '**/*'
+            withAWS(credentials: 'aws', region: "${REGION}") {
+              sh "tar -czf /tmp/artifacts.tar.gz ."
+              sh "mv /tmp/artifacts.tar.gz \"${ARTIFACT_DIR}/artifacts-${JOB_NAME}-${BUILD_NUMBER}.tar.gz\""
+              // note: do not use includepathpattern! https://issues.jenkins-ci.org/browse/JENKINS-47046
+              s3Upload(acl: 'PublicRead', bucket: 'bootkube-pr-logs', path: "pr/${JOB_NAME}-${BUILD_NUMBER}/",
+                file: "${ARTIFACT_DIR}")
+            }
           }
         }
       }

--- a/hack/jenkins/pipelines/bootkube-e2e/Jenkinsfile
+++ b/hack/jenkins/pipelines/bootkube-e2e/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
   }
   environment {
     CLUSTER_NAME="${JOB_NAME}-${BUILD_NUMBER}"
+    ARTIFACT_DIR="${WORKSPACE}/artifacts"
     GOPATH = "${WORKSPACE}"
     WORKDIR = "${WORKSPACE}/src/github.com/kubernetes-incubator/bootkube"
     KUBECONFIG = "${WORKSPACE}/src/github.com/kubernetes-incubator/bootkube/hack/quickstart/cluster/auth/kubeconfig"
@@ -35,6 +36,7 @@ pipeline {
       steps {
         // jnlp slave runs as "jenkins" user, use the escape hatch. (https://hub.docker.com/r/jenkins/slave/~/dockerfile/)
         sh "chmod -R go+rw /home/jenkins"
+        sh "mkdir -p \"${ARTIFACT_DIR}\""
         dir("${WORKDIR}") {
           checkout scm
         }
@@ -64,10 +66,17 @@ pipeline {
   }
   post {
     always {
-      script { // break the seal so that we can put cleanup in a stage
+      script {
+        stage('collect-logs') {
+          sh "${WORKDIR}/hack/jenkins/scripts/gather-logs.sh || true"
+          sh """bash -c "cp -r ${WORKDIR}/hack/quickstart/logs-** ${ARTIFACT_DIR}/";"""
+        }
         stage('cleanup') {
-          dir("${WORKDIR}") {
-            sh "./hack/jenkins/scripts/tqs-down.sh"
+          sh "(${WORKDIR}/hack/jenkins/scripts/tqs-down.sh || true) |& tee -a ${ARTIFACT_DIR}/cleanup.log"
+        }
+        stage('archive-logs') {
+          dir("${ARTIFACT_DIR}") {
+            archiveArtifacts '**/*'
           }
         }
       }

--- a/hack/jenkins/scripts/gather-logs.sh
+++ b/hack/jenkins/scripts/gather-logs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+set -x
+set -euo pipefail
+
+export IDENT="${IDENT:-"${HOME}/.ssh/id_rsa"}"
+
+cd ${DIR}/../../terraform-quickstart/
+
+# TODO: unclear why ssh-agent isn't still running from tqs-up.sh...
+if [ -z "${SSH_AUTH_SOCK:-}" ] ; then
+  ssh-agent -s > "/tmp/bootkube-tqs-sshagent.env"
+  source "/tmp/bootkube-tqs-sshagent.env"
+  ssh-add "${IDENT}"
+fi
+
+./genlogs.sh
+./copylogs.sh

--- a/hack/jenkins/scripts/tqs-down.sh
+++ b/hack/jenkins/scripts/tqs-down.sh
@@ -12,8 +12,10 @@ export IDENT="${IDENT:-"${HOME}/.ssh/id_rsa"}"
 
 cd "${DIR}/../../terraform-quickstart"
 
+set +x
 export TF_VAR_access_key_id="${ACCESS_KEY_ID}"
 export TF_VAR_access_key="${ACCESS_KEY_SECRET}"
+set -x
 export TF_VAR_resource_owner="${CLUSTER_NAME}"
 export TF_VAR_ssh_public_key="$(cat "${IDENT}.pub")"
 export TF_VAR_additional_masters="${ADDITIONAL_MASTERS}"

--- a/hack/jenkins/scripts/tqs-up.sh
+++ b/hack/jenkins/scripts/tqs-up.sh
@@ -23,8 +23,10 @@ if [ -z "${SSH_AUTH_SOCK:-}" ] ; then
   ssh-add "${IDENT}"
 fi
 
+set +x
 export TF_VAR_access_key_id="${ACCESS_KEY_ID}"
 export TF_VAR_access_key="${ACCESS_KEY_SECRET}"
+set -x
 export TF_VAR_resource_owner="${CLUSTER_NAME}"
 export TF_VAR_ssh_public_key="$(cat "${IDENT}.pub")"
 export TF_VAR_additional_masters="${ADDITIONAL_MASTERS}"


### PR DESCRIPTION
jenkins: bootkube-e2e: collect, archive logs:
* Collects systemd+docker logs from the machines, as the existing Jenkins was doing.
* Archives all artifacts at the end, making them easily accessible from the job UI

jenkins: bootkube-e2e: upload logs to s3:
* Tees into log files in each stage (Jenkins makes it impossible to get the raw build log in a declarative pipeline from scm job, this was the best option I could come up with)
* Makes a `tar.gz` of all archived assets.
* Uploads the archived assets, and the `tar.gz` (convenience) in a public s3 bucket
* Sets the commit status to point to the public s3 bucket instead of to our private Jenkins