### PR TITLE
jenkins: bootkube-e2e: groovy interpolate repo name at job creation time

### DIFF
--- a/hack/jenkins/jobs/bootkube_e2e.groovy
+++ b/hack/jenkins/jobs/bootkube_e2e.groovy
@@ -1,5 +1,5 @@
 // META
-default_repo = "kubernetes-incubator/bootkube"
+repo = "kubernetes-incubator/bootkube"
 
 // CONFIG
 org_whitelist = ['coreos', 'coreos-inc']
@@ -16,7 +16,6 @@ network_providers.each { np ->
   pipelineJob(job_name) {
     parameters {
       stringParam('sha1', 'origin/master', 'git reference to build')
-      stringParam('repo', default_repo,    'git repo url to pull from')
     }
     definition {
       triggers {
@@ -48,8 +47,8 @@ network_providers.each { np ->
         scm {
           git {
             remote {
-              github('${repo}')
-              refspec('+refs/heads/*:refs/remotes/origin/*')
+              github("${repo}")
+              refspec('+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/*')
               credentials('github_userpass')
             }
             branch('${sha1}')


### PR DESCRIPTION
I was hoping to "late" interpolate the repo name in, but it's unnecessary for allowing users to run jobs on un-pushed PRs, /and/ it breaks GHPRB.

So, interpolate it when Job DSL runs and creates the job, instead of allowing the placeholder to flow into the job.

cc: @rithujohn191 