### PR TITLE
jenkins: prevent resource leak when log agg fails

### DIFF
--- a/hack/jenkins/pipelines/bootkube-e2e/Jenkinsfile
+++ b/hack/jenkins/pipelines/bootkube-e2e/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
       script {
         stage('collect-logs') {
           sh "${WORKDIR}/hack/jenkins/scripts/gather-logs.sh || true"
-          sh """bash -c "cp -r ${WORKDIR}/hack/quickstart/logs-** ${ARTIFACT_DIR}/";"""
+          sh """bash -c "cp -r ${WORKDIR}/hack/quickstart/logs-** ${ARTIFACT_DIR}/ || true";"""
         }
         stage('cleanup') {
           sh "(${WORKDIR}/hack/jenkins/scripts/tqs-down.sh || true) |& tee -a ${ARTIFACT_DIR}/cleanup.log"


### PR DESCRIPTION
Just noticed a tiny bit of resource leakage in Jenkins (https://jenkins-kube-upstream.prod.coreos.systems/job/tku-bootkube-e2e-flannel/78/console). This should prevent that.

cc: @rithujohn191 @rphillips 