### PR TITLE
pkg/asset: update checkpointer to include CRI v1alpha2 support

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -11,5 +11,5 @@ var DefaultImages = ImageVersions{
 	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.8",
 	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8",
 	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8",
-	PodCheckpointer: "quay.io/coreos/pod-checkpointer:3cd08279c564e95c8b42a0b97c073522d4a6b965",
+	PodCheckpointer: "quay.io/coreos/pod-checkpointer:9dc83e1ab3bc36ca25c9f7c18ddef1b91d4a0558",
 }


### PR DESCRIPTION
Closes https://github.com/kubernetes-incubator/bootkube/issues/934

cc @colemickens 

**Upgrade note:** Users MUST update their checkpointer before updating to Kubernetes v1.10