### PR TITLE
OWNERS: Update the doc reference

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,5 @@
 # See the OWNERS file documentation:
-#  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
+#  https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
 
 approvers:
   - aaronlevy


### PR DESCRIPTION
The old reference was removed in kubernetes/kubernetes#48029.  Before that removal it [had been pointing][0] at [community's `devel/owners.md`][1].  [community's `devel/owners.md`][1] is currently a stub itself, pointing at [community's `guide/owners.md`][2], which has (for now?) the real docs.

[0]: https://github.com/kubernetes/kubernetes/pull/48029/files#diff-f3af94ed8de81012aae465b1863344dfL1
[1]: https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
[2]: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md