### PR TITLE
Makefile: Drop GO15VENDOREXPERIMENT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-export GO15VENDOREXPERIMENT:=1
 export CGO_ENABLED:=0
 export GOARCH:=amd64
 export PATH:=$(PATH):$(PWD)


### PR DESCRIPTION
This [became the default behavior in Go 1.6 and the switch was dropped in Go 1.7][1].  We've required Go 1.8+ since at least #775, so there's no need to set the switch anymore.

[1]: https://blog.golang.org/go1.7