### PR TITLE
Makefile: Drop hard-coded Bash and simplify gofmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export GOARCH:=amd64
 export PATH:=$(PATH):$(PWD)
 
 LOCAL_OS:=$(shell uname | tr A-Z a-z)
-GOFILES:=$(shell find . -name '*.go' | grep -v -E '(./vendor)')
+GOFILES:=$(shell find . -name '*.go' ! -path './vendor/*')
 LDFLAGS=-X github.com/kubernetes-incubator/bootkube/pkg/version.Version=$(shell $(CURDIR)/build/git-version.sh)
 TERRAFORM:=$(shell command -v terraform 2> /dev/null)
 

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ release: \
 	check \
 	_output/release/bootkube.tar.gz \
 
-check:
-	@gofmt -l -s $(GOFILES) | read; if [ $$? == 0 ]; then gofmt -s -d $(GOFILES); exit 1; fi
+check: gofmt
 ifdef TERRAFORM
 	$(TERRAFORM) fmt -check ; if [ ! $$? -eq 0 ]; then exit 1; fi
 else
@@ -37,6 +36,10 @@ endif
 	@go vet $(shell go list ./... | grep -v '/vendor/')
 	@./scripts/verify-gopkg.sh
 	@go test -v $(shell go list ./... | grep -v '/vendor/\|/e2e')
+
+gofmt:
+	gofmt -s -w $(GOFILES)
+	git diff --exit-code
 
 install:
 	go install -ldflags "$(LDFLAGS)" ./cmd/bootkube
@@ -80,4 +83,4 @@ vendor:
 clean:
 	rm -rf _output
 
-.PHONY: all check clean install release vendor
+.PHONY: all check clean gofmt install release vendor

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ export CGO_ENABLED:=0
 export GOARCH:=amd64
 export PATH:=$(PATH):$(PWD)
 
-SHELL:=$(shell which bash)
 LOCAL_OS:=$(shell uname | tr A-Z a-z)
 GOFILES:=$(shell find . -name '*.go' | grep -v -E '(./vendor)')
 LDFLAGS=-X github.com/kubernetes-incubator/bootkube/pkg/version.Version=$(shell $(CURDIR)/build/git-version.sh)


### PR DESCRIPTION
I'm reverting #870 here and also removing the code that seemed to have motivated it.  Details on the individual changes in the commit messages.  The `find` commit is something of a drive-by; I'm happy to split it out into its own pull request if that would make review easier.