### PR TITLE
Makefile: Respect GOBIN

### DIFF
--- a/Documentation/development.md
+++ b/Documentation/development.md
@@ -3,15 +3,14 @@
 ## Requirements
 
 * Go 1.10+
-* Configured [GOPATH](http://golang.org/doc/code.html#GOPATH)
 
 ## Building
 
-First, clone the repo into the proper location in your $GOPATH:
+First, clone the repo into the proper location in your [`GOPATH`][GOPATH]:
 
 ```
 go get -u github.com/kubernetes-incubator/bootkube
-cd $GOPATH/src/github.com/kubernetes-incubator/bootkube
+cd $(go env GOPATH | cut -d: -f1)/src/github.com/kubernetes-incubator/bootkube
 ```
 
 Then build:
@@ -71,3 +70,5 @@ Commenting on the PR:
 * `coreosbot run e2e checkpointer`: can be used to specifically test new checkpointer code.
     * This will build a new checkpointer image from the PR, and includes that image as part of the checkpointer daemonset.
 * `coreosbot run conformance`: run upstream Kubernetes conformance tests
+
+[GOPATH]: https://golang.org/cmd/go/#hdr-GOPATH_environment_variable

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ export PATH:=$(PATH):$(PWD)
 SHELL:=$(shell which bash)
 LOCAL_OS:=$(shell uname | tr A-Z a-z)
 GOFILES:=$(shell find . -name '*.go' | grep -v -E '(./vendor)')
-GOPATH_BIN:=$(shell echo ${GOPATH} | awk 'BEGIN { FS = ":" }; { print $1 }')/bin
+GOPATH ?= $(shell go env GOPATH)
+PRIMARY_GOPATH ?= $(shell echo ${GOPATH} | cut -d : -f 1)
+GOBIN ?= $(PRIMARY_GOPATH)/bin
 LDFLAGS=-X github.com/kubernetes-incubator/bootkube/pkg/version.Version=$(shell $(CURDIR)/build/git-version.sh)
 TERRAFORM:=$(shell command -v terraform 2> /dev/null)
 
@@ -41,7 +43,7 @@ endif
 	@go test -v $(shell go list ./... | grep -v '/vendor/\|/e2e')
 
 install: _output/bin/$(LOCAL_OS)/bootkube
-	cp $< $(GOPATH_BIN)
+	cp $< $(GOBIN)
 
 _output/bin/%: GOOS=$(word 1, $(subst /, ,$*))
 _output/bin/%: GOARCH=$(word 2, $(subst /, ,$*))


### PR DESCRIPTION
`GOBIN` (documented [here][1]) defaults to `DIR/bin`, but it's a configurable variable in its own right.  This command updates our calculations, using `?=` (documented [here][2]) to avoid expensive shell operations when we don't actually need the result (because a different target was called or because the user provided their own value).

I've also used `go env GOPATH` to get the ([platform-specific][1]) default value when the environment variable is not set.

And I've used [`cut`][3] instead of [`awk`][4] to pull out the first component of `GOPATH`.  Both are in POSIX, but `cut` is a simpler tool for this particular problem.

This will have trivial context conflicts with the in-flight #948.  I'm happy to rebase the other if/when one of them lands.

[1]: https://golang.org/cmd/go/#hdr-GOPATH_environment_variable
[2]: https://www.gnu.org/software/make/manual/html_node/Setting.html
[3]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/cut.html
[4]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/awk.html