### PR TITLE
Makefile: Remove clean prerequisites from build targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ before_script:
 go:
   - 1.10.x
 script:
-  - make clean release
+  - make release

--- a/Documentation/development.md
+++ b/Documentation/development.md
@@ -16,20 +16,23 @@ cd $(go env GOPATH | cut -d: -f1)/src/github.com/kubernetes-incubator/bootkube
 Then build:
 
 ```
-make clean all
+make clean
+make all
 ```
 
 ## Local Development Environments
 
-To easily launch local vagrant development clusters:
+To easily launch local, single-node vagrant development clusters:
 
 ```
-# Launch a single-node cluster
+make clean-vm-single
 make run-single
 ```
 
+You can also launch a multi-node cluster:
+
 ```
-# Launch a multi-node cluster
+make clean-vm-multi
 make run-multi
 ```
 


### PR DESCRIPTION
The `clean` target has been included there since 1f346000 (#46).  But `clean` has been a `release` prerequisite since 04848d13 (#47), so the `.travis.yml` entry is redundant.