### PR TITLE
build/git-version: Only call 'git' once

### DIFF
--- a/build/git-version.sh
+++ b/build/git-version.sh
@@ -1,22 +1,4 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
 
-# parse the current git commit hash
-COMMIT=$(git rev-parse HEAD)
-
-# check if the current commit has a matching tag
-TAG=$(git describe --exact-match --abbrev=0 --tags ${COMMIT} 2> /dev/null || true)
-
-# use the matching tag as the version, if available
-if [ -z "$TAG" ]; then
-    VERSION=$COMMIT
-else
-    VERSION=$TAG
-fi
-
-# check for changed files (not untracked files)
-if [ -n "$(git diff --shortstat 2> /dev/null | tail -n1)" ]; then
-    VERSION="${VERSION}-dirty"
-fi
-
-echo $VERSION
+DESCRIPTION=$(git describe --abbrev=100 --dirty) &&
+echo "${DESCRIPTION##*-g}"


### PR DESCRIPTION
Simplify the logic from #47 to:

* Move from Bash to a generic POSIX shell.  This makes the script more portable (it will work on POSIX systems without Bash).  It does mean we need to drop the `set` (which [is not in POSIX][1]), but that's not a major problem because:

    * We can use `&&`-chaining instead of `set -e`.
    * We do only have the one locally-defined variable, so we don't need `set -u`.
    * The simpler logic has no pipes, so `set -o pipefail` would no longer matter.

* Replace the previous multiple Git calls with a single call to `git describe`.

    * Use `--dirty` so we can drop the previous `diff` call.

    * Drop `--tags`, because we don't want to use lightweight (non-annotated) tags.  We want to use annotated tags, because we want to use signed release tags.  There's no code check for tag signatures here, but [`RELEASING.md` requests `tag -s vX.Y.Z`][1.5], which will create signed, annotated tags.

    * Git's SHA-1 hashes are 40 hex digits, but I've used `--abbrev=100` to get unabbreviated hashes even in the face of [future hash transitions][2].  This is a bit of a hack compared to the previous approach, because at some point Git may have >100-char hashes. But if that happens, it will be far enough in the future that I think the simplification we get here is worth it (and this constant is easy to bump if we need to).

    * The new call always returns the most recent tag, and (for commits which are not exact tag matches) also includes the abbreviated commit.  To isolate the hash (and possible dirty-mark) for commits that are not exact tags, I use [POSIX's `${parameter##[word]}` prefix-pattern removal][3].  Exact tags are unlikely to include `-g` (unless it is in the tag itself), so for them the prefix-removal is a no-op.  Again, this is a bit of a hack, since a tag might include `-g`, but I think that's unlikely enough (as mentioned above, [`RELEASING.md` requests `vX.Y.Z` for tags][1.5]) that the simplification we get here is worth it.

Fixes #132.

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html
[1.5]: https://github.com/kubernetes-incubator/bootkube/blob/fbcb6802f4b9dd181784914b758e3abc1f58d38c/RELEASING.md#tag-a-release
[2]: https://github.com/git/git/blob/v2.16.3/Documentation/technical/hash-function-transition.txt
[3]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02