### PR TITLE
Documentation/development: Bump minimum Go version to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ before_script:
   - unzip terraform_0.11.3_linux_amd64.zip
   - export PATH=$PWD:$PATH
 go:
-  - 1.9.x
   - 1.10.x
 script:
   - make clean release

--- a/Documentation/development.md
+++ b/Documentation/development.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-* Go 1.8+
+* Go 1.10+
 * Configured [GOPATH](http://golang.org/doc/code.html#GOPATH)
 
 ## Building
@@ -14,7 +14,7 @@ go get -u github.com/kubernetes-incubator/bootkube
 cd $GOPATH/src/github.com/kubernetes-incubator/bootkube
 ```
 
-Then, to build (only Go verson 1.8 is supported now):
+Then build:
 
 ```
 make clean all


### PR DESCRIPTION
This [gets us][2] a fixed `CGO_ENABLED=0 go install`][1] and avoids 1.8 (which is [no longer supported upstream now that 1.10 has been released][3]).

I've also dropped the version information from the build comment (it's mentioned just before in the “Requirements” section) to DRY things up a bit.

[1]: https://github.com/golang/go/issues/18981
[2]: https://github.com/golang/go/commit/8f70e1f8a91
[3]: https://golang.org/doc/devel/release.html#policy