### PR TITLE
Makefile: Actually use 'go install ...' for the install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,6 @@ export PATH:=$(PATH):$(PWD)
 SHELL:=$(shell which bash)
 LOCAL_OS:=$(shell uname | tr A-Z a-z)
 GOFILES:=$(shell find . -name '*.go' | grep -v -E '(./vendor)')
-GOPATH ?= $(shell go env GOPATH)
-PRIMARY_GOPATH ?= $(shell echo ${GOPATH} | cut -d : -f 1)
-GOBIN ?= $(PRIMARY_GOPATH)/bin
 LDFLAGS=-X github.com/kubernetes-incubator/bootkube/pkg/version.Version=$(shell $(CURDIR)/build/git-version.sh)
 TERRAFORM:=$(shell command -v terraform 2> /dev/null)
 
@@ -42,8 +39,8 @@ endif
 	@./scripts/verify-gopkg.sh
 	@go test -v $(shell go list ./... | grep -v '/vendor/\|/e2e')
 
-install: _output/bin/$(LOCAL_OS)/bootkube
-	cp $< $(GOBIN)
+install:
+	go install -ldflags "$(LDFLAGS)" ./cmd/bootkube
 
 _output/bin/%: GOOS=$(word 1, $(subst /, ,$*))
 _output/bin/%: GOARCH=$(word 2, $(subst /, ,$*))


### PR DESCRIPTION
This was my intention with #949, but I seem to have missed the actual code :/.  Instead, that pull-request landed an earlier implementation which we intended to drop based on #949 [review][1].

This commit has the intended implementation.  For detailed motivation, see the description in dbf0b6a5.

[1]: https://github.com/kubernetes-incubator/bootkube/pull/949#issuecomment-378292372