### PR TITLE
Replace Jenkins `sh` with a `bash` step that sets `set -euo pipefail`

### DIFF
--- a/hack/jenkins/pipelines/bootkube-e2e/Jenkinsfile
+++ b/hack/jenkins/pipelines/bootkube-e2e/Jenkinsfile
@@ -1,5 +1,7 @@
 // Declarative Pipeline (used by `bootkube-e2e-*` jobs)
 
+def bash(String cmd) { sh("#/usr/bin/env bash\nset -euo pipefail\n${cmd}") }
+
 pipeline {
   agent {
     kubernetes {
@@ -37,8 +39,8 @@ pipeline {
     stage('checkout') {
       steps {
         // jnlp slave runs as "jenkins" user, use the escape hatch. (https://hub.docker.com/r/jenkins/slave/~/dockerfile/)
-        sh "chmod -R go+rw /home/jenkins"
-        sh "mkdir -p \"${ARTIFACT_DIR}\""
+        bash "chmod -R go+rw /home/jenkins"
+        bash "mkdir -p \"${ARTIFACT_DIR}\""
         dir("${WORKDIR}") {
           checkout scm
         }
@@ -47,21 +49,21 @@ pipeline {
     stage('build') {
       steps {
         dir("${WORKDIR}") {
-          sh "make release |& tee -a ${ARTIFACT_DIR}/build.log"
+          bash "make release |& tee -a ${ARTIFACT_DIR}/build.log"
         }
       }
     }
     stage('deploy') {
       steps {
         dir("${WORKDIR}") {
-          sh "./hack/jenkins/scripts/tqs-up.sh |& tee -a ${ARTIFACT_DIR}/deploy.log"
+          bash "./hack/jenkins/scripts/tqs-up.sh |& tee -a ${ARTIFACT_DIR}/deploy.log"
         }
       }
     }
     stage('e2e') {
       steps {
         dir("${WORKDIR}") {
-          sh "./hack/jenkins/scripts/e2e.sh |& tee -a ${ARTIFACT_DIR}/e2e.log"
+          bash "./hack/jenkins/scripts/e2e.sh |& tee -a ${ARTIFACT_DIR}/e2e.log"
         }
       }
     }
@@ -74,18 +76,18 @@ pipeline {
     always {
       script {
         stage('collect-logs') {
-          sh "${WORKDIR}/hack/jenkins/scripts/gather-logs.sh || true"
-          sh """bash -c "cp -r ${WORKDIR}/hack/quickstart/logs-** ${ARTIFACT_DIR}/ || true";"""
+          bash "${WORKDIR}/hack/jenkins/scripts/gather-logs.sh || true"
+          bash "cp -r ${WORKDIR}/hack/quickstart/logs-** ${ARTIFACT_DIR}/ || true"
         }
         stage('cleanup') {
-          sh "(${WORKDIR}/hack/jenkins/scripts/tqs-down.sh || true) |& tee -a ${ARTIFACT_DIR}/cleanup.log"
+          bash "(${WORKDIR}/hack/jenkins/scripts/tqs-down.sh || true) |& tee -a ${ARTIFACT_DIR}/cleanup.log"
         }
         stage('archive-logs') {
           dir("${ARTIFACT_DIR}") {
             archiveArtifacts '**/*'
             withAWS(credentials: 'aws', region: "${REGION}") {
-              sh "tar -czf /tmp/artifacts.tar.gz ."
-              sh "mv /tmp/artifacts.tar.gz \"${ARTIFACT_DIR}/artifacts-${JOB_NAME}-${BUILD_NUMBER}.tar.gz\""
+              bash "tar -czf /tmp/artifacts.tar.gz ."
+              bash "mv /tmp/artifacts.tar.gz \"${ARTIFACT_DIR}/artifacts-${JOB_NAME}-${BUILD_NUMBER}.tar.gz\""
               // note: do not use includepathpattern! https://issues.jenkins-ci.org/browse/JENKINS-47046
               s3Upload(acl: 'PublicRead', bucket: 'bootkube-pr-logs', path: "pr/${JOB_NAME}-${BUILD_NUMBER}/",
                 file: "${ARTIFACT_DIR}")

--- a/hack/jenkins/pipelines/hyperkube-release/Jenkinsfile
+++ b/hack/jenkins/pipelines/hyperkube-release/Jenkinsfile
@@ -1,3 +1,4 @@
+def bash(String cmd) { sh("#/usr/bin/env bash\nset -euo pipefail\n${cmd}") }
 
 podTemplate(label: 'hyperkube-build',
   containers: [containerTemplate(name: 'build', image: 'quay.io/coreos/hyperkube-builder:0.2', ttyEnabled: true, command: 'cat')],
@@ -8,20 +9,20 @@ podTemplate(label: 'hyperkube-build',
       git 'https://github.com/coreos/kubernetes.git'
       container('build') {
         withCredentials([usernamePassword(credentialsId: 'quay_userpass', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
-          sh '''
-             export IMAGE_TAG=$(echo ${KUBERNETES_VERSION} | tr + _)
+          bash '''
+              export IMAGE_TAG=$(echo ${KUBERNETES_VERSION} | tr + _)
 
-             git checkout ${KUBERNETES_VERSION}
-             build/run.sh make cross ARCH=amd64 KUBE_FASTBUILD=true WHAT=cmd/hyperkube
-             pushd cluster/images/hyperkube && make VERSION=$(IMAGE_TAG) REGISTRY=quay.io/coreos && popd
-             docker tag quay.io/coreos/hyperkube-amd64:$IMAGE_TAG quay.io/coreos/hyperkube:$IMAGE_TAG
-             docker images
-             if [ "$PUSH_IMAGE" = true ] && ! docker pull quay.io/coreos/hyperkube:$IMAGE_TAG ; then
-                 set +x # don't log passwords
-                 docker login quay.io --username $DOCKER_USER --password $DOCKER_PASS
-                 docker push quay.io/coreos/hyperkube:$IMAGE_TAG
-                 wget https://quay.io/c1/aci/quay.io/coreos/hyperkube/$IMAGE_TAG/aci/linux/amd64/ # warm cache before it gets hit in parallel
-             fi
+              git checkout ${KUBERNETES_VERSION}
+              build/run.sh make cross ARCH=amd64 KUBE_FASTBUILD=true WHAT=cmd/hyperkube
+              pushd cluster/images/hyperkube && make VERSION=$(IMAGE_TAG) REGISTRY=quay.io/coreos && popd
+              docker tag quay.io/coreos/hyperkube-amd64:$IMAGE_TAG quay.io/coreos/hyperkube:$IMAGE_TAG
+              docker images
+              if [ "$PUSH_IMAGE" = true ] && ! docker pull quay.io/coreos/hyperkube:$IMAGE_TAG ; then
+                  set +x # don't log passwords
+                  docker login quay.io --username $DOCKER_USER --password $DOCKER_PASS
+                  docker push quay.io/coreos/hyperkube:$IMAGE_TAG
+                  wget https://quay.io/c1/aci/quay.io/coreos/hyperkube/$IMAGE_TAG/aci/linux/amd64/ # warm cache before it gets hit in parallel
+              fi
           '''
         }
       }


### PR DESCRIPTION
Jenkins is currently marking stages with failing scripts as "succeeded". It looks like this is happening because of our piping into `tee`.

Replace `sh` with a new, custom `bash` step that will `set -euo pipefail` initially to safely run scripts and surface failures correctly.