### PR TITLE
Makefile: Use 'go env GOOS' instead of uname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ export CGO_ENABLED:=0
 export GOARCH:=amd64
 export PATH:=$(PATH):$(PWD)
 
-LOCAL_OS:=$(shell uname | tr A-Z a-z)
+GOOS ?= $(shell go env GOOS)
 GOFILES:=$(shell find . -name '*.go' ! -path './vendor/*')
 LDFLAGS=-X github.com/kubernetes-incubator/bootkube/pkg/version.Version=$(shell $(CURDIR)/build/git-version.sh)
 TERRAFORM:=$(shell command -v terraform 2> /dev/null)
 
 all: \
-	_output/bin/$(LOCAL_OS)/bootkube \
+	_output/bin/$(GOOS)/bootkube \
 	_output/bin/linux/bootkube \
 	_output/bin/linux/checkpoint
 
@@ -56,7 +56,8 @@ _output/release/bootkube.tar.gz: _output/bin/linux/bootkube _output/bin/darwin/b
 	tar czf $@ -C _output bin/linux/bootkube bin/darwin/bootkube bin/linux/checkpoint
 
 run-%: GOFLAGS = -i
-run-%: clean-vm-% _output/bin/linux/bootkube _output/bin/$(LOCAL_OS)/bootkube
+run-%: clean-vm-% _output/bin/linux/bootkube _output/bin/$(GOOS)/bootkube
+	test $(GOOS) = $$(uname | tr A-Z a-z)
 	@cd hack/$*-node && ./bootkube-up
 	@echo "Bootkube ready"
 


### PR DESCRIPTION
And change the variable from `LOCAL_OS` to `GOOS`.

We've been using `uname` for this since `LOCAL_OS` landed in #47, but there's no need to reach outside of Go for this information (one caveat below).  Using `go env` also ensures we get the canonical phrasing without the `tr` pipe.

I'm using [`?=`][1] to avoid an expensive shell operation when we don't actually need the result (because a different target was called or because the user provided their own value).

The `uname`/`tr` → `go env` change affects the `run-%` prereqs if someone calls make with `GOOS` set to a non-native system.  But I don't think that use case is likely, so I've added a guard (with the old `uname`/`tr` logic) to fail it cleanly instead of trying to guess what was intended.

[1]: https://www.gnu.org/software/make/manual/html_node/Setting.html