### PR TITLE
use k8s.gcr.io mirror

### DIFF
--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -8,7 +8,7 @@ coreos:
       content: |
         [Service]
         EnvironmentFile=/etc/environment
-        Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
+        Environment=KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
         Environment=KUBELET_IMAGE_TAG=v1.10.0
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -1,5 +1,5 @@
 [Service]
-Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
+Environment=KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
 Environment=KUBELET_IMAGE_TAG=v1.10.0
 Environment=KUBELET_MINIMUM_CONTAINER_TTL_DURATION=3m0s
 Environment=KUBELET_MAXIMUM_DEAD_CONTAINERS=-1

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -1,5 +1,5 @@
 [Service]
-Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
+Environment=KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
 Environment=KUBELET_IMAGE_TAG=v1.10.0
 Environment=KUBELET_MINIMUM_CONTAINER_TTL_DURATION=3m0s
 Environment=KUBELET_MAXIMUM_DEAD_CONTAINERS=-1

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -8,7 +8,7 @@ coreos:
       content: |
         [Service]
         EnvironmentFile=/etc/environment
-        Environment=KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
+        Environment=KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
         Environment=KUBELET_IMAGE_TAG=v1.10.0
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -7,9 +7,9 @@ var DefaultImages = ImageVersions{
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
 	Calico:          "quay.io/calico/node:v3.0.3",
 	CalicoCNI:       "quay.io/calico/cni:v2.0.0",
-	Hyperkube:       "gcr.io/google_containers/hyperkube:v1.10.0",
-	KubeDNS:         "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.8",
-	KubeDNSMasq:     "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8",
-	KubeDNSSidecar:  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8",
+	Hyperkube:       "k8s.gcr.io/hyperkube:v1.10.0",
+	KubeDNS:         "k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.8",
+	KubeDNSMasq:     "k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8",
+	KubeDNSSidecar:  "k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8",
 	PodCheckpointer: "quay.io/coreos/pod-checkpointer:9dc83e1ab3bc36ca25c9f7c18ddef1b91d4a0558",
 }


### PR DESCRIPTION
gcr.io/google_containers is being deprecated in favor of the k8s.gcr.io domain.