### PR TITLE
pkg/checkpoint: support projected secret/configmap volumes

### DIFF
--- a/pkg/checkpoint/config_map.go
+++ b/pkg/checkpoint/config_map.go
@@ -10,6 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const defaultConfigMapMode = os.FileMode(0600)
+
 // checkpointConfigMapVolumes ensures that all pod configMaps are checkpointed locally, then converts the configMap volume to a hostpath.
 func (c *checkpointer) checkpointConfigMapVolumes(pod *v1.Pod) (*v1.Pod, error) {
 	uid, gid, err := podUserAndGroup(pod)
@@ -50,11 +52,68 @@ func (c *checkpointer) checkpointConfigMap(namespace, podName, configMapName str
 
 	// TODO(aaron): No need to store if already exists
 	for f, d := range configMap.Data {
-		if err := writeAndAtomicRename(filepath.Join(basePath, f), []byte(d), uid, gid, 0600); err != nil {
+		if err := writeAndAtomicRename(filepath.Join(basePath, f), []byte(d), uid, gid, defaultConfigMapMode); err != nil {
 			return "", fmt.Errorf("failed to write configMap %s: %v", configMap.Name, err)
 		}
 	}
 	return basePath, nil
+}
+
+// checkpointConfigMapProjection will locally store configMap data from volumes with ProjectedVolumeSources.
+// The path to the configmap data becomes: checkpointConfigMapPath/namespace/podname/volumename/configmap.file
+// Where each "configmap.file" is a path from the ConfigMapProjection.KeyToPath field.
+func (c *checkpointer) checkpointConfigMapProjection(namespace, podName, volumeName string, configMapProjection *v1.ConfigMapProjection, uid, gid int) error {
+
+	configMapName := configMapProjection.Name
+	isOptional := configMapProjection.Optional != nil && *configMapProjection.Optional
+
+	configMap, err := c.apiserver.Core().ConfigMaps(namespace).Get(configMapName, metav1.GetOptions{})
+	if err != nil && isOptional {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to retrieve configMap %s/%s: %v", namespace, configMapName, err)
+	}
+
+	basePath := configMapPath(namespace, podName, volumeName)
+	if err = os.MkdirAll(basePath, 0700); err != nil {
+		return fmt.Errorf("failed to create configMap checkpoint path %s: %v", basePath, err)
+	}
+	if err = os.Chown(basePath, uid, gid); err != nil {
+		return fmt.Errorf("failed to chown configMap checkpoint path %s: %v", basePath, err)
+	}
+
+	// TODO(aaron): No need to store if already exists
+	for _, item := range configMapProjection.Items {
+		configMapItemKey := item.Key
+		configMapItemMode := defaultConfigMapMode
+		if item.Mode != nil {
+			configMapItemMode = os.FileMode(*item.Mode)
+		}
+		if _, ok := configMap.Data[configMapItemKey]; !ok {
+			if isOptional {
+				continue
+			}
+			return fmt.Errorf("failed to find item %s configMap %s/%s: %v", configMapItemKey, namespace, configMapName, err)
+		}
+		if err := writeAndAtomicRename(filepath.Join(basePath, item.Path), []byte(configMap.Data[configMapItemKey]), uid, gid, configMapItemMode); err != nil {
+			return fmt.Errorf("failed to write configMap %s: %v", configMap.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *checkpointer) checkpointProjectedConfigMaps(namespace, podName, volumeName string, volumeSources []v1.VolumeProjection, uid, gid int) error {
+
+	for _, vp := range volumeSources {
+		err := c.checkpointConfigMapProjection(namespace, podName, volumeName, vp.ConfigMap, uid, gid)
+		if err != nil {
+			return fmt.Errorf("failed to checkpoint projected configMap for pod %s/%s: %v", namespace, podName, err)
+		}
+	}
+
+	return nil
 }
 
 func configMapPath(namespace, podName, configMapName string) string {

--- a/pkg/checkpoint/pod.go
+++ b/pkg/checkpoint/pod.go
@@ -72,6 +72,15 @@ func sanitizeCheckpointPod(cp *v1.Pod) *v1.Pod {
 		} else if v.ConfigMap != nil {
 			v.HostPath = &v1.HostPathVolumeSource{Path: configMapPath(cp.Namespace, cp.Name, v.ConfigMap.Name)}
 			v.ConfigMap = nil
+		} else if v.Projected != nil {
+			// can only currently support projected volumes with all secrets or all configmaps
+			if volumeHasSecretProjection(v) {
+				v.HostPath = &v1.HostPathVolumeSource{Path: secretPath(cp.Namespace, cp.Name, v.Name)}
+				v.Projected = nil
+			} else if volumeHasConfigMapProjection(v) {
+				v.HostPath = &v1.HostPathVolumeSource{Path: configMapPath(cp.Namespace, cp.Name, v.Name)}
+				v.Projected = nil
+			}
 		}
 	}
 

--- a/pkg/checkpoint/process.go
+++ b/pkg/checkpoint/process.go
@@ -250,6 +250,14 @@ func (c *checkpointer) createCheckpointsForValidParents() {
 				glog.Errorf("Failed to checkpoint configMaps for pod %s: %v", id, err)
 				continue
 			}
+
+			_, err = c.checkpointProjectedVolumes(pod)
+			if err != nil {
+				//TODO(aaron): This can end up spamming logs at times when api-server is unavailable. To reduce spam
+				//             we could only log error if api-server can't be contacted and existing configmap doesn't exist.
+				glog.Errorf("Failed to checkpoint projected volume for pod %s: %v", id, err)
+				continue
+			}
 		}
 	}
 

--- a/pkg/checkpoint/projected.go
+++ b/pkg/checkpoint/projected.go
@@ -1,0 +1,77 @@
+package checkpoint
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+)
+
+func (c *checkpointer) checkpointProjectedVolumes(pod *v1.Pod) (*v1.Pod, error) {
+	uid, gid, err := podUserAndGroup(pod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user and group for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+	}
+
+	for i := range pod.Spec.Volumes {
+		v := &pod.Spec.Volumes[i]
+
+		if v.VolumeSource.Projected != nil {
+			p := v.VolumeSource.Projected
+			if volumeHasSecretProjection(v) {
+				err := c.checkpointProjectedSecrets(pod.Namespace, pod.Name, v.Name, p.Sources, uid, gid)
+				if err != nil {
+					return nil, fmt.Errorf("failed to checkpoint projected secrets for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+				}
+			}
+			if volumeHasConfigMapProjection(v) {
+				err := c.checkpointProjectedConfigMaps(pod.Namespace, pod.Name, v.Name, p.Sources, uid, gid)
+				if err != nil {
+					return nil, fmt.Errorf("failed to checkpoint projected configmaps for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+				}
+			}
+			if volumeHasDownwardAPIProjection(v) {
+				return nil, fmt.Errorf("no support to checkpoint projected DownwardAPI for pod %s/%s", pod.Namespace, pod.Name)
+			}
+		}
+	}
+	return pod, nil
+}
+
+func volumeHasSecretProjection(volume *v1.Volume) bool {
+	hasSecretProjection := false
+	if volume.Projected != nil {
+		for _, s := range volume.Projected.Sources {
+			if s.Secret != nil {
+				hasSecretProjection = true
+				break
+			}
+		}
+	}
+	return hasSecretProjection
+}
+
+func volumeHasConfigMapProjection(volume *v1.Volume) bool {
+	hasConfigMapProjection := false
+	if volume.Projected != nil {
+		for _, s := range volume.Projected.Sources {
+			if s.ConfigMap != nil {
+				hasConfigMapProjection = true
+				break
+			}
+		}
+	}
+	return hasConfigMapProjection
+}
+
+func volumeHasDownwardAPIProjection(volume *v1.Volume) bool {
+	hasDownwardAPIProjection := false
+	if volume.Projected != nil {
+		for _, s := range volume.Projected.Sources {
+			if s.DownwardAPI != nil {
+				hasDownwardAPIProjection = true
+				break
+			}
+		}
+	}
+	return hasDownwardAPIProjection
+}

--- a/pkg/checkpoint/secret.go
+++ b/pkg/checkpoint/secret.go
@@ -10,6 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const defaultSecretMode = os.FileMode(0600)
+
 // checkpointSecretVolumes ensures that all pod secrets are checkpointed locally, then converts the secret volume to a hostpath.
 func (c *checkpointer) checkpointSecretVolumes(pod *v1.Pod) (*v1.Pod, error) {
 	uid, gid, err := podUserAndGroup(pod)
@@ -27,6 +29,7 @@ func (c *checkpointer) checkpointSecretVolumes(pod *v1.Pod) (*v1.Pod, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to checkpoint secret for pod %s/%s: %v", pod.Namespace, pod.Name, err)
 		}
+
 	}
 	return pod, nil
 }
@@ -50,12 +53,69 @@ func (c *checkpointer) checkpointSecret(namespace, podName, secretName string, u
 
 	// TODO(aaron): No need to store if already exists
 	for f, d := range secret.Data {
-		if err := writeAndAtomicRename(filepath.Join(basePath, f), d, uid, gid, 0600); err != nil {
+		if err := writeAndAtomicRename(filepath.Join(basePath, f), d, uid, gid, defaultSecretMode); err != nil {
 			return "", fmt.Errorf("failed to write secret %s: %v", secret.Name, err)
 		}
 	}
 
 	return basePath, nil
+}
+
+// checkpointSecretProjection will locally store secret data from volumes with ProjectedVolumeSources.
+// The path to the secret data becomes: checkpointSecretPath/namespace/podname/volumename/secret.file
+// Where each "secret.file" is a path from the SecretProjection.KeyToPath field.
+func (c *checkpointer) checkpointSecretProjection(namespace, podName, volumeName string, secretProjection *v1.SecretProjection, uid, gid int) error {
+
+	secretName := secretProjection.Name
+	isOptional := secretProjection.Optional != nil && *secretProjection.Optional
+
+	secret, err := c.apiserver.Core().Secrets(namespace).Get(secretName, metav1.GetOptions{})
+	if err != nil && isOptional {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to retrieve secret %s/%s: %v", namespace, secretName, err)
+	}
+
+	basePath := secretPath(namespace, podName, volumeName)
+	if err = os.MkdirAll(basePath, 0700); err != nil {
+		return fmt.Errorf("failed to create secret checkpoint path %s: %v", basePath, err)
+	}
+	if err = os.Chown(basePath, uid, gid); err != nil {
+		return fmt.Errorf("failed to chown secret checkpoint path %s: %v", basePath, err)
+	}
+
+	// TODO(aaron): No need to store if already exists
+	for _, item := range secretProjection.Items {
+		secretItemKey := item.Key
+		secretItemMode := defaultSecretMode
+		if item.Mode != nil {
+			secretItemMode = os.FileMode(*item.Mode)
+		}
+		if _, ok := secret.Data[secretItemKey]; !ok {
+			if isOptional {
+				continue
+			}
+			return fmt.Errorf("failed to find item %s secret %s/%s: %v", secretItemKey, namespace, secretName, err)
+		}
+		if err := writeAndAtomicRename(filepath.Join(basePath, item.Path), secret.Data[secretItemKey], uid, gid, secretItemMode); err != nil {
+			return fmt.Errorf("failed to write secret %s: %v", secret.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *checkpointer) checkpointProjectedSecrets(namespace, podName, volumeName string, volumeSources []v1.VolumeProjection, uid, gid int) error {
+
+	for _, vp := range volumeSources {
+		err := c.checkpointSecretProjection(namespace, podName, volumeName, vp.Secret, uid, gid)
+		if err != nil {
+			return fmt.Errorf("failed to checkpoint projected secret for pod %s/%s: %v", namespace, podName, err)
+		}
+	}
+
+	return nil
 }
 
 func secretPath(namespace, podName, secretName string) string {


### PR DESCRIPTION
to allow kubeadm versions of kube-apiserver pod to still work

fixes #969

because secrets and configmaps currently have different base hostpaths, we can't work with projected volumes containing both.