### PR TITLE
pkg/poll: Add a Poll helper that respects Context

### DIFF
--- a/cmd/bootkube/main.go
+++ b/cmd/bootkube/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -31,13 +32,18 @@ var (
 )
 
 func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	flag.Parse()
-	util.InitLogs()
-	defer util.FlushLogs()
+
+	logsExit := make(chan error, 1)
+	util.InitLogs(ctx, logsExit)
 
 	cmdRoot.AddCommand(cmdVersion)
 	if err := cmdRoot.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		cancel()
+		<-logsExit
 		os.Exit(1)
 	}
 }

--- a/cmd/bootkube/start.go
+++ b/cmd/bootkube/start.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 
 	"github.com/spf13/cobra"
@@ -33,6 +34,8 @@ func init() {
 }
 
 func runCmdStart(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
 	bk, err := bootkube.NewBootkube(bootkube.Config{
 		AssetDir:        startOpts.assetDir,
 		PodManifestPath: startOpts.podManifestPath,
@@ -42,7 +45,7 @@ func runCmdStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = bk.Run()
+	err = bk.Run(ctx)
 	if err != nil {
 		// Always report errors.
 		bootkube.UserOutput("Error: %v\n", err)

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,13 +9,19 @@ import (
 )
 
 func TestSmoke(t *testing.T) {
-	nginx, err := testworkload.NewNginx(client, namespace, testworkload.WithNginxPingJobLabels(map[string]string{"allow": "access"}))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	nginx, err := testworkload.NewNginx(ctx, client, namespace, testworkload.WithNginxPingJobLabels(map[string]string{"allow": "access"}))
 	if err != nil {
 		t.Fatalf("Test nginx creation failed: %v", err)
 	}
-	defer nginx.Delete()
+	defer nginx.Delete(ctx)
 
-	if err := retry(60, 5*time.Second, nginx.IsReachable); err != nil {
+	if err := retry(60, 5*time.Second, func() error {
+		timeoutCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
+		defer cancel()
+		return nginx.IsReachable(timeoutCtx)
+	}); err != nil {
 		t.Errorf("%s is not reachable: %v", nginx.Name, err)
 	}
 }

--- a/pkg/poll/poll.go
+++ b/pkg/poll/poll.go
@@ -1,0 +1,67 @@
+// Package poll supports polling until a condition is satisfied or a
+// context finishes.
+package poll
+
+import (
+	"context"
+	"time"
+)
+
+// ConditionFunc returns true if the condition is satisfied, or an
+// error if the loop should be aborted.
+type ConditionFunc func(ctx context.Context) (done bool, err error)
+
+// Poll tries a condition func until it returns true, an error, or the
+// context is done.
+//
+// If the context is done before interval elapses, Poll will not call
+// 'condition' at all.
+//
+// Some intervals may be missed if the condition takes too long or the time
+// window is too short.
+func Poll(ctx context.Context, interval time.Duration, condition ConditionFunc) (err error) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			ok, err := condition(ctx)
+			if err != nil {
+				return err
+			}
+			if ok {
+				return nil
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// PollImmediate is like Poll, except it tries the condition
+// immediately without waiting for the first interval.
+func PollImmediate(ctx context.Context, interval time.Duration, condition ConditionFunc) (err error) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	ok, err := condition(ctx)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	for {
+		select {
+		case <-ticker.C:
+			ok, err := condition(ctx)
+			if err != nil {
+				return err
+			}
+			if ok {
+				return nil
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/pkg/poll/poll_test.go
+++ b/pkg/poll/poll_test.go
@@ -1,0 +1,90 @@
+package poll
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestPollSecondMatch(t *testing.T) {
+	ctx := context.Background()
+	i := 0
+	condition := func(ctx context.Context) (ok bool, err error) {
+		i++
+		if i == 2 {
+			return true, nil
+		}
+		return false, nil
+	}
+	interval := time.Second
+	start := time.Now()
+	err := Poll(ctx, interval, condition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	elapsed := time.Now().Sub(start)
+	if math.Abs(elapsed.Seconds()/interval.Seconds()-2) > 0.2 {
+		t.Fatalf("expected 2 seconds, got %f", elapsed.Seconds())
+	}
+}
+
+func TestPollCancelMatch(t *testing.T) {
+	timeout := time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	condition := func(ctx context.Context) (ok bool, err error) {
+		return false, nil
+	}
+	start := time.Now()
+	err := Poll(ctx, 2*timeout, condition)
+	if err != context.DeadlineExceeded {
+		t.Fatalf("expected %v, got %v", context.DeadlineExceeded, err)
+	}
+	elapsed := time.Now().Sub(start)
+	if math.Abs(elapsed.Seconds()/timeout.Seconds()-1) > 0.2 {
+		t.Fatalf("expected %f seconds, got %f", timeout.Seconds(), elapsed.Seconds())
+	}
+}
+
+func TestPollConditionError(t *testing.T) {
+	ctx := context.Background()
+	conditionError := errors.New("condition error")
+	condition := func(ctx context.Context) (ok bool, err error) {
+		return false, conditionError
+	}
+	interval := time.Second
+	start := time.Now()
+	err := Poll(ctx, interval, condition)
+	if err != conditionError {
+		t.Fatalf("expected %v, got %v", conditionError, err)
+	}
+	elapsed := time.Now().Sub(start)
+	if math.Abs(elapsed.Seconds()/interval.Seconds()-1) > 0.2 {
+		t.Fatalf("expected %f seconds, got %f", interval.Seconds(), elapsed.Seconds())
+	}
+}
+
+func TestPollImmediateSecondMatch(t *testing.T) {
+	ctx := context.Background()
+	i := 0
+	condition := func(ctx context.Context) (ok bool, err error) {
+		time.Sleep(500 * time.Millisecond)
+		i++
+		if i == 2 {
+			return true, nil
+		}
+		return false, nil
+	}
+	interval := time.Second
+	start := time.Now()
+	err := PollImmediate(ctx, interval, condition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	elapsed := time.Now().Sub(start)
+	if math.Abs(elapsed.Seconds()/interval.Seconds()-1.5) > 0.2 {
+		t.Fatalf("expected 1.5 seconds, got %f", elapsed.Seconds())
+	}
+}


### PR DESCRIPTION
This is like the `k8s.io/apimachinery/pkg/util/wait` `Poll`, except it takes a `Context` argument to allow canceling for any reason.  The k8s utility only cancels the poller on timeouts.  This PR includes an initial commit adding the new package, and then provides follow-up commits porting portions of the repository over to the new package.  Hopefully this makes the full change easier to review, because the individual commit messages can go into more detail about smaller ports.  I'm also happy to split this up into per-commit PRs, or squash the PR down to a single commit, if that would be easier.