### PR TITLE
pkg/asset/k8s: Evenly weight chars in newBootstrapToken

### DIFF
--- a/pkg/asset/k8s_test.go
+++ b/pkg/asset/k8s_test.go
@@ -1,0 +1,31 @@
+package asset
+
+import (
+	"testing"
+)
+
+func TestEncodeBytes(t *testing.T) {
+	token := make([]byte, 22)
+	random := []byte{ // 1324076502674089023697701463353265679
+		255,
+		2,
+		3,
+		4,
+		5,
+		6,
+		7,
+		8,
+		9,
+		10,
+		11,
+		12,
+		13,
+		14,
+		15,
+	}
+	encodeBytes(validBootstrapTokenChars, random, token)
+	expected := "n2r8j0ug4twvqmqt53hyff"
+	if string(token) != expected {
+		t.Errorf("%s != %s", string(token), expected)
+	}
+}


### PR DESCRIPTION
The `256 % len(charset)` remainder unevenly biased characters listed earlier in the charset array.  For example, 256 is `7 * 36 + 4`, so a 36-character charset that naively used `int(b) % len(charset)` would include the first four characters (0 through 3) 14% (`8/7`) more frequently than the other characters.

The new integer approach is unbiased and a more efficient use of entropy, because we no longer collapse 256 possible values into 36 possible values.  With the current 36-character token charset, this reduces our read from 22 bytes to 15 bytes.

`SetBytes` converts the full input slice into a big integer.  There may be a more efficient approach to this that consumes the input incrementally, but `SetBytes` is convenient.  We can always polish more later if we want a more efficient approach.

The endian-ness doesn't matter for our current use case, because the input data is random.  I've documented it to make independently calculating the expected test values easier, but we can flip the endian-ness of the internal helper now or later on if it's convenient to do so.