### PR TITLE
AWS Quickstart: mention TAG_MASTER

### DIFF
--- a/hack/quickstart/init-node.sh
+++ b/hack/quickstart/init-node.sh
@@ -85,6 +85,9 @@ if [ "${REMOTE_HOST}" != "local" ]; then
 
     echo
     echo "Node (${REMOTE_HOST}) bootstrap complete. It may take a few minutes for the node to become ready."
+    if [ "$TAG_MASTER" = true ] ; then
+        echo "NOTE: You have configured this node as a master. You may want to set up load balancing with your cloud provider so that masters receive equal traffic and gracefully fail over."
+    fi
 
 # Execute this script locally on the machine, assumes a kubelet.service file has already been placed on host.
 elif [ "$1" == "local" ]; then

--- a/hack/quickstart/quickstart-aws.md
+++ b/hack/quickstart/quickstart-aws.md
@@ -77,3 +77,11 @@ IDENT=${CLUSTER_PREFIX}-key.pem ./init-node.sh <PUBLIC_IP> cluster/auth/kubeconf
 ```
 $ kubectl --kubeconfig=cluster/auth/kubeconfig get nodes
 ```
+
+### Add Additional Masters
+
+As with the **Add Workers** step above, only set `TAG_MASTER=true`
+
+```
+IDENT=${CLUSTER_PREFIX}-key.pem TAG_MASTER=true ./init-node.sh <PUBLIC_IP> cluster/auth/kubeconfig
+```


### PR DESCRIPTION
Ref #311 There should be a mention of adding additional masters. I understand this is a difficult thing to place correctly, since it's important to note that boot-kube is only necessary for the first node in the cluster.  This is why I mentioned it last.  It could also be a comment line in the **Add Workers** section if you think it's too confusing down here.