### PR TITLE
Cilium CNI

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -66,7 +66,7 @@ func init() {
 	cmdRender.Flags().StringVar(&renderOpts.podCIDR, "pod-cidr", "10.2.0.0/16", "The CIDR range of cluster pods.")
 	cmdRender.Flags().StringVar(&renderOpts.serviceCIDR, "service-cidr", "10.3.0.0/24", "The CIDR range of cluster services.")
 	cmdRender.Flags().StringVar(&renderOpts.cloudProvider, "cloud-provider", "", "The provider for cloud services.  Empty string for no provider")
-	cmdRender.Flags().StringVar(&renderOpts.networkProvider, "network-provider", "flannel", "CNI network provider (flannel or experimental-canal).")
+	cmdRender.Flags().StringVar(&renderOpts.networkProvider, "network-provider", "flannel", "CNI network provider (flannel, experimental-canal, or Cilium).")
 }
 
 func runCmdRender(cmd *cobra.Command, args []string) error {
@@ -102,7 +102,7 @@ func validateRenderOpts(cmd *cobra.Command, args []string) error {
 	if renderOpts.apiServers == "" {
 		return errors.New("Missing requried flag: --api-servers")
 	}
-	if renderOpts.networkProvider != asset.NetworkFlannel && renderOpts.networkProvider != asset.NetworkCalico && renderOpts.networkProvider != asset.NetworkCanal {
+	if renderOpts.networkProvider != asset.NetworkFlannel && renderOpts.networkProvider != asset.NetworkCalico && renderOpts.networkProvider != asset.NetworkCanal && renderOpts.networkProvider != asset.NetworkCilium {
 		return errors.New("Must specify --network-provider flannel or experimental-calico or experimental-canal")
 	}
 	return nil

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -61,6 +61,12 @@ const (
 	AssetPathCalicoGlobalNetworkSetsCRD     = "manifests/calico-global-network-sets-crd.yaml"
 	AssetPathCalicoIPPoolsCRD               = "manifests/calico-ip-pools-crd.yaml"
 	AssetPathCalicoClusterInformationsCRD   = "manifests/calico-cluster-informations-crd.yaml"
+	AssetPathCiliumCfg                      = "manifests/cilium-cfg.yaml"
+	AssetPathCilium                         = "manifests/cilium.yaml"
+	AssetPathCiliumClusterRoleBinding       = "manifests/cilium-cluster-role-binding.yaml"
+	AssetPathCiliumClusterRole              = "manifests/cilium-cluster-role.yaml"
+	AssetPathCiliumSA                       = "manifests/cilium-sa.yaml"
+	AssetPathCiliumSecret                   = "manifests/cilium-secret.yaml"
 	AssetPathAPIServerSecret                = "manifests/kube-apiserver-secret.yaml"
 	AssetPathAPIServer                      = "manifests/kube-apiserver.yaml"
 	AssetPathControllerManager              = "manifests/kube-controller-manager.yaml"
@@ -127,6 +133,7 @@ type ImageVersions struct {
 	FlannelCNI      string
 	Calico          string
 	CalicoCNI       string
+	Cilium          string
 	CoreDNS         string
 	Hyperkube       string
 	Kenc            string
@@ -189,6 +196,15 @@ func NewDefaultAssets(conf Config) (Assets, error) {
 		return Assets{}, err
 	}
 	as = append(as, cmSecret)
+	
+  // Cilium ETCD secret
+	if conf.NetworkProvider == NetworkCilium && conf.EtcdUseTLS {
+		cSecret, err := newCiliumSecretAsset(as)
+		if err != nil {
+			return Assets{}, err
+		}
+		as = append(as, cSecret)
+	}
 
 	return as, nil
 }

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -7,6 +7,7 @@ var DefaultImages = ImageVersions{
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
 	Calico:          "quay.io/calico/node:v3.0.3",
 	CalicoCNI:       "quay.io/calico/cni:v2.0.0",
+	Cilium:          "docker.io/cilium/cilium:v1.1",
 	CoreDNS:         "k8s.gcr.io/coredns:1.1.3",
 	Hyperkube:       "k8s.gcr.io/hyperkube:v1.11.2",
 	PodCheckpointer: "quay.io/coreos/pod-checkpointer:9dc83e1ab3bc36ca25c9f7c18ddef1b91d4a0558",

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -7,7 +7,7 @@ var DefaultImages = ImageVersions{
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
 	Calico:          "quay.io/calico/node:v3.0.3",
 	CalicoCNI:       "quay.io/calico/cni:v2.0.0",
-	Cilium:          "docker.io/cilium/cilium:v1.2.0",
+	Cilium:          "docker.io/cilium/cilium:v1.1",
 	CoreDNS:         "k8s.gcr.io/coredns:1.1.3",
 	Hyperkube:       "k8s.gcr.io/hyperkube:v1.11.2",
 	PodCheckpointer: "quay.io/coreos/pod-checkpointer:9dc83e1ab3bc36ca25c9f7c18ddef1b91d4a0558",

--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -7,7 +7,7 @@ var DefaultImages = ImageVersions{
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
 	Calico:          "quay.io/calico/node:v3.0.3",
 	CalicoCNI:       "quay.io/calico/cni:v2.0.0",
-	Cilium:          "docker.io/cilium/cilium:v1.1",
+	Cilium:          "docker.io/cilium/cilium:v1.2.0",
 	CoreDNS:         "k8s.gcr.io/coredns:1.1.3",
 	Hyperkube:       "k8s.gcr.io/hyperkube:v1.11.2",
 	PodCheckpointer: "quay.io/coreos/pod-checkpointer:9dc83e1ab3bc36ca25c9f7c18ddef1b91d4a0558",

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -112,15 +112,13 @@ func newDynamicAssets(conf Config) Assets {
 			MustCreateAssetFromTemplate(AssetPathCalicoNetworkPoliciesCRD, internal.CalicoNetworkPoliciesCRD, conf),
 			MustCreateAssetFromTemplate(AssetPathCalicoClusterInformationsCRD, internal.CalicoClusterInformationsCRD, conf),
 			MustCreateAssetFromTemplate(AssetPathCalicoIPPoolsCRD, internal.CalicoIPPoolsCRD, conf))
-	}
 	case NetworkCilium:
 		assets = append(assets,
 			MustCreateAssetFromTemplate(AssetPathCilium, internal.CiliumTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathCiliumCfg, internal.CiliumCfgTemplate, conf),
 			MustCreateAssetFromTemplate(AssetPathCiliumClusterRole, internal.CiliumClusterRole, conf),
 			MustCreateAssetFromTemplate(AssetPathCiliumClusterRoleBinding, internal.CiliumClusterRoleBinding, conf),
-			MustCreateAssetFromTemplate(AssetPathCiliumSA, internal.CiliumServiceAccount, conf),
-		)
+			MustCreateAssetFromTemplate(AssetPathCiliumSA, internal.CiliumServiceAccount, conf))
 	}
 	return assets
 }


### PR DESCRIPTION
#779 

Add upstream Cilium CNI option.

Base templates adapted from official Cilium documentation: https://raw.githubusercontent.com/cilium/cilium/v1.1/examples/kubernetes/1.11/cilium.yaml

Cilium initContainer installs latest releast of containernetworking/cni releases required by k8s.