### PR TITLE
checkpointer: ignore Affinity within podspec

### DIFF
--- a/cmd/checkpoint/README.md
+++ b/cmd/checkpoint/README.md
@@ -17,7 +17,7 @@ This is accomplished by managing checkpoints as static pod manifests:
 ## Use
 
 Any pod which contains the `checkpointer.alpha.coreos.com/checkpoint=true` annotation will be considered a viable "parent pod" which should be checkpointed.
-The parent pod cannot itself be a static pod, and is not a checkpoint itself.
+The parent pod cannot itself be a static pod, and is not a checkpoint itself. Affinity is not supported for a pod, and any pod labelled with the checkpoint annotation will be checkpointed.
 
 Checkpoints are denoted by the `checkpointer.alpha.coreos.com/checkpoint-of` annotation. This annotation will point to the parent of this checkpoint by pod name.
 

--- a/pkg/checkpoint/pod.go
+++ b/pkg/checkpoint/pod.go
@@ -63,6 +63,9 @@ func sanitizeCheckpointPod(cp *v1.Pod) *v1.Pod {
 	cp.Spec.ServiceAccountName = ""
 	cp.Spec.DeprecatedServiceAccount = ""
 
+	// Remove affinity
+	cp.Spec.Affinity = nil
+
 	// Sanitize the volumes
 	for i := range cp.Spec.Volumes {
 		v := &cp.Spec.Volumes[i]


### PR DESCRIPTION
Kubernetes 1.12.x introduced new logic for Affinity [1]. In addition to
new logic, the Pod contains a default affinity. The new default affinity
gets serialized into the checkpoint file, and the 1.12.x kubelet does
not restore the pod due to the affinity.

This PR removes the affinity from the spec and documents that affinity's
are not supported.

```
"affinity": {
      "nodeAffinity": {
        "requiredDuringSchedulingIgnoredDuringExecution": {
          "nodeSelectorTerms": [
            {
              "matchExpressions": null
            }
          ]
        }
      }
    },

```

/cc @aaronlevy @dghubble 
/fixes #1001 

[1] https://github.com/kubernetes/kubernetes/pull/68173
[2] https://github.com/kubernetes/kubernetes/blob/e39b510726113581c6f6a9c2db1753d794aa9cce/pkg/controller/daemon/util/daemonset_util.go#L183-L196