### PR TITLE
checkpointer: ignore Affinity within podspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ before_script:
   - unzip terraform_0.11.3_linux_amd64.zip
   - export PATH=$PWD:$PATH
 go:
-  - 1.10.x
+  - 1.11.x
 script:
   - make release

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ endif
 
 gofmt:
 	gofmt -s -w $(GOFILES)
-	git diff --exit-code
 
 install:
 	go install -ldflags "$(LDFLAGS)" ./cmd/bootkube

--- a/build/build-release.sh
+++ b/build/build-release.sh
@@ -5,5 +5,5 @@ BOOTKUBE_ROOT=$(git rev-parse --show-toplevel)
 sudo rkt run \
     --volume bk,kind=host,source=${BOOTKUBE_ROOT} \
     --mount volume=bk,target=/go/src/github.com/kubernetes-incubator/bootkube \
-    --insecure-options=image docker://golang:1.9.4 --exec /bin/bash -- -c \
+    --insecure-options=image docker://golang:1.11.1 --exec /bin/bash -- -c \
     "cd /go/src/github.com/kubernetes-incubator/bootkube && make release"

--- a/cmd/checkpoint/README.md
+++ b/cmd/checkpoint/README.md
@@ -17,7 +17,7 @@ This is accomplished by managing checkpoints as static pod manifests:
 ## Use
 
 Any pod which contains the `checkpointer.alpha.coreos.com/checkpoint=true` annotation will be considered a viable "parent pod" which should be checkpointed.
-The parent pod cannot itself be a static pod, and is not a checkpoint itself.
+The parent pod cannot itself be a static pod, and is not a checkpoint itself. Affinity is not supported for a pod, and any pod labelled with the checkpoint annotation will be checkpointed.
 
 Checkpoints are denoted by the `checkpointer.alpha.coreos.com/checkpoint-of` annotation. This annotation will point to the parent of this checkpoint by pod name.
 

--- a/hack/tests/conformance-gce.sh
+++ b/hack/tests/conformance-gce.sh
@@ -114,6 +114,6 @@ else
 
     #TODO(pb): See if there is a way to make the --inherit-env option replace
     #passing all the variables manually. 
-    sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.9.4 --exec /bin/bash -- -c \
+    sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.11.1 --exec /bin/bash -- -c \
         "IN_CONTAINER=true COREOS_CHANNEL=${COREOS_CHANNEL} GCE_PREFIX=${GCE_PREFIX} GCE_SERVICE_ACCOUNT=${GCE_SERVICE_ACCOUNT} GCE_PROJECT=${GCE_PROJECT} /build/bootkube/hack/tests/$(basename $0)"
 fi

--- a/hack/tests/conformance-test.sh
+++ b/hack/tests/conformance-test.sh
@@ -44,5 +44,5 @@ CONFORMANCE="\
  KUBECONFIG=/kubeconfig KUBERNETES_CONFORMANCE_TEST=Y go run hack/e2e.go \
  -- -v --test --check-version-skew=false --provider=skeleton --test_args='--ginkgo.focus=\[Conformance\]'"
 
-CMD="sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.9.4 --exec /bin/bash -- -c \"${INIT} && ${BUILD} && ${CONFORMANCE}\""
+CMD="sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:1.11.1 --exec /bin/bash -- -c \"${INIT} && ${BUILD} && ${CONFORMANCE}\""
 ssh -q  -o UserKnownHostsFile=/dev/null -o stricthostkeychecking=no -i ${ssh_key} -p ${ssh_port} core@${ssh_host} "${CMD}"

--- a/pkg/checkpoint/pod.go
+++ b/pkg/checkpoint/pod.go
@@ -63,6 +63,9 @@ func sanitizeCheckpointPod(cp *v1.Pod) *v1.Pod {
 	cp.Spec.ServiceAccountName = ""
 	cp.Spec.DeprecatedServiceAccount = ""
 
+	// Remove affinity
+	cp.Spec.Affinity = nil
+
 	// Sanitize the volumes
 	for i := range cp.Spec.Volumes {
 		v := &cp.Spec.Volumes[i]

--- a/pkg/tlsutil/tlsutil.go
+++ b/pkg/tlsutil/tlsutil.go
@@ -78,7 +78,7 @@ func NewSelfSignedCACertificate(cfg CertConfig, key *rsa.PrivateKey) (*x509.Cert
 		NotAfter:              now.Add(Duration365d * 10).UTC(),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 
 	certDERBytes, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, key.Public(), key)


### PR DESCRIPTION
Kubernetes 1.12.x introduced new logic for Affinity [1]. In addition to
new logic, the Pod contains a default affinity. The new default affinity
gets serialized into the checkpoint file, and the 1.12.x kubelet does
not restore the pod due to the affinity.

This PR removes the affinity from the spec and documents that affinity's
are not supported.

```
"affinity": {
      "nodeAffinity": {
        "requiredDuringSchedulingIgnoredDuringExecution": {
          "nodeSelectorTerms": [
            {
              "matchExpressions": null
            }
          ]
        }
      }
    },

```

[1] https://github.com/kubernetes/kubernetes/pull/68173
[2] https://github.com/kubernetes/kubernetes/blob/e39b510726113581c6f6a9c2db1753d794aa9cce/pkg/controller/daemon/util/daemonset_util.go#L183-L196