### PR TITLE
start: add --require-pods flag

### DIFF
--- a/cmd/bootkube/start.go
+++ b/cmd/bootkube/start.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -22,14 +24,23 @@ var (
 		assetDir        string
 		podManifestPath string
 		strict          bool
+		requiredPods    []string
 	}
 )
+
+var defaultRequiredPods = []string{
+	"kube-system/pod-checkpointer",
+	"kube-system/kube-apiserver",
+	"kube-system/kube-scheduler",
+	"kube-system/kube-controller-manager",
+}
 
 func init() {
 	cmdRoot.AddCommand(cmdStart)
 	cmdStart.Flags().StringVar(&startOpts.assetDir, "asset-dir", "", "Path to the cluster asset directory. Expected layout genereted by the `bootkube render` command.")
 	cmdStart.Flags().StringVar(&startOpts.podManifestPath, "pod-manifest-path", "/etc/kubernetes/manifests", "The location where the kubelet is configured to look for static pod manifests.")
 	cmdStart.Flags().BoolVar(&startOpts.strict, "strict", false, "Strict mode will cause bootkube to exit early if any manifests in the asset directory cannot be created.")
+	cmdStart.Flags().StringSliceVar(&startOpts.requiredPods, "required-pods", defaultRequiredPods, "List of pods with their namespace (written as <namespace>/<pod-name>) that are required to be running before the start command does the pivot.")
 }
 
 func runCmdStart(cmd *cobra.Command, args []string) error {
@@ -37,6 +48,7 @@ func runCmdStart(cmd *cobra.Command, args []string) error {
 		AssetDir:        startOpts.assetDir,
 		PodManifestPath: startOpts.podManifestPath,
 		Strict:          startOpts.strict,
+		RequiredPods:    startOpts.requiredPods,
 	})
 	if err != nil {
 		return err
@@ -56,6 +68,11 @@ func validateStartOpts(cmd *cobra.Command, args []string) error {
 	}
 	if startOpts.assetDir == "" {
 		return errors.New("missing required flag: --asset-dir")
+	}
+	for _, nsPod := range startOpts.requiredPods {
+		if len(strings.Split(nsPod, "/")) != 2 {
+			return fmt.Errorf("invalid required pod: expected %q to be of shape <namespace>/<pod-name>", nsPod)
+		}
 	}
 	return nil
 }

--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -12,23 +12,18 @@ import (
 
 const assetTimeout = 20 * time.Minute
 
-var requiredPods = []string{
-	"pod-checkpointer",
-	"kube-apiserver",
-	"kube-scheduler",
-	"kube-controller-manager",
-}
-
 type Config struct {
 	AssetDir        string
 	PodManifestPath string
 	Strict          bool
+	RequiredPods    []string
 }
 
 type bootkube struct {
 	podManifestPath string
 	assetDir        string
 	strict          bool
+	requiredPods    []string
 }
 
 func NewBootkube(config Config) (*bootkube, error) {
@@ -36,6 +31,7 @@ func NewBootkube(config Config) (*bootkube, error) {
 		assetDir:        config.AssetDir,
 		podManifestPath: config.PodManifestPath,
 		strict:          config.Strict,
+		requiredPods:    config.RequiredPods,
 	}, nil
 }
 
@@ -71,7 +67,7 @@ func (b *bootkube) Run() error {
 		return err
 	}
 
-	if err = WaitUntilPodsRunning(kubeConfig, requiredPods, assetTimeout); err != nil {
+	if err = WaitUntilPodsRunning(kubeConfig, b.requiredPods, assetTimeout); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
By default we wait for the pods pod-checkpointer, kube-apiserver, kube-scheduler, kube-controller-manager in the kube-system namespace. This PR adds the `--required-pods` flag to the start command to customize this list, including custom namespaces of the shape `<ns>/<pod-name>`.