### PR TITLE
Make e2e test commands copy-pastable

### DIFF
--- a/hack/multi-node/README.md
+++ b/hack/multi-node/README.md
@@ -13,10 +13,10 @@ This will generate the default assets in the `cluster` directory and launch mult
 ## Running E2E tests
 
 ```
-$ ssh-add ~/.vagrant.d/insecure_private_key
-$ export KUBECONFIG=$PWD/cluster/auth/kubeconfig
-$ cd ../.. # project root
-$ go test -v ./e2e/ --kubeconfig=$KUBECONFIG
+ssh-add ~/.vagrant.d/insecure_private_key
+export KUBECONFIG=$PWD/cluster/auth/kubeconfig
+cd ../.. # project root
+go test -v ./e2e/ --kubeconfig=$KUBECONFIG
 ```
 
 ## Cleaning up


### PR DESCRIPTION
Remove prefixed `$` and make the instructions to run e2e test copy and
pastable.
