### PR TITLE
Disable Kubelet read-only port 10255

### DIFF
--- a/Documentation/network-requirements.md
+++ b/Documentation/network-requirements.md
@@ -24,5 +24,5 @@ The information below describes a minimum set of port allocations used by Kubern
 | TCP      | 4194        | Master & Worker Nodes          | The port of the localhost cAdvisor endpoint |
 | UDP      | 4789        | Master & Worker Nodes          | flannel overlay network - *vxlan backend* |
 | TCP      | 10250       | Master Nodes                   | Worker node Kubelet API for exec and logs.                                  |
-| TCP      | 10255       | Master & Worker Nodes          | Worker node read-only Kubelet API (Heapster).                                  |
+| TCP      | 10255       | Master & Worker Nodes          | (Optional) Worker node read-only Kubelet API (Heapster).               |
 | TCP      | 30000-32767 | External Application Consumers | Default port range for [external service][https://kubernetes.io/docs/concepts/services-networking/service] ports. Typically, these ports would need to be exposed to external load-balancers, or other external consumers of the application itself. |

--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -43,6 +43,7 @@ coreos:
           --network-plugin=cni \
           --node-labels=node-role.kubernetes.io/master \
           --pod-manifest-path=/etc/kubernetes/manifests \
+          --read-only-port=0 \
           --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
           --rotate-certificates
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/hack/quickstart/kubelet.service
+++ b/hack/quickstart/kubelet.service
@@ -40,6 +40,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --network-plugin=cni \
   --node-labels=${node_label} \
   --pod-manifest-path=/etc/kubernetes/manifests \
+  --read-only-port=0 \
   --register-with-taints=${node_taint} \
   --rotate-certificates
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -43,6 +43,7 @@ coreos:
           --network-plugin=cni \
           --node-labels=node-role.kubernetes.io/master \
           --pod-manifest-path=/etc/kubernetes/manifests \
+          --read-only-port=0 \
           --rotate-certificates
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -81,6 +81,8 @@ const (
 	AssetPathCheckpointerSA                 = "manifests/pod-checkpointer-sa.yaml"
 	AssetPathCheckpointerRole               = "manifests/pod-checkpointer-role.yaml"
 	AssetPathCheckpointerRoleBinding        = "manifests/pod-checkpointer-role-binding.yaml"
+	AssetPathCheckpointerClusterRole        = "manifests/pod-checkpointer-cluster-role.yaml"
+	AssetPathCheckpointerClusterRoleBinding = "manifests/pod-checkpointer-cluster-role-binding.yaml"
 	AssetPathEtcdClientSecret               = "manifests/etcd-client-tls.yaml"
 	AssetPathEtcdPeerSecret                 = "manifests/etcd-peer-tls.yaml"
 	AssetPathEtcdServerSecret               = "manifests/etcd-server-tls.yaml"

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -373,6 +373,30 @@ subjects:
   namespace: kube-system
 `)
 
+var CheckpointerClusterRole = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-checkpointer
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/proxy"]
+    verbs: ["get"]
+`)
+
+var CheckpointerClusterRoleBinding = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pod-checkpointer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pod-checkpointer
+subjects:
+- kind: ServiceAccount
+  name: pod-checkpointer
+  namespace: kube-system
+`)
+
 var ControllerManagerTemplate = []byte(`apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -48,6 +48,8 @@ func newStaticAssets(imageVersions ImageVersions) Assets {
 		MustCreateAssetFromTemplate(AssetPathCheckpointerSA, internal.CheckpointerServiceAccount, conf),
 		MustCreateAssetFromTemplate(AssetPathCheckpointerRole, internal.CheckpointerRole, conf),
 		MustCreateAssetFromTemplate(AssetPathCheckpointerRoleBinding, internal.CheckpointerRoleBinding, conf),
+		MustCreateAssetFromTemplate(AssetPathCheckpointerClusterRole, internal.CheckpointerClusterRole, conf),
+		MustCreateAssetFromTemplate(AssetPathCheckpointerClusterRoleBinding, internal.CheckpointerClusterRoleBinding, conf),
 		MustCreateAssetFromTemplate(AssetPathCSRApproverRoleBinding, internal.CSRApproverRoleBindingTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathCSRBootstrapRoleBinding, internal.CSRNodeBootstrapTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathCSRRenewalRoleBinding, internal.CSRRenewalRoleBindingTemplate, conf),


### PR DESCRIPTION
`pod-checkpointer` creates an `insecureClient` and `secureClient` to the kubelet, but only makes use of the former (via 10255). Adapt `localParentPods` to try to use the secure client first, then the insecure client to support clusters that disable the kubelet read-only port.

Open questions:

* What about we just always use the kubelet secure API (instead of having a fallback)?
* Testing with the secure client, we'll need a ClusterRole with node/proxy get. Surprising since the pod-checkpointer also mounts the admin kubeconfig from the host (possibly not being used). 

## Background

Today in bootkube, the kubelet read-only port (10255) is enabled and pod-checkpointer [uses](https://github.com/kubernetes-incubator/bootkube/blob/master/pkg/checkpoint/kubelet.go#L52) its `/pods` endpoint to get all pods (later filters to find parent pods). That all works fine.

We've come a long way toward eliminating the read-only port. Cloud load balancers can now health check the apiserver, Prometheus can [use the kubelet secure](https://github.com/poseidon/typhoon/pull/217) API to scrape metrics, and [heapster can get metrics](https://github.com/poseidon/typhoon/pull/323) from the kubelet secure API too.

Running clusters with kubelet `read-only-port=0` (disabled), the active pod-checkpointer will log:

```
failed to list local parent pods, assuming none are running: Get http://127.0.0.1:10255/pods/: dial tcp 127.0.0.1:10255: connect: connection refused
```

Interestingly, even with localParentPods calls failing on these clusters, recovery from cluster power cycling is unaffected. But I figure if we can eliminate this one last use of the read-only API, all the better.