### PR TITLE
pkg/checkpoint: Try kubelet secureClient, fallback to read-only

### DIFF
--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -110,7 +110,7 @@ func (c *checkpointer) run() {
 	for {
 		time.Sleep(defaultPollingFrequency)
 
-		// We must use both the :10255/pods endpoint and CRI shim, because /pods
+		// We must use both the kubelet /pods endpoint and CRI shim, because /pods
 		// endpoint could have stale data. The /pods endpoint will only show the last cached
 		// status which has successfully been written to an apiserver. However, if there is
 		// no apiserver, we may get stale state (e.g. saying pod is running, when it really is


### PR DESCRIPTION
Change pod-checkpointer to first try to list pods via the Kubeletsecure (10250) endpoint, then fallback to the Kubelet read-only (10255) endpoint, before defaulting to an empty list of parent pods

Related: #1025