### PR TITLE
Handle AppsV1 resources inside bootkube recover

### DIFF
--- a/pkg/recovery/apiserver.go
+++ b/pkg/recovery/apiserver.go
@@ -41,12 +41,12 @@ func (b *apiServerBackend) read(context.Context) (*controlPlane, error) {
 		return nil, err
 	}
 	cp.configMaps = *configMaps
-	deployments, err := b.client.ExtensionsV1beta1().Deployments("kube-system").List(metav1.ListOptions{})
+	deployments, err := b.client.AppsV1().Deployments("kube-system").List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	cp.deployments = *deployments
-	daemonSets, err := b.client.ExtensionsV1beta1().DaemonSets("kube-system").List(metav1.ListOptions{})
+	daemonSets, err := b.client.AppsV1().DaemonSets("kube-system").List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/recovery/recover.go
+++ b/pkg/recovery/recover.go
@@ -17,8 +17,8 @@ import (
 	"reflect"
 
 	"github.com/ghodss/yaml"
+	v1apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -63,8 +63,8 @@ func init() {
 		}
 	}
 	addTypeMeta(&v1.ConfigMap{}, v1.SchemeGroupVersion)
-	addTypeMeta(&v1beta1.DaemonSet{}, v1beta1.SchemeGroupVersion)
-	addTypeMeta(&v1beta1.Deployment{}, v1beta1.SchemeGroupVersion)
+	addTypeMeta(&v1apps.DaemonSet{}, v1apps.SchemeGroupVersion)
+	addTypeMeta(&v1apps.Deployment{}, v1apps.SchemeGroupVersion)
 	addTypeMeta(&v1.Pod{}, v1.SchemeGroupVersion)
 	addTypeMeta(&v1.Secret{}, v1.SchemeGroupVersion)
 }
@@ -77,8 +77,8 @@ type Backend interface {
 // controlPlane holds the control plane objects that are recovered from a backend.
 type controlPlane struct {
 	configMaps  v1.ConfigMapList
-	daemonSets  v1beta1.DaemonSetList
-	deployments v1beta1.DeploymentList
+	daemonSets  v1apps.DaemonSetList
+	deployments v1apps.DeploymentList
 	secrets     v1.SecretList
 }
 
@@ -133,7 +133,7 @@ func (cp *controlPlane) renderBootstrap() (asset.Assets, error) {
 }
 
 // extractBootstrapPods extracts bootstrap pod specs from daemonsets and deployments.
-func extractBootstrapPods(daemonSets []v1beta1.DaemonSet, deployments []v1beta1.Deployment) ([]v1.Pod, error) {
+func extractBootstrapPods(daemonSets []v1apps.DaemonSet, deployments []v1apps.Deployment) ([]v1.Pod, error) {
 	var pods []v1.Pod
 	for _, ds := range daemonSets {
 		if isBootstrapApp(ds.Labels) {

--- a/pkg/recovery/recover_test.go
+++ b/pkg/recovery/recover_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	v1apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -25,8 +25,8 @@ var (
 				Data: map[string]string{"key": "value"},
 			}},
 		},
-		daemonSets: v1beta1.DaemonSetList{
-			Items: []v1beta1.DaemonSet{{
+		daemonSets: v1apps.DaemonSetList{
+			Items: []v1apps.DaemonSet{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kube-apiserver",
 					Namespace: "kube-system",
@@ -35,7 +35,7 @@ var (
 						"k8s-app": "kube-apiserver",
 					},
 				},
-				Spec: v1beta1.DaemonSetSpec{
+				Spec: v1apps.DaemonSetSpec{
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -64,8 +64,8 @@ var (
 				},
 			}},
 		},
-		deployments: v1beta1.DeploymentList{
-			Items: []v1beta1.Deployment{{
+		deployments: v1apps.DeploymentList{
+			Items: []v1apps.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kube-scheduler",
 					Namespace: "kube-system",
@@ -74,7 +74,7 @@ var (
 						"k8s-app": "kube-scheduler",
 					},
 				},
-				Spec: v1beta1.DeploymentSpec{
+				Spec: v1apps.DeploymentSpec{
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -412,8 +412,8 @@ func TestIsNotBootstrapApp(t *testing.T) {
 func TestSetTypeMeta(t *testing.T) {
 	for _, obj := range []runtime.Object{
 		&v1.ConfigMap{},
-		&v1beta1.DaemonSet{},
-		&v1beta1.Deployment{},
+		&v1apps.DaemonSet{},
+		&v1apps.Deployment{},
 		&v1.Pod{},
 		&v1.Secret{},
 	} {


### PR DESCRIPTION
This bug fixes #977

My knowledge of kubernetes client-go is almost non, however because the recovery is failing on old resource types I have shifted these to use apps/v1 https://godoc.org/k8s.io/client-go/kubernetes#Clientset.AppsV1 which should be backwards compatible with the extensionsv1 interface.

Please let me know if I am missing something or am tackling this from a wrong perspective.