### PR TITLE
build,image: support building multi-arch container images

### DIFF
--- a/build/build-image.sh
+++ b/build/build-image.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 BUILD_IMAGE=${BUILD_IMAGE:-}
 PUSH_IMAGE=${PUSH_IMAGE:-false}
+GOARCH=${GOARCH:-amd64}
 
 if [ -z "${BUILD_IMAGE}" ]; then
     echo "BUILD_IMAGE env var must be set"

--- a/image/bootkube/build-image.sh
+++ b/image/bootkube/build-image.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 IMAGE_REPO=${IMAGE_REPO:-quay.io/coreos/bootkube}
+GOARCH=${GOARCH:-amd64}
 
 readonly BOOTKUBE_ROOT=$(git rev-parse --show-toplevel)
 readonly VERSION=${VERSION:-$(${BOOTKUBE_ROOT}/build/git-version.sh)}
@@ -9,14 +10,14 @@ readonly VERSION=${VERSION:-$(${BOOTKUBE_ROOT}/build/git-version.sh)}
 function image::build() {
     local TEMP_DIR=$(mktemp -d -t bootkube.XXXX)
 
-    cp $BOOTKUBE_ROOT/_output/bin/linux/bootkube ${TEMP_DIR}
+    cp $BOOTKUBE_ROOT/_output/bin/linux/${GOARCH}/bootkube ${TEMP_DIR}
     cp $BOOTKUBE_ROOT/image/bootkube/Dockerfile ${TEMP_DIR}
 
-    docker build -t ${IMAGE_REPO}:${VERSION} -f ${TEMP_DIR}/Dockerfile ${TEMP_DIR}
+    docker build -t ${IMAGE_REPO}:${VERSION}-${GOARCH} -f ${TEMP_DIR}/Dockerfile ${TEMP_DIR}
     rm -rf ${TEMP_DIR}
 }
 
 function image::name() {
-    echo "${IMAGE_REPO}:${VERSION}"
+    echo "${IMAGE_REPO}:${VERSION}-${GOARCH}"
 }
 

--- a/image/checkpoint/build-image.sh
+++ b/image/checkpoint/build-image.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 IMAGE_REPO=${IMAGE_REPO:-quay.io/coreos/pod-checkpointer}
+GOARCH=${GOARCH:-amd64}
 
 readonly BOOTKUBE_ROOT=$(git rev-parse --show-toplevel)
 readonly VERSION=${VERSION:-$(${BOOTKUBE_ROOT}/build/git-version.sh)}
@@ -10,13 +11,13 @@ function image::build() {
     local TEMP_DIR=$(mktemp -d -t checkpoint.XXXX)
 
     # Add assets for container build
-    cp ${BOOTKUBE_ROOT}/_output/bin/linux/checkpoint ${TEMP_DIR}
+    cp ${BOOTKUBE_ROOT}/_output/bin/linux/${GOARCH}/checkpoint ${TEMP_DIR}
     cp ${BOOTKUBE_ROOT}/image/checkpoint/Dockerfile ${TEMP_DIR}
 
-    docker build -t ${IMAGE_REPO}:${VERSION} -f ${TEMP_DIR}/Dockerfile ${TEMP_DIR}
+    docker build -t ${IMAGE_REPO}:${VERSION}-${GOARCH} -f ${TEMP_DIR}/Dockerfile ${TEMP_DIR}
     rm -rf ${TEMP_DIR}
 }
 
 function image::name() {
-    echo "${IMAGE_REPO}:${VERSION}"
+    echo "${IMAGE_REPO}:${VERSION}-${GOARCH}"
 }


### PR DESCRIPTION
Allow users to build container images for multiple architectures, like `arm64`.

Also add Makefile targets to customize build parameters.

For example:

```
make release-bootkube IMAGE_REPO_BOOTKUBE=quay.io/kinvolk/bootkube GOARCH=arm64 VERSION=v0.14.0
make release-podcheckpointer IMAGE_REPO_PODCHECKPOINTER=quay.io/kinvolk/pod-checkpointer GOARCH=arm64 VERSION=83e25e5968391b9eb342042c435d1b3eeddb2be1
```

To do that, we need to also fix hidden build issues in `make cross` target, so that the default release target can cross-build binaries.