### PR TITLE
Drop Typhoon links - it no longer uses bootkube.

### DIFF
--- a/Documentation/users-integrations.md
+++ b/Documentation/users-integrations.md
@@ -2,11 +2,7 @@
 
 This document tracks projects, integrations, and use cases for bootkube. [Join the community](../README.md), and help us keep the list up-to-date.
 
-* [Tectonic](https://coreos.com/tectonic) - Enterprise-ready Kubernetes clusters
-* [Matchbox](https://coreos.com/matchbox/docs/latest/) - Easily launch self-hosted clusters on Bare-metal
-* [kubermesh](https://github.com/kubermesh/kubermesh) - Bare metal, self-hosted, self-healing/provisioning, mesh network kubernetes cluster. See the [blog post](http://ocadotechnology.com/blog/creating-a-distributed-data-centre-architecture-using-kubernetes-and-containers/) for more details.
 * [Lokomotive](https://github.com/kinvolk/lokomotive) - Open source Kubernetes distribution that ships pure upstream Kubernetes. It focuses on being minimal, easy to use, and secure by default.
+* [kubermesh](https://github.com/kubermesh/kubermesh) - Bare metal, self-hosted, self-healing/provisioning, mesh network kubernetes cluster. See the [blog post](http://ocadotechnology.com/blog/creating-a-distributed-data-centre-architecture-using-kubernetes-and-containers/) for more details.
 * [Archon](https://github.com/kubeup/archon) - Kubernetes management and automation tool based on the [operator pattern](https://coreos.com/blog/introducing-operators.html)
-* [Typhoon](https://github.com/poseidon/typhoon) - Minimal and free Kubernetes distribution
-* [bootkube-terraform](https://github.com/poseidon/bootkube-terraform) - Terraform module for rendering bootkube manifests and assets
 * [kube-linode](https://github.com/kahkhang/kube-linode) - Provision a CoreOS/Kubernetes cluster on Linode


### PR DESCRIPTION
reordered the have the most active distro first.